### PR TITLE
fix: restore maximized to edges when leaving fullscreen

### DIFF
--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1753,6 +1753,9 @@ namespace umbriel {
   }
 
   void View::setMaximizedToEdges(bool maximized) {
+    if (!maximized) {
+      m_restoreMaximizedToEdges = false;
+    }
     if (!m_toplevel->base->initialized || maximized == m_maximizedToEdges) {
       return;
     }
@@ -2084,6 +2087,7 @@ namespace umbriel {
     );
     if (fullscreen && m_maximizedToEdges) {
       setMaximizedToEdges(false);
+      m_restoreMaximizedToEdges = true;
     }
     if (fullscreen && !m_tiled && !m_toplevel->current.fullscreen) {
       const wlr_box& geometry = m_toplevel->base->geometry;
@@ -2179,6 +2183,10 @@ namespace umbriel {
     } else {
       m_pendingUnfullscreenSize = false;
       m_unfullscreenGraceStartMsec = 0;
+    }
+    if (!fullscreen && m_restoreMaximizedToEdges) {
+      m_restoreMaximizedToEdges = false;
+      setMaximizedToEdges(true);
     }
     updateForeignState();
     if (m_workspace != nullptr && m_workspace->group() != nullptr) {

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -310,6 +310,7 @@ namespace umbriel {
     bool m_positioned = false;
     bool m_tiled = false;
     bool m_maximizedToEdges = false;
+    bool m_restoreMaximizedToEdges = false;
     wlr_box m_fullscreenRestoreBox{};
     bool m_hasFullscreenRestoreBox = false;
     bool m_pinned = false;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Restore maximized to edges when leaving fullscreen.

## Motivation

<!-- What problem does this solve? -->
When firefox is maximized to edges, if you fullscreen a youtube video for example, when leaving fullscreen firefox will be minimized.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Discord.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
