### PR TITLE
fix(workspace): warp cursor on cross-output switch

### DIFF
--- a/docs/user/keybinds.md
+++ b/docs/user/keybinds.md
@@ -80,6 +80,9 @@ Add `/output` to target another output explicitly. On a dynamic output, a
 numeric target first uses the preferred output. If the number is beyond the
 current workspace list, Umbriel uses the last workspace.
 
+When `workspace-switch` targets a workspace on another monitor, the cursor warps
+to the center of that monitor, so focus follows the switch.
+
 ### Window and layout actions
 
 These take no argument.

--- a/src/server/actions.cpp
+++ b/src/server/actions.cpp
@@ -481,6 +481,10 @@ namespace umbriel {
         }
       }
       group->select(*target);
+      Output* destination = group->output();
+      if (destination != nullptr && destination != server.outputFromWlr(server.preferredOutput())) {
+        warpToOutputCenter(server, *destination);
+      }
       return true;
     }
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

`workspace-switch` now warps the cursor to the target monitor when the target workspace is on a different one, matching what `output-focus-*` already does.

## Motivation

Focus and new-window placement both resolve through `preferredOutput()`, which is the output under the pointer. Switching to a workspace on another monitor didn't move the pointer to the target output, so the target workspace was shown while the next window still opened on the monitor you just left.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

n/a

## Testing

- `just format`, `just build debug`, `just test debug` (16/16), `just lint debug`
- Tested before and after the change in a native session, confirming that after the change the newly spawned window opens on the target output. Switching within the same output doesn't move the cursor.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

n/a

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

Updated the docs because while I think focus following workspace switching is intuitive, the cursor warping to the center of the screen might not be, so I thought it would be useful to explain why it happens. If you don't think it's necessary to explain that in the docs I can remove that.
