### PR TITLE
fix(view): restore column width after fullscreen

### DIFF
--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -2142,11 +2142,12 @@ namespace umbriel {
       m_refullscreenOnTile = false;
     }
     // Leaving column maximize when entering real fullscreen avoids a stale
-    // widthFrac=1.0 column after the client leaves fullscreen.
+    // widthFrac=1.0 column after the client leaves fullscreen. Toggle it off
+    // so ScrollingLayout restores the width saved when maximize was enabled.
     if (fullscreen && m_tiled && m_workspace != nullptr) {
       const int column = m_workspace->layout().columnOf(this);
       if (m_workspace->layout().isFullWidth(column)) {
-        m_workspace->layout().clearFullWidthState(column);
+        m_workspace->layout().toggleFullWidth(column);
         wlr_xdg_toplevel_set_maximized(m_toplevel, false);
       }
     }

--- a/tests/harness/checks/170_fullscreen_restore_width.sh
+++ b/tests/harness/checks/170_fullscreen_restore_width.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Entering fullscreen from a full-width column must preserve the column width that maximize saved for restoration.
+set -euo pipefail
+
+window_width() {
+  "$UMBRIEL" windows --json | jq -r '.[] | select(.title == "fullscreen-width") | .w'
+}
+
+readonly CLIENT="$(dirname "$UMBRIEL")/subsurface-client"
+readonly CLIENT_LOG="$UMBRIEL_RUNTIME_DIR/fullscreen-width-client.log"
+
+wait_for_width() {
+  local expected=$1
+  for _ in $(seq 60); do
+    [[ $(window_width) == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for width $expected: $($UMBRIEL windows --json)"
+  return 1
+}
+
+"$CLIENT" fullscreen-width 640 480 > "$CLIENT_LOG" 2>&1 &
+
+# The default 0.5 scrolling column is 624 px on the 1280x720 harness output.
+readonly ORIGINAL_WIDTH=624
+readonly FULL_WIDTH=1260
+wait_for_width "$ORIGINAL_WIDTH"
+
+"$UMBRIEL" msg window-toggle-maximize > /dev/null
+wait_for_width "$FULL_WIDTH"
+
+"$UMBRIEL" msg window-toggle-fullscreen > /dev/null
+wait_for_width 1280
+
+"$UMBRIEL" msg window-toggle-fullscreen > /dev/null
+wait_for_width "$ORIGINAL_WIDTH"
+
+echo "fullscreen round trip restored the maximized column from $FULL_WIDTH to $ORIGINAL_WIDTH"


### PR DESCRIPTION
## Summary

- restore a scrolling column's saved width when entering fullscreen from column-maximized state
- avoid leaving `widthFrac` at `1.0` after fullscreen exits
- add a headless compositor regression check for the maximize → fullscreen → restore round trip

## Reproduction

1. Focus a tiled window in the scrolling layout.
2. Run `window-toggle-maximize`.
3. Run `window-toggle-fullscreen` twice.
4. The window remains full-width instead of returning to its original column width.

`clearFullWidthState()` discarded `savedWidthFrac` but intentionally left the current `widthFrac` unchanged. Using the existing toggle path restores the saved fraction before fullscreen takes over.

## Verification

- `meson test -C build-pr --print-errorlogs` (19/19 passed)
- `./tests/harness/verify.sh build-pr/umbriel 170_fullscreen_restore_width -v`
  - confirms the round trip restores the column from 1260 px to 624 px

Originally found and verified during nbshell integration testing with Zen Browser.