### PR TITLE
fix: remove maximized to edges windows decoration in overview

### DIFF
--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -165,7 +165,7 @@ namespace umbriel {
 
     const auto& appearance = config().appearance;
     const int total = appearance.totalBorderWidth();
-    const bool decorated = total > 0 && !view->toplevel()->current.fullscreen;
+    const bool decorated = total > 0 && !view->toplevel()->current.fullscreen && !view->maximizedToEdges();
     // Scale the radius and each thickness once, then derive the rings from those scaled values. Rounding the outer
     // radius on its own drifts from the ring's own thickness at fractional zoom, so the curve stops matching the
     // stroke.


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Removed window decoration in overview when maximized to edges.

## Motivation

<!-- What problem does this solve? -->
Windows maximized to edges still have borders in overview.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Discord.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
