### PR TITLE
feat(input): add numlock_toggle config option

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -411,7 +411,7 @@ variant = ""      # XKB variant
 options = ""      # XKB options, comma-separated
 repeat_rate = 25  # 0-1000 Hz, 0 disables
 repeat_delay = 600 # 0-10000 ms
-numlock_toggle = true # true enables NumLock when Umbriel starts; false leaves it off
+numlock_toggle = true # true enables NumLock when a keyboard connects; false leaves it off
 ```
 
 `layout` takes a comma-separated list to load several layouts at once

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -411,7 +411,7 @@ variant = ""      # XKB variant
 options = ""      # XKB options, comma-separated
 repeat_rate = 25  # 0-1000 Hz, 0 disables
 repeat_delay = 600 # 0-10000 ms
-numlock_toggle = true # true enables NumLock on startup; false leaves it off
+numlock_toggle = true # true enables NumLock when Umbriel starts; false leaves it off
 ```
 
 `layout` takes a comma-separated list to load several layouts at once

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -411,6 +411,7 @@ variant = ""      # XKB variant
 options = ""      # XKB options, comma-separated
 repeat_rate = 25  # 0-1000 Hz, 0 disables
 repeat_delay = 600 # 0-10000 ms
+numlock_toggle = true # true enables NumLock on startup; false leaves it off
 ```
 
 `layout` takes a comma-separated list to load several layouts at once

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -143,6 +143,7 @@ variant = ""
 options = ""                   # XKB options, e.g. "grp:alt_shift_toggle"
 repeat_rate = 25               # 0-1000 Hz
 repeat_delay = 600             # 0-10000 ms
+numlock_toggle = true          # true enables NumLock on startup; false leaves it off
 
 [input.touchpad]
 tap = true                      # enabled by default; false disables tap-to-click

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -143,7 +143,7 @@ variant = ""
 options = ""                   # XKB options, e.g. "grp:alt_shift_toggle"
 repeat_rate = 25               # 0-1000 Hz
 repeat_delay = 600             # 0-10000 ms
-numlock_toggle = true # true enables NumLock when Umbriel starts; false leaves it off
+numlock_toggle = true # true enables NumLock when a keyboard connects; false leaves it off
 
 [input.touchpad]
 tap = true                      # enabled by default; false disables tap-to-click

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -143,7 +143,7 @@ variant = ""
 options = ""                   # XKB options, e.g. "grp:alt_shift_toggle"
 repeat_rate = 25               # 0-1000 Hz
 repeat_delay = 600             # 0-10000 ms
-numlock_toggle = true          # true enables NumLock on startup; false leaves it off
+numlock_toggle = true # true enables NumLock when Umbriel starts; false leaves it off
 
 [input.touchpad]
 tap = true                      # enabled by default; false disables tap-to-click

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -752,7 +752,8 @@ namespace umbriel {
               .text("variant", in.keyboard.variant)
               .text("options", in.keyboard.options)
               .integer("repeat_rate", 0, 1000, in.keyboard.repeatRate)
-              .integer("repeat_delay", 0, 10000, in.keyboard.repeatDelay);
+              .integer("repeat_delay", 0, 10000, in.keyboard.repeatDelay)
+              .boolean("numlock_toggle", in.keyboard.numlockToggle);
         });
         if (const toml::node* keyboardNode = s.node("keyboard");
             keyboardNode != nullptr && !validateKeyboardInput(in.keyboard, keyboardNode->source(), "input.keyboard")) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -398,6 +398,7 @@ namespace umbriel {
         std::string options;
         int repeatRate = 25;
         int repeatDelay = 600;
+        bool numlockToggle = false;
         bool operator==(const Keyboard&) const = default;
       } keyboard;
 

--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -80,7 +80,7 @@ namespace umbriel {
     if (input.keyboard.numlockToggle) {
       const xkb_mod_index_t numLock = xkb_keymap_mod_get_index(m_keyboard->keymap, XKB_MOD_NAME_NUM);
       if (numLock != XKB_MOD_INVALID) {
-        xkb_state_update_mask(m_keyboard->xkb_state, 0, 0, 1U << numLock, 0, 0, 0);
+        wlr_keyboard_notify_modifiers(m_keyboard, 0, 0, 1U << numLock, 0);
       }
     }
     // The name list or keymap changed; resend the current state so consumers

--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -77,6 +77,12 @@ namespace umbriel {
       xkb_context_unref(context);
     }
     wlr_keyboard_set_repeat_info(m_keyboard, repeatRate, repeatDelay);
+    if (input.keyboard.numlockToggle) {
+      const xkb_mod_index_t numLock = xkb_keymap_mod_get_index(m_keyboard->keymap, XKB_MOD_NAME_NUM);
+      if (numLock != XKB_MOD_INVALID) {
+        xkb_state_update_mask(m_keyboard->xkb_state, 0, 0, 1U << numLock, 0, 0, 0);
+      }
+    }
     // The name list or keymap changed; resend the current state so consumers
     // observe the reload even when the effective group did not move.
     notifyLayoutIfChanged();

--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -25,6 +25,12 @@ namespace umbriel {
         m_virtual(wlr_input_device_get_virtual_keyboard(device) != nullptr),
         m_deviceName(device->name != nullptr ? device->name : "") {
     applyConfig();
+    if (!m_virtual && config().input.keyboard.numlockToggle && m_keyboard->keymap != nullptr) {
+      const xkb_mod_index_t numLock = xkb_keymap_mod_get_index(m_keyboard->keymap, XKB_MOD_NAME_NUM);
+      if (numLock != XKB_MOD_INVALID) {
+        wlr_keyboard_notify_modifiers(m_keyboard, 0, 0, 1U << numLock, 0);
+      }
+    }
 
     m_modifiers.notify = onModifiers;
     wl_signal_add(&m_keyboard->events.modifiers, &m_modifiers);
@@ -77,12 +83,6 @@ namespace umbriel {
       xkb_context_unref(context);
     }
     wlr_keyboard_set_repeat_info(m_keyboard, repeatRate, repeatDelay);
-    if (input.keyboard.numlockToggle) {
-      const xkb_mod_index_t numLock = xkb_keymap_mod_get_index(m_keyboard->keymap, XKB_MOD_NAME_NUM);
-      if (numLock != XKB_MOD_INVALID) {
-        wlr_keyboard_notify_modifiers(m_keyboard, 0, 0, 1U << numLock, 0);
-      }
-    }
     // The name list or keymap changed; resend the current state so consumers
     // observe the reload even when the effective group did not move.
     notifyLayoutIfChanged();


### PR DESCRIPTION
## Summary

Adds an `input.keyboard.numlock_toggle` config option. When enabled, Umbriel locks Num Lock on whenever a physical keyboard connects, so the numpad types digits from session start without pressing the Num Lock key first.

Implementation: in the `Keyboard` constructor (after `applyConfig()` sets the keymap), the modifier index for `XKB_MOD_NAME_NUM` is resolved and `wlr_keyboard_notify_modifiers()` is called with the Num Lock mask. That single wlroots call updates the XKB state, refreshes `wlr_keyboard::modifiers`, and emits the modifiers event so clients observe the locked modifier.

## Motivation

Num Lock defaults to off on most keyboards, so users with a numpad must press Num Lock after every login and every keyboard hotplug. Compositors like sway and Hyprland expose a numlock-on-startup setting. Umbriel had no equivalent and no way to configure initial modifier state.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

None

## Testing

- `just debug` — builds clean, no warnings
- `just test` — all 19 unit tests pass
- `./build-debug/umbriel validate -c examples/config.toml` — `config: ok`
- `just check 050_config_reload` — PASS; config reload handles the new key correctly
- Manual, native session with `numlock_toggle = true`:
  - numpad types digits immediately after login and after keyboard hotplug
  - Num Lock key still toggles normally afterwards; LED follows the modifier
  - toggling Num Lock off, then `umbriel msg config-reload`, stays off
  - config reload resets Num Lock to off (keymap rebuild), same as Caps Lock
- Manual, option unset/false. behavior unchanged (Num Lock off at startup)
- `just format` run
- `just lint` reports pre-existing clang-tidy findings in `src/server/wine_color_manager.cpp` only, a file this PR does not touch. All files changed by this PR pass clean.

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

Keyboard modifier state is input-layer and session-wide, so monitor/layout scenarios do not interact with this change.
## Screenshots / Videos

Not applicable

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

- Defaults: the code fallback is `false`. `examples/config.toml` uses `numlock_toggle = true`
- The state is applied through `wlr_keyboard_notify_modifiers()` (same approach as sway), so clients, the seat, and the keyboard LED all observe the locked modifier.
- Applied per physical keyboard at connect time only. Config reloads rebuild the keymap and therefore reset all locked modifiers. Num Lock now behaves the same as Caps Lock instead of re-locking on every reload.
- Virtual keyboards are excluded, matching how `applyConfig()` already treats their keymaps.