### PR TITLE
fix: pinned windows over fullscreen window while dragging

### DIFF
--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -15,7 +15,6 @@
 // clang-format off
 #include <algorithm>
 #include <cmath>
-#include "wlr-layer-shell-unstable-v1-protocol.h"
 #include "wlr.h"
 // clang-format on
 #include "workspace/scratchpad.h"
@@ -503,9 +502,7 @@ namespace umbriel {
     m_dragOpacity = 1.0F;
     m_effectiveOpacityCommitPending = false;
     setFadeAlpha(m_fadeAlpha);
-    wlr_scene_node_place_below(
-        &m_server->dragTree()->node, &m_server->shellLayerTree(ZWLR_LAYER_SHELL_V1_LAYER_TOP)->node
-    );
+    wlr_scene_node_place_below(&m_server->dragTree()->node, &m_server->dragIconTree()->node);
     wlr_scene_node_place_below(&m_server->dragShadowTree()->node, &m_server->dragTree()->node);
     if (ScratchpadManager* scratchpad = m_server->scratchpadManager();
         scratchpad != nullptr && scratchpad->contains(this)) {

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -15,6 +15,7 @@
 // clang-format off
 #include <algorithm>
 #include <cmath>
+#include "wlr-layer-shell-unstable-v1-protocol.h"
 #include "wlr.h"
 // clang-format on
 #include "workspace/scratchpad.h"
@@ -487,6 +488,10 @@ namespace umbriel {
     m_dragOpacity = kDragOpacity;
     setFadeAlpha(m_fadeAlpha);
     m_effectiveOpacityCommitPending = false;
+    if (m_pinned) {
+      wlr_scene_node_place_above(&m_server->dragShadowTree()->node, &m_server->pinnedTree()->node);
+      wlr_scene_node_place_above(&m_server->dragTree()->node, &m_server->dragShadowTree()->node);
+    }
     wlr_scene_node_reparent(&m_sceneTree->node, m_server->dragTree());
     reparentShadow(m_server->dragShadowTree());
     setNodeEnabled(true);
@@ -498,6 +503,10 @@ namespace umbriel {
     m_dragOpacity = 1.0F;
     m_effectiveOpacityCommitPending = false;
     setFadeAlpha(m_fadeAlpha);
+    wlr_scene_node_place_below(
+        &m_server->dragTree()->node, &m_server->shellLayerTree(ZWLR_LAYER_SHELL_V1_LAYER_TOP)->node
+    );
+    wlr_scene_node_place_below(&m_server->dragShadowTree()->node, &m_server->dragTree()->node);
     if (ScratchpadManager* scratchpad = m_server->scratchpadManager();
         scratchpad != nullptr && scratchpad->contains(this)) {
       scratchpad->restorePresentation(this);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Pinned windows stays over fullscreen windows while moving them.

## Motivation

<!-- What problem does this solve? -->
The pinned windows disappeared when moving them over a fullscreen window.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
On discord.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
