### PR TITLE
fix(harness): build all helpers and add testing tools to the devshell 

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -22,6 +22,8 @@ pkgs.mkShell {
     jq
     foot
     python3
+    imagemagick
+    procps
     xwayland-satellite
   ];
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Three fixes so `just verify` runs all tests to completion under `nix develop`.

- `verify` only compiled `pointer-client` and `unmap-client`, so checks that spawn `drag-client` or `global-client` ran against missing or stale binaries. Now all four are built.
- `040_spawn` marked the child process with `exec -a`. coreutils in nixpkgs is a single binary that dispatches on `argv[0]`, so overriding `argv[0]` breaks `sleep`. The marker is now in a trailing comment, which `pgrep -f` still matches. The retry loop also ran `pgrep -f "$MARKER" | head -1` with `set -o pipefail`, which failed on the first miss instead of retrying. This is now fixed.
- The devshell was missing six tools the checks invoke (resulting in failures), so I added them

## Motivation

Making all checks run in `just verify` and making them all pass in `nix develop`

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging
- [ ] Documentation

## Related Issue

n/a

## Testing

`nix develop --command just verify`

## Manual Coverage

<!-- Mark what applies to this PR. -->

n/a (no runtime behaviour changes)

## Screenshots / Videos

n/a

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

I did initially have more text fixes but lemmy beat me to it 😭 