### PR TITLE
feat(nix): wire the desktop portal from the NixOS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,12 +195,16 @@ See [`examples/config.toml`](examples/config.toml) for the packaged starting con
 Declarative configuration uses Nix attrsets serialized to TOML with `pkgs.formats.toml`.
 
 ```nix
-# flake input
+# flake inputs
 umbriel.url = "git+https://github.com/noctalia-dev/umbriel";
+xdg-desktop-portal-umbriel.url = "github:noctalia-dev/xdg-desktop-portal-umbriel";
 
 # NixOS
 imports = [ inputs.umbriel.nixosModules.default ];
-programs.umbriel.enable = true;
+programs.umbriel = {
+  enable = true;
+  portalPackage = inputs.xdg-desktop-portal-umbriel.packages.${pkgs.stdenv.hostPlatform.system}.default;
+};
 
 # home-manager
 imports = [ inputs.umbriel.homeModules.default ];
@@ -218,6 +222,10 @@ programs.umbriel = {
   };
 };
 ```
+
+The portal lives in [a separate repository](https://github.com/noctalia-dev/xdg-desktop-portal-umbriel) and can
+be used via a separate flake input. Setting `portalPackage` will configure the `xdg.portal` backend and install
+the portal configuration, which is required for screencasting.
 
 When `settings` is omitted, the Home Manager and hjem modules leave the user path untouched so Umbriel loads its
 packaged configuration. Home Manager also accepts a raw TOML string or a path. The hjem module is exported as

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -16,6 +16,14 @@ in
       default = null;
       description = "The umbriel package to install.";
     };
+
+    portalPackage = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = ''
+        The xdg-desktop-portal-umbriel package to install.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable (
@@ -41,6 +49,14 @@ in
         # Required for greetd / noctalia-greeter to discover the session (Name=Umbriel).
         # Plain systemPackages .desktop files are not enough; NixOS aggregates via this.
         services.displayManager.sessionPackages = [ cfg.package ];
+      })
+
+      (lib.mkIf (cfg.portalPackage != null) {
+        xdg.portal = {
+          enable = lib.mkDefault true;
+          extraPortals = [ cfg.portalPackage ];
+          configPackages = [ cfg.portalPackage ];
+        };
       })
     ]
   );


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds `programs.umbriel.portalPackage` to the NixOS module. It registers xdg-desktop-portal-umbriel as an `xdg.portal` backend and installs the config that selects it. Also documented it in the README

## Motivation

People struggling to figure out how to use the portal, so this simplifies the interface, aligns it with the pending nixpkgs module, and documents it in the readme

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

n/a

## Testing

`nix flake check` passes. Checked via eval that the portal lands in both `xdg.portal.extraPortals` and `configPackages`, and `xdg.portal.enable` becomes true. Verified that leaving `portalPackage` unset changes nothing.

## Manual Coverage

<!-- Mark what applies to this PR. -->

n/a

## Screenshots / Videos

n/a

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
