### PR TITLE
fix(nix): disable the nixpkgs umbriel module

### DIFF
--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -8,6 +8,9 @@ let
   cfg = config.programs.umbriel;
 in
 {
+  # Disable the nixpkgs module to avoid conflicts
+  disabledModules = [ "programs/wayland/umbriel.nix" ];
+
   options.programs.umbriel = {
     enable = lib.mkEnableOption "Umbriel, a Wayland compositor built on wlroots and SceneFX.";
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

same thing as https://github.com/noctalia-dev/noctalia/pull/4087

## Motivation

same thing as https://github.com/noctalia-dev/noctalia/pull/4087

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging
- [ ] Documentation

## Related Issue

n/a

## Testing

tested via eval (against nixpkgs master)

## Manual Coverage

n/a

## Screenshots / Videos

n/a

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
