### PR TITLE
feat: add window-cycle-width-back action

### DIFF
--- a/docs/user/keybinds.md
+++ b/docs/user/keybinds.md
@@ -103,6 +103,7 @@ These take no argument.
 | `window-consume-left` | Pull the focused window into the column to its left. |
 | `window-expel-right` | Pop the focused window out of its column into a new column to the right. |
 | `window-cycle-width` | Cycle the focused column through its preset widths. |
+| `window-cycle-width-back` | Cycle the focused column through its preset widths in reverse. |
 | `window-toggle-fullscreen` | Toggle fullscreen for the focused window. |
 | `window-toggle-maximize` | Toggle the focused column's full-width state. |
 | `window-toggle-maximize-to-edges` | Toggle maximization of the focused window to the usable area's edges, without gaps or borders. Layer-shell exclusive zones remain visible. |

--- a/src/config/keybind_parse.cpp
+++ b/src/config/keybind_parse.cpp
@@ -181,6 +181,7 @@ namespace umbriel {
         {"window-close", "[<window-id>]", KeybindAction::WindowClose, ActionArgKind::OptionalWindowId},
         {"window-consume-left", "", KeybindAction::WindowConsumeLeft},
         {"window-cycle-width", "", KeybindAction::WindowCycleWidth},
+        {"window-cycle-width-back", "", KeybindAction::WindowCycleWidthBack},
         {"window-expel-right", "", KeybindAction::WindowExpelRight},
         {"window-focus", "<window-id>", KeybindAction::WindowFocusId, ActionArgKind::WindowId},
         {"window-focus-down", "", KeybindAction::WindowFocusDown},

--- a/src/config/keybind_parse.cpp
+++ b/src/config/keybind_parse.cpp
@@ -464,6 +464,7 @@ namespace umbriel {
     add(KeybindAction::WindowConsumeLeft, XKB_KEY_comma);
     add(KeybindAction::WindowExpelRight, XKB_KEY_period);
     add(KeybindAction::WindowCycleWidth, XKB_KEY_r);
+    add(KeybindAction::WindowCycleWidthBack, XKB_KEY_r, WLR_MODIFIER_SHIFT);
     add(KeybindAction::ToggleFullscreen, XKB_KEY_f);
     add(KeybindAction::ToggleMaximize, XKB_KEY_f, WLR_MODIFIER_CTRL);
     add(KeybindAction::ToggleMaximizeToEdges, XKB_KEY_m);

--- a/src/config/keybind_parse.h
+++ b/src/config/keybind_parse.h
@@ -38,6 +38,7 @@ namespace umbriel {
     WindowConsumeLeft,
     WindowExpelRight,
     WindowCycleWidth,
+    WindowCycleWidthBack,
     WindowSetWidth,
     ToggleMaximize,
     ToggleMaximizeToEdges,

--- a/src/layout/dwindle.cpp
+++ b/src/layout/dwindle.cpp
@@ -493,7 +493,7 @@ namespace umbriel {
     return verticalSibling(view, direction);
   }
 
-  bool DwindleLayout::cycleWidth(int columnIndex) {
+  bool DwindleLayout::cycleWidth(int columnIndex, int direction) {
     Node* node = nodeAtFlatIndex(columnIndex);
     const std::vector<WidthSplit> splits = widthSplits(node);
     if (splits.empty()) {
@@ -504,8 +504,16 @@ namespace umbriel {
       current *= widthShare(split);
     }
     const auto& presets = m_config->widthPresets;
-    const auto it = std::ranges::find_if(presets, [current](double preset) { return preset > current + 0.0001; });
-    const double next = (it == presets.end()) ? presets[0] : *it;
+    double next = 0.0;
+    if (direction < 0) {
+      const auto it = std::ranges::find_if(presets | std::views::reverse, [current](double preset) {
+        return preset < current - 0.0001;
+      });
+      next = it == presets.rend() ? presets.back() : *it;
+    } else {
+      const auto it = std::ranges::find_if(presets, [current](double preset) { return preset > current + 0.0001; });
+      next = it == presets.end() ? presets[0] : *it;
+    }
     return applyWidthFraction(splits, next);
   }
 

--- a/src/layout/dwindle.h
+++ b/src/layout/dwindle.h
@@ -70,7 +70,7 @@ namespace umbriel {
     [[nodiscard]] uint32_t sanitizeResizeEdges(const View* view, uint32_t edges) const override;
     std::unique_ptr<ResizeGrab> beginResize(View* view, uint32_t edges, const wlr_box& usable) override;
 
-    bool cycleWidth(int columnIndex) override;
+    bool cycleWidth(int columnIndex, int direction) override;
     bool toggleFullWidth(int columnIndex) override;
     [[nodiscard]] bool isFullWidth(int columnIndex) const override;
     bool setWidthFraction(int columnIndex, double fraction) override;

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -122,7 +122,7 @@ namespace umbriel {
 
     [[nodiscard]] virtual View* focusVerticalLeaf(const View* /*view*/, int /*direction*/) const { return nullptr; }
 
-    virtual bool cycleWidth(int columnIndex) = 0;
+    virtual bool cycleWidth(int columnIndex, int direction) = 0;
     virtual bool toggleFullWidth(int columnIndex) = 0;
     virtual bool setWidthFraction(int columnIndex, double fraction) = 0;
     virtual void clearFullWidthState(int columnIndex) = 0;

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <ranges>
 
 // wlr_box and WLR_EDGE_* only. Layout geometry must not pull src/wlr.h, which
 // drags SceneFX and the renderer into a translation unit that does arithmetic.
@@ -454,16 +455,22 @@ namespace umbriel {
     return {.x = it->x, .y = it->y, .width = it->width, .height = it->height};
   }
 
-  bool ScrollingLayout::cycleWidth(int columnIndex) {
+  bool ScrollingLayout::cycleWidth(int columnIndex, int direction) {
     if (columnIndex < 0 || columnIndex >= static_cast<int>(m_columns.size())) {
       return false;
     }
     Column& column = m_columns[static_cast<size_t>(columnIndex)];
     const auto& presets = m_config->widthPresets;
-    const auto it = std::ranges::find_if(presets, [current = column.widthFrac](double preset) {
-      return preset > current + 0.0001;
-    });
-    column.widthFrac = it == presets.end() ? presets[0] : *it;
+    const double current = column.widthFrac;
+    if (direction < 0) {
+      const auto it = std::ranges::find_if(presets | std::views::reverse, [current](double preset) {
+        return preset < current - 0.0001;
+      });
+      column.widthFrac = it == presets.rend() ? presets.back() : *it;
+    } else {
+      const auto it = std::ranges::find_if(presets, [current](double preset) { return preset > current + 0.0001; });
+      column.widthFrac = it == presets.end() ? presets[0] : *it;
+    }
     column.savedWidthFrac = 0.0;
     return true;
   }

--- a/src/layout/scrolling.h
+++ b/src/layout/scrolling.h
@@ -51,7 +51,7 @@ namespace umbriel {
     [[nodiscard]] InitialSize
     initialSize(const wlr_box& usable, std::optional<double> ruleWidthFraction) const override;
 
-    bool cycleWidth(int columnIndex) override;
+    bool cycleWidth(int columnIndex, int direction) override;
     bool toggleFullWidth(int columnIndex) override;
     bool setWidthFraction(int columnIndex, double fraction) override;
     void clearFullWidthState(int columnIndex) override;

--- a/src/scene/cheatsheet_rows.cpp
+++ b/src/scene/cheatsheet_rows.cpp
@@ -280,6 +280,7 @@ namespace {
     case A::WindowConsumeLeft:
     case A::WindowExpelRight:
     case A::WindowCycleWidth:
+    case A::WindowCycleWidthBack:
     case A::WindowSetWidth:
     case A::WindowModifyWidth:
     case A::WindowCenter:

--- a/src/server/actions.cpp
+++ b/src/server/actions.cpp
@@ -436,9 +436,9 @@ namespace umbriel {
       return true;
     }
 
-    bool actionCycleWidth(Server& server, const Keybind& /*bind*/, std::string* /*error*/) {
+    template <int Direction> bool actionCycleWidth(Server& server, const Keybind& /*bind*/, std::string* /*error*/) {
       if (Workspace* workspace = activeWorkspace(server)) {
-        workspace->cycleFocusedWidth();
+        workspace->cycleFocusedWidth(Direction);
       }
       return true;
     }
@@ -875,7 +875,8 @@ namespace umbriel {
         &actionMoveVertical<1>,
         &actionConsumeLeft,
         &actionExpelRight,
-        &actionCycleWidth,
+        &actionCycleWidth<1>,
+        &actionCycleWidth<-1>,
         &actionSetWidth,
         &actionToggleMaximize,
         &actionToggleMaximizeToEdges,

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -673,12 +673,12 @@ namespace umbriel {
     return scrollingVertical() ? moveLaneAlongStrip(direction) : moveWithinLane(direction);
   }
 
-  bool Workspace::cycleFocusedWidth() {
+  bool Workspace::cycleFocusedWidth(int direction) {
     if (m_focusedView != nullptr && m_focusedView->maximizedToEdges()) {
       m_focusedView->setMaximizedToEdges(false);
     }
     const int column = m_layout->columnOf(m_focusedView);
-    if (!m_layout->cycleWidth(column)) {
+    if (!m_layout->cycleWidth(column, direction)) {
       return false;
     }
     wlr_xdg_toplevel_set_maximized(m_focusedView->toplevel(), false);

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -96,7 +96,7 @@ namespace umbriel {
     bool consumeFocusedLeft();
     bool expelFocusedRight();
     bool moveFocusedVertical(int direction);
-    bool cycleFocusedWidth();
+    bool cycleFocusedWidth(int direction);
     bool setFocusedWidth(double fraction);
     // Incremental width change: apply `delta` to the focused column's current
     // width fraction, clamped to [0.1, 1.0].

--- a/tests/unit/dwindle_layout.cpp
+++ b/tests/unit/dwindle_layout.cpp
@@ -425,6 +425,30 @@ UMBRIEL_TEST(resizeBoundaryRejectsAScreenFacingEdge) {
   CHECK(!fixture.layout.setResizeBoundary(stub(0), WLR_EDGE_LEFT, 0.75));
 }
 
+UMBRIEL_TEST(cycleWidthBackWalksThePresetsInReverse) {
+  Fixture fixture;
+  fixture.config.widthPresets = {1.0 / 3.0, 0.5, 2.0 / 3.0};
+  fixture.addLeaves(2);
+  fixture.layout.arrange(kUsable);
+
+  const int span = kUsable.width - 2 * fixture.config.edgePad - fixture.config.totalGap;
+
+  CHECK(fixture.layout.setWidthFraction(0, 2.0 / 3.0));
+
+  CHECK(fixture.layout.cycleWidth(0, -1));
+  fixture.layout.arrange(kUsable);
+  CHECK(std::abs(fixture.layout.targetBox(stub(0)).width - static_cast<int>(span * 0.5)) <= 2);
+
+  CHECK(fixture.layout.cycleWidth(0, -1));
+  fixture.layout.arrange(kUsable);
+  CHECK(std::abs(fixture.layout.targetBox(stub(0)).width - static_cast<int>(span * (1.0 / 3.0))) <= 2);
+
+  // Wraps back to the last preset.
+  CHECK(fixture.layout.cycleWidth(0, -1));
+  fixture.layout.arrange(kUsable);
+  CHECK(std::abs(fixture.layout.targetBox(stub(0)).width - static_cast<int>(span * (2.0 / 3.0))) <= 2);
+}
+
 // The scrolling-only API is no longer reachable from a DwindleLayout at all: scroll offsets, column positions, and row
 // weights moved onto ScrollingLayout, so the question a previous test asked here ("does dwindle answer 0?") cannot be
 // compiled any more. That is the point. Callers reach those through Workspace::scrollingLayout(), which is null for a

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -301,16 +301,32 @@ UMBRIEL_TEST(cycleWidthWalksThePresets) {
   fixture.addColumns(1);
   CHECK(fixture.layout.setWidthFraction(0, 1.0 / 3));
 
-  CHECK(fixture.layout.cycleWidth(0));
+  CHECK(fixture.layout.cycleWidth(0, 1));
   const double second = fixture.layout.widthFraction(0);
   CHECK(std::fabs(second - 0.5) < 1e-6);
 
-  CHECK(fixture.layout.cycleWidth(0));
+  CHECK(fixture.layout.cycleWidth(0, 1));
   CHECK(std::fabs(fixture.layout.widthFraction(0) - 2.0 / 3) < 1e-6);
 
   // Wraps back to the first preset.
-  CHECK(fixture.layout.cycleWidth(0));
+  CHECK(fixture.layout.cycleWidth(0, 1));
   CHECK(std::fabs(fixture.layout.widthFraction(0) - 1.0 / 3) < 1e-6);
+}
+
+UMBRIEL_TEST(cycleWidthBackWalksThePresetsInReverse) {
+  Fixture fixture;
+  fixture.addColumns(1);
+  CHECK(fixture.layout.setWidthFraction(0, 2.0 / 3));
+
+  CHECK(fixture.layout.cycleWidth(0, -1));
+  CHECK(std::fabs(fixture.layout.widthFraction(0) - 0.5) < 1e-6);
+
+  CHECK(fixture.layout.cycleWidth(0, -1));
+  CHECK(std::fabs(fixture.layout.widthFraction(0) - 1.0 / 3) < 1e-6);
+
+  // Wraps back to the last preset.
+  CHECK(fixture.layout.cycleWidth(0, -1));
+  CHECK(std::fabs(fixture.layout.widthFraction(0) - 2.0 / 3) < 1e-6);
 }
 
 UMBRIEL_TEST(toggleFullWidthRestoresThePreviousFraction) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Add `window-cycle-width-back` action.

## Motivation

I use `width_presets = [0.25, 0.375, 0.5, 0.625, 0.75, 1.0]` to resize my windows, instead of incrementing/decrementing a fixed value, that way I can have matching fractions that don't necessarily change by a fixed amount.

Being able to cycle back width presets fits better my usability because then I don't need to hit bind multiple times to achieve the desired size.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
N/A

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- Run:
```
just format
just test
just lint
```
- Tested both tilling modes with multiple windows, including wayland native ones like foot

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->
None

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

I followed a niri-like approach for action name, let me know if maybe something closer to noctalia's IPC would fit better, like `umbriel msg window-cycle-width:[previous|next]`.
