### PR TITLE
build(nix): use scenefx from submodule instead of flake input

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Declarative configuration uses Nix attrsets serialized to TOML with `pkgs.format
 
 ```nix
 # flake input
-umbriel.url = "path:/path/to/umbriel"; # or github:noctalia-dev/umbriel
+umbriel.url = "git+https://github.com/noctalia-dev/umbriel";
 
 # NixOS
 imports = [ inputs.umbriel.nixosModules.default ];

--- a/flake.lock
+++ b/flake.lock
@@ -15,25 +15,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "scenefx": "scenefx"
-      }
-    },
-    "scenefx": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1787367884,
-        "narHash": "sha256-CanY5gX81OUvTNpafLc9Bkdk26Xrlq99rkrQQd98EKM=",
-        "ref": "umbriel",
-        "rev": "a7ceecd5336edd3ac7245e65ab2ee1b12dfa97ca",
-        "revCount": 319,
-        "type": "git",
-        "url": "https://github.com/noctalia-dev/scenefx"
-      },
-      "original": {
-        "ref": "umbriel",
-        "type": "git",
-        "url": "https://github.com/noctalia-dev/scenefx"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -9,73 +9,39 @@
   outputs =
     { self, nixpkgs, ... }:
     let
-      inherit (nixpkgs.lib) genAttrs getExe;
-
       systems = [
         "x86_64-linux"
         "aarch64-linux"
       ];
 
       forEachSystem =
-        perSystem:
-        genAttrs systems (
-          system:
-          let
-            pkgs = nixpkgs.legacyPackages.${system};
-          in
-          perSystem { inherit pkgs system; }
-        );
+        perSystem: nixpkgs.lib.genAttrs systems (system: perSystem nixpkgs.legacyPackages.${system});
+
+      withDefaultPackage =
+        module:
+        { pkgs, lib, ... }:
+        {
+          imports = [ module ];
+          programs.umbriel.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
     in
     {
-      overlays.default = final: prev: {
+      overlays.default = final: _: {
         umbriel = final.callPackage ./nix/package.nix { };
       };
 
-      packages = forEachSystem (
-        { pkgs, ... }:
-        {
-          default = pkgs.callPackage ./nix/package.nix { };
-        }
-      );
+      packages = forEachSystem (pkgs: {
+        default = pkgs.callPackage ./nix/package.nix { };
+      });
 
-      devShells = forEachSystem (
-        { pkgs, system, ... }:
-        {
-          default = pkgs.callPackage ./nix/devshell.nix {
-            umbriel = self.packages.${system}.default;
-          };
-        }
-      );
-
-      apps = forEachSystem (
-        { system, ... }:
-        {
-          default = {
-            type = "app";
-            program = getExe self.packages.${system}.default;
-          };
-        }
-      );
-
-      homeModules.default =
-        { pkgs, lib, ... }:
-        {
-          imports = [ ./nix/home-module.nix ];
-          programs.umbriel.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.callPackage ./nix/devshell.nix {
+          umbriel = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
         };
+      });
 
-      hjemModules.default =
-        { pkgs, lib, ... }:
-        {
-          imports = [ ./nix/hjem-module.nix ];
-          programs.umbriel.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
-        };
-
-      nixosModules.default =
-        { pkgs, lib, ... }:
-        {
-          imports = [ ./nix/nixos-module.nix ];
-          programs.umbriel.package = lib.mkDefault self.packages.${pkgs.stdenv.hostPlatform.system}.default;
-        };
+      homeModules.default = withDefaultPackage ./nix/home-module.nix;
+      hjemModules.default = withDefaultPackage ./nix/hjem-module.nix;
+      nixosModules.default = withDefaultPackage ./nix/nixos-module.nix;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,19 +2,12 @@
   description = "Umbriel, a Wayland compositor built on wlroots and SceneFX.";
 
   inputs = {
+    self.submodules = true;
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
-    scenefx = {
-      url = "git+https://github.com/noctalia-dev/scenefx?ref=umbriel";
-      flake = false;
-    };
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      scenefx,
-    }:
+    { self, nixpkgs, ... }:
     let
       inherit (nixpkgs.lib) genAttrs getExe;
 
@@ -35,13 +28,13 @@
     in
     {
       overlays.default = final: prev: {
-        umbriel = final.callPackage ./nix/package.nix { inherit scenefx; };
+        umbriel = final.callPackage ./nix/package.nix { };
       };
 
       packages = forEachSystem (
         { pkgs, ... }:
         {
-          default = pkgs.callPackage ./nix/package.nix { inherit scenefx; };
+          default = pkgs.callPackage ./nix/package.nix { };
         }
       );
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -24,11 +24,18 @@
   nlohmann_json,
   xwayland-satellite,
   makeBinaryWrapper,
-  scenefx,
 }:
 let
   inherit (builtins) baseNameOf head match readFile;
-  source = ../.;
+  source =
+    lib.throwIf (!builtins.pathExists (../. + "/subprojects/scenefx/meson.build")) ''
+      umbriel: subprojects/scenefx is missing.
+
+      This flake needs a Git submodule, which the `github:` fetcher cannot
+      fetch because it downloads a tarball. Use the Git fetcher instead:
+
+        inputs.umbriel.url = "git+https://github.com/noctalia-dev/umbriel";
+    '' ../.;
   version = head (match ".*\n  version: '([0-9][^']+)'.*" (readFile ../meson.build));
 in
 stdenv.mkDerivation {
@@ -36,12 +43,6 @@ stdenv.mkDerivation {
   inherit version;
 
   src = source;
-
-  preConfigure = ''
-    mkdir -p subprojects
-    rm -rf subprojects/scenefx
-    cp -r ${scenefx} subprojects/scenefx
-  '';
 
   nativeBuildInputs = [
     makeBinaryWrapper


### PR DESCRIPTION


## Summary

SceneFX is now pulled as a submodule rather than as a flake input, so the submodule link is the source of truth for the version.

**This is a breaking change** for anyone using the `github:` fetcher in their flake, which was previously in the readme as the way to use it. There's now an eval time check for the submodule which will give these users an error with instructions they can use to fix it.

This also enabled a bit of simplification in the flake, and I did a bit of refactoring while I was at it

## Motivation

Fixes various drift issues, including where changing the SceneFX fork would break the flake until the input was bumped to match.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Refactoring
- [x] Build / packaging
- [x] Documentation

## Related Issue

n/a

## Testing

testing the flake from a local checkout:
```
nix flake check
nix build .#
nix build .#devShells.x86_64-linux.default
```

building with the flake fetcher:
```
nix build 'git+https://github.com/samiser/umbriel?ref=fix-flake' (it works)

nix build github:samiser/umbriel/fix-flake
[... eval trace ...]
error: umbriel: subprojects/scenefx is missing.

       This flake needs a Git submodule, which the `github:` fetcher cannot
       fetch because it downloads a tarball. Use the Git fetcher instead:

         inputs.umbriel.url = "git+https://github.com/noctalia-dev/umbriel";
```


## Manual Coverage

<!-- Mark what applies to this PR. -->

n/a (byte identical build to before these changes)

## Screenshots / Videos

n/a

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
