### PR TITLE
fix(output): restore windows when every output goes away at once

### DIFF
--- a/docs/user/outputs.md
+++ b/docs/user/outputs.md
@@ -5,9 +5,10 @@ connector names such as `DP-1` or `HDMI-A-1`. Nested outputs use `WL-1`;
 headless outputs use `HEADLESS-1`.
 
 When an output is disconnected or disabled through configuration, Umbriel moves
-its windows to the active workspace on another enabled output. Scratchpad
-windows move with that output assignment. If no enabled output remains, windows
-stay without a workspace until one becomes available.
+its windows to the active workspace on another enabled output, and moves them
+back to the workspace they came from when it returns. Scratchpad windows move
+with that output assignment. If no enabled output remains, windows stay without
+a workspace until one becomes available.
 
 Run `umbriel outputs` inside a session to list connector names and modes.
 

--- a/docs/user/outputs.md
+++ b/docs/user/outputs.md
@@ -7,8 +7,8 @@ headless outputs use `HEADLESS-1`.
 When an output is disconnected or disabled through configuration, Umbriel moves
 its windows to the active workspace on another enabled output, and moves them
 back to the workspace they came from when it returns. Scratchpad windows move
-with that output assignment. If no enabled output remains, windows stay without
-a workspace until one becomes available.
+with that output assignment and return with it too. If no enabled output
+remains, windows stay without a workspace until one becomes available.
 
 Run `umbriel outputs` inside a session to list connector names and modes.
 

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -1641,7 +1641,7 @@ namespace umbriel {
       view->setPosition(x, y);
     } else if (output != nullptr && output->workspaceGroup() != nullptr) {
       if (Workspace* target = output->workspaceGroup()->active(); view->workspace() != target) {
-        view->setWorkspace(target);
+        view->moveToWorkspace(target);
         view->setPosition(x, y);
       }
     }

--- a/src/layout/drop_target.cpp
+++ b/src/layout/drop_target.cpp
@@ -398,7 +398,7 @@ namespace umbriel {
       if (view.workspace() != &target) {
         // Auto-attach would split the focused leaf and send a stale configure
         // before the explicit placement below.
-        view.setWorkspace(&target, /*attachToLayout=*/false);
+        view.moveToWorkspace(&target, /*attachToLayout=*/false);
       } else {
         dwindle->removeView(&view);
       }
@@ -414,7 +414,7 @@ namespace umbriel {
     }
 
     if (view.workspace() != &target) {
-      view.setWorkspace(&target, /*attachToLayout=*/false);
+      view.moveToWorkspace(&target, /*attachToLayout=*/false);
     }
     if (drop.row >= 0) {
       target.layout().insertViewIntoColumn(&view, std::max(0, drop.column), drop.row);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,6 +148,11 @@ int main(int argc, char** argv) {
       // Help only when -h/--help is the immediate argument (not buried in spawn args).
       if (argc == 3 && isHelpFlag(argv[2])) {
         std::println("Usage: umbriel {} {}", spec->name, spec->argSpec);
+        if (spec->name != "msg") {
+          std::println("");
+          std::println("{}", spec->description);
+          return EXIT_SUCCESS;
+        }
         std::println("");
         std::println("Send an action to the running compositor.");
         std::println("Use `msg spawn <cmd...>` as shorthand for `msg spawn:<cmd...>`.");

--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -1666,7 +1666,7 @@ namespace umbriel {
     } else if (target != nullptr && dropState != nullptr && insertedWorkspace) {
       view->rememberFloatingPosition();
       if (view->workspace() != target) {
-        view->setWorkspace(target, /*attachToLayout=*/false);
+        view->moveToWorkspace(target, /*attachToLayout=*/false);
       }
       view->restoreFloatingPosition();
       m_server->focusView(view, FocusReason::DragDrop);
@@ -1681,7 +1681,7 @@ namespace umbriel {
                           std::lround((cardBox.y - rowTop(metrics, dropState->rowScroll, targetRow)) / metrics.zoom)
             );
         if (view->workspace() != target) {
-          view->setWorkspace(target, /*attachToLayout=*/false);
+          view->moveToWorkspace(target, /*attachToLayout=*/false);
         }
         view->setPosition(x, y);
       }

--- a/src/server/actions.cpp
+++ b/src/server/actions.cpp
@@ -147,7 +147,7 @@ namespace umbriel {
       if (floating) {
         view.rememberFloatingPosition();
       }
-      view.setWorkspace(&target); // layoutAttach self-guards on tiled()
+      view.moveToWorkspace(&target); // layoutAttach self-guards on tiled()
       target.group()->activate(&target);
       if (floating) {
         view.restoreFloatingPosition();
@@ -733,14 +733,14 @@ namespace umbriel {
       const double width = source->layout().columns()[static_cast<size_t>(column)].widthFrac;
 
       View* first = columnViews.front();
-      first->setWorkspace(destination, /*attachToLayout=*/false);
+      first->moveToWorkspace(destination, /*attachToLayout=*/false);
       destination->layout().insertView(first, static_cast<int>(destination->layout().columns().size()));
       if (destination->scrollingLayout() != nullptr) {
         destination->layout().setWidthFraction(destination->layout().columnOf(first), width);
       }
       for (size_t i = 1; i < columnViews.size(); ++i) {
         View* view = columnViews[i];
-        view->setWorkspace(destination, /*attachToLayout=*/false);
+        view->moveToWorkspace(destination, /*attachToLayout=*/false);
         destination->layout().insertViewIntoColumn(view, destination->layout().columnOf(first), static_cast<int>(i));
       }
       destination->markArrange();
@@ -790,20 +790,20 @@ namespace umbriel {
           continue;
         }
         View* first = column.views.front();
-        first->setWorkspace(destination, /*attachToLayout=*/false);
+        first->moveToWorkspace(destination, /*attachToLayout=*/false);
         destination->layout().insertView(first, static_cast<int>(destination->layout().columns().size()));
         if (destination->scrollingLayout() != nullptr) {
           destination->layout().setWidthFraction(destination->layout().columnOf(first), column.widthFrac);
         }
         for (size_t i = 1; i < column.views.size(); ++i) {
           View* view = column.views[i];
-          view->setWorkspace(destination, /*attachToLayout=*/false);
+          view->moveToWorkspace(destination, /*attachToLayout=*/false);
           destination->layout().insertViewIntoColumn(view, destination->layout().columnOf(first), static_cast<int>(i));
         }
       }
       for (View* view : floats) {
         view->rememberFloatingPosition();
-        view->setWorkspace(destination);
+        view->moveToWorkspace(destination);
         view->restoreFloatingPosition();
       }
 

--- a/src/server/ipc_commands.cpp
+++ b/src/server/ipc_commands.cpp
@@ -58,6 +58,8 @@ namespace umbriel {
       }
     }
 
+    void printOutputName(const nlohmann::json& ok) { std::println("{}", ok.get<std::string>()); }
+
     std::string fourccName(uint32_t format) {
       if (format == DRM_FORMAT_INVALID) {
         return "invalid";
@@ -398,12 +400,33 @@ namespace umbriel {
     return nlohmann::json{{"ok", nullptr}};
   }
 
+  nlohmann::json IpcCommands::outputCreate(Server& server, std::string_view arg) {
+    std::string error;
+    const std::string name = server.createHeadlessOutput(std::string(arg), &error);
+    if (!error.empty()) {
+      return nlohmann::json{{"err", error}};
+    }
+    return nlohmann::json{{"ok", name}};
+  }
+
+  nlohmann::json IpcCommands::outputDestroy(Server& server, std::string_view arg) {
+    std::string error;
+    if (!server.destroyOutput(std::string(arg), &error)) {
+      return nlohmann::json{{"err", error}};
+    }
+    return nlohmann::json{{"ok", nullptr}};
+  }
+
   static constexpr IpcCommandSpec kIpcCommands[] = {
       {"msg", "<action> [args...]", "send an action to the compositor", true, &IpcCommands::msg, nullptr},
       {"windows", "", "list windows (app id and title)", false, &IpcCommands::windows, &printWindows},
       {"layers", "", "list layer-shell surfaces", false, &IpcCommands::layers, &printLayers},
       {"color", "", "show color-management state", false, &IpcCommands::color, &printColor},
       {"keyboard-layouts", "", "list keyboard layouts", false, &IpcCommands::keyboardLayouts, nullptr},
+      {"output-create", "<name>", "create a headless output (headless sessions only)", true, &IpcCommands::outputCreate,
+       &printOutputName},
+      {"output-destroy", "<name>", "destroy an output (headless sessions only)", true, &IpcCommands::outputDestroy,
+       nullptr},
   };
 
   std::span<const IpcCommandSpec> ipcCommands() { return kIpcCommands; }

--- a/src/server/ipc_commands.h
+++ b/src/server/ipc_commands.h
@@ -13,6 +13,8 @@ namespace umbriel {
     static nlohmann::json layers(Server& server, std::string_view arg);
     static nlohmann::json color(Server& server, std::string_view arg);
     static nlohmann::json msg(Server& server, std::string_view arg);
+    static nlohmann::json outputCreate(Server& server, std::string_view arg);
+    static nlohmann::json outputDestroy(Server& server, std::string_view arg);
   };
 
   struct IpcCommandSpec {

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -287,6 +287,7 @@ namespace umbriel {
 
     void removeOutput(Output* output);
     void reassignOutputViews(Output* source, Output* destination);
+    void scheduleDisplacedViewRestore();
     void removeKeyboard(Keyboard* keyboard);
     void removeView(View* view);
     void removeLayerSurface(LayerSurface* layerSurface, wlr_output* output);
@@ -342,6 +343,7 @@ namespace umbriel {
     static int onBackgroundFrameTimer(void* data);
     static int onTerminateSignal(int signal, void* data);
     static void onIpcWindowsIdle(void* data);
+    static void onDisplacedRestoreIdle(void* data);
 
     void addOutput(wlr_output* output);
     void addKeyboard(wlr_input_device* device);
@@ -384,6 +386,7 @@ namespace umbriel {
     void handleWorkspaceCommit(void* data);
     [[nodiscard]] Workspace* workspaceFromHandle(wlr_ext_workspace_handle_v1* handle) const;
     void applyOutputManagerConfig(wlr_output_configuration_v1* config, bool testOnly);
+    void restoreDisplacedViews();
     [[nodiscard]] WorkspaceGroup* workspaceGroupFromHandle(wlr_ext_workspace_group_handle_v1* handle) const;
 
     struct IdleInhibitorWatch {
@@ -517,6 +520,7 @@ namespace umbriel {
     // Non-null while a windows-event idle callback is pending. The idle source
     // removes itself when it runs, so a non-null pointer means "already queued".
     wl_event_source* m_ipcWindowsIdle = nullptr;
+    wl_event_source* m_displacedRestoreIdle = nullptr;
     // SIGINT / SIGTERM, delivered on the event loop rather than in a signal
     // handler, so shutdown runs ordinary code instead of async-signal-safe code.
     wl_event_source* m_signalSources[2]{};

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -285,6 +285,11 @@ namespace umbriel {
     // The tablet-v2 handle for a wlroots tablet, or nullptr when unknown.
     [[nodiscard]] wlr_tablet_v2_tablet* tabletV2FromWlr(const wlr_tablet* tablet) const;
 
+    // Create and destroy headless outputs at runtime, which is how a test drives a monitor being unplugged and coming
+    // back. Returns the new output's name, or an empty string with `error` set.
+    std::string createHeadlessOutput(const std::string& name, std::string* error);
+    bool destroyOutput(const std::string& name, std::string* error);
+
     void removeOutput(Output* output);
     void reassignOutputViews(Output* source, Output* destination);
     void scheduleDisplacedViewRestore();
@@ -521,6 +526,8 @@ namespace umbriel {
     // removes itself when it runs, so a non-null pointer means "already queued".
     wl_event_source* m_ipcWindowsIdle = nullptr;
     wl_event_source* m_displacedRestoreIdle = nullptr;
+    // Name to give the next output the backend hands over, set while createHeadlessOutput is adding one.
+    std::string m_pendingOutputName;
     // SIGINT / SIGTERM, delivered on the event loop rather than in a signal
     // handler, so shutdown runs ordinary code instead of async-signal-safe code.
     wl_event_source* m_signalSources[2]{};

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -1506,7 +1506,7 @@ namespace umbriel {
       ++restored;
     }
     if (m_scratchpadManager != nullptr) {
-      m_scratchpadManager->adoptOrphans(fallback);
+      restored += m_scratchpadManager->restoreDisplaced(fallback);
     }
     if (restored > 0) {
       kLog.info("restored {} displaced windows", restored);

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -984,6 +984,10 @@ namespace umbriel {
   void Server::raiseLockTree() { wlr_scene_node_raise_to_top(&m_lockTree->node); }
 
   void Server::addOutput(wlr_output* output) {
+    if (!m_pendingOutputName.empty()) {
+      // Before the Output exists: adding it to the layout advertises the name to clients, and it cannot change after.
+      wlr_output_set_name(output, m_pendingOutputName.c_str());
+    }
     m_outputs.push_back(std::make_unique<Output>(*this, output));
     scheduleDisplacedViewRestore();
     markDirty(Dirty::Backdrop | Dirty::Banner | Dirty::Cheatsheet | Dirty::QuitConfirm);

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -21,10 +21,23 @@
 #include "workspace/scratchpad.h"
 #include "workspace/workspace.h"
 
+#include <algorithm>
+#include <charconv>
+#include <limits>
+#include <optional>
+#include <vector>
+
 namespace umbriel {
 
   namespace {
     constexpr Logger kLog("server");
+
+    // Dynamic workspaces are numbered, static ones can be named; sort the numbers by value and push names to the end.
+    size_t workspaceOrder(std::string_view name) {
+      size_t index = 0;
+      const auto [end, error] = std::from_chars(name.data(), name.data() + name.size(), index);
+      return error == std::errc{} && end == name.data() + name.size() ? index : std::numeric_limits<size_t>::max();
+    }
 
     View* viewForSurface(Server& server, wlr_surface* surface) {
       if (surface == nullptr) {
@@ -344,6 +357,7 @@ namespace umbriel {
         }
         reassignOutputViews(output.get(), fallback);
       }
+      scheduleDisplacedViewRestore();
       updateOutputManagerConfig();
       // A disabled output must not keep keyboard focus: pull it onto a live one.
       refocus();
@@ -971,6 +985,7 @@ namespace umbriel {
 
   void Server::addOutput(wlr_output* output) {
     m_outputs.push_back(std::make_unique<Output>(*this, output));
+    scheduleDisplacedViewRestore();
     markDirty(Dirty::Backdrop | Dirty::Banner | Dirty::Cheatsheet | Dirty::QuitConfirm);
     if (m_sessionLocked) {
       updateLockBlank();
@@ -1381,16 +1396,123 @@ namespace umbriel {
     Workspace* targetWorkspace = destination != nullptr && destination->workspaceGroup() != nullptr
         ? destination->workspaceGroup()->active()
         : nullptr;
+    const char* sourceName = source->wlr()->name;
     if (sourceGroup != nullptr) {
+      // Record every home before the first move; setWorkspace empties workspaces as views leave and a dynamic group
+      // renumbers what is left, under the windows that have not been read yet.
+      std::vector<View*> leaving;
       for (const auto& view : m_registry.all()) {
         Workspace* workspace = view->workspace();
-        if (workspace != nullptr && workspace->group() == sourceGroup) {
-          view->setWorkspace(targetWorkspace);
+        if (workspace == nullptr || workspace->group() != sourceGroup) {
+          continue;
+        }
+        if (!view->displacedHome() && sourceName != nullptr) {
+          view->markDisplaced({.outputName = sourceName, .workspaceName = workspace->name()});
+        }
+        leaving.push_back(view.get());
+      }
+      for (View* view : leaving) {
+        const bool floating = view->floating();
+        if (floating) {
+          view->rememberFloatingPosition();
+        }
+        view->setWorkspace(targetWorkspace);
+        if (floating && targetWorkspace != nullptr) {
+          view->restoreFloatingPosition();
         }
       }
     }
     if (m_scratchpadManager != nullptr) {
       m_scratchpadManager->moveOutput(source, destination);
+    }
+  }
+
+  // Deferred to idle: outputs come back one at a time, and a returning one has no workspace group until addOutput is
+  // done with it.
+  void Server::scheduleDisplacedViewRestore() {
+    if (m_displacedRestoreIdle != nullptr) {
+      return;
+    }
+    m_displacedRestoreIdle = wl_event_loop_add_idle(wl_display_get_event_loop(m_display), onDisplacedRestoreIdle, this);
+    if (m_displacedRestoreIdle == nullptr) {
+      kLog.error("failed to register displaced window restore idle source");
+      restoreDisplacedViews();
+    }
+  }
+
+  void Server::onDisplacedRestoreIdle(void* data) {
+    auto* server = static_cast<Server*>(data);
+    server->m_displacedRestoreIdle = nullptr;
+    server->restoreDisplacedViews();
+  }
+
+  void Server::restoreDisplacedViews() {
+    Output* fallback = outputFromWlr(preferredOutput());
+    if (fallback == nullptr) {
+      return;
+    }
+    std::vector<View*> displaced;
+    for (const auto& entry : m_registry.all()) {
+      if (entry->displacedHome()) {
+        displaced.push_back(entry.get());
+      }
+    }
+    // Restore in workspace order; a dynamic group only grows workspace N+1 once N is occupied, and a higher home
+    // reaching it first lands on the trailing empty workspace instead.
+    std::ranges::sort(displaced, [](const View* lhs, const View* rhs) {
+      const View::DisplacedHome& left = *lhs->displacedHome();
+      const View::DisplacedHome& right = *rhs->displacedHome();
+      if (left.outputName != right.outputName) {
+        return left.outputName < right.outputName;
+      }
+      const size_t leftIndex = workspaceOrder(left.workspaceName);
+      const size_t rightIndex = workspaceOrder(right.workspaceName);
+      return leftIndex != rightIndex ? leftIndex < rightIndex : left.workspaceName < right.workspaceName;
+    });
+    size_t restored = 0;
+    for (View* view : displaced) {
+      const View::DisplacedHome home = *view->displacedHome();
+      Output* target = outputFromName(home.outputName);
+      WorkspaceGroup* group = target != nullptr ? target->workspaceGroup() : nullptr;
+      const bool atHome = group != nullptr;
+      if (!atHome) {
+        // The home output is still gone: rescue only a view left with no workspace at all, and leave the rest put.
+        if (view->workspace() != nullptr) {
+          continue;
+        }
+        group = fallback->workspaceGroup();
+        if (group == nullptr) {
+          continue;
+        }
+      }
+      Workspace* workspace = atHome ? group->workspaceForSelector(home.workspaceName) : nullptr;
+      if (workspace == nullptr) {
+        workspace = group->active();
+      }
+      if (workspace == nullptr) {
+        continue;
+      }
+      if (atHome) {
+        view->clearDisplaced();
+      }
+      if (workspace == view->workspace()) {
+        continue;
+      }
+      const bool floating = view->floating();
+      view->setWorkspace(workspace);
+      if (floating) {
+        view->restoreFloatingPosition();
+      }
+      ++restored;
+    }
+    if (m_scratchpadManager != nullptr) {
+      m_scratchpadManager->adoptOrphans(fallback);
+    }
+    if (restored > 0) {
+      kLog.info("restored {} displaced windows", restored);
+      refreshSurfaceScales();
+      refocus();
+      scheduleIpcWindowsEvent();
     }
   }
 

--- a/src/server/server_outputs.cpp
+++ b/src/server/server_outputs.cpp
@@ -10,6 +10,65 @@
 
 namespace umbriel {
 
+  namespace {
+    // Headless outputs are created at the size the backend gives the ones from WLR_HEADLESS_OUTPUTS.
+    constexpr unsigned int kHeadlessWidth = 1280;
+    constexpr unsigned int kHeadlessHeight = 720;
+
+    wlr_backend* headlessBackend(wlr_backend* backend) {
+      if (backend == nullptr || wlr_backend_is_headless(backend)) {
+        return backend;
+      }
+      if (!wlr_backend_is_multi(backend)) {
+        return nullptr;
+      }
+      wlr_backend* headless = nullptr;
+      wlr_multi_for_each_backend(
+          backend,
+          [](wlr_backend* candidate, void* data) {
+            if (wlr_backend_is_headless(candidate)) {
+              *static_cast<wlr_backend**>(data) = candidate;
+            }
+          },
+          &headless
+      );
+      return headless;
+    }
+  } // namespace
+
+  std::string Server::createHeadlessOutput(const std::string& name, std::string* error) {
+    wlr_backend* headless = headlessBackend(m_backend);
+    if (headless == nullptr) {
+      *error = "no headless backend in this session";
+      return {};
+    }
+    for (const auto& output : m_outputs) {
+      if (output->wlr()->name != nullptr && name == output->wlr()->name) {
+        *error = "output already exists: " + name;
+        return {};
+      }
+    }
+    m_pendingOutputName = name;
+    wlr_output* output = wlr_headless_add_output(headless, kHeadlessWidth, kHeadlessHeight);
+    m_pendingOutputName.clear();
+    if (output == nullptr) {
+      *error = "failed to create a headless output";
+      return {};
+    }
+    return output->name != nullptr ? output->name : "";
+  }
+
+  bool Server::destroyOutput(const std::string& name, std::string* error) {
+    for (const auto& output : m_outputs) {
+      if (output->wlr()->name != nullptr && name == output->wlr()->name) {
+        wlr_output_destroy(output->wlr());
+        return true;
+      }
+    }
+    *error = "unknown output: " + name;
+    return false;
+  }
+
   void Server::arrangeLayers(wlr_output* output) {
     if (Output* out = outputFromWlr(output)) {
       out->markDirty(Dirty::LayerArrange);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -220,6 +220,11 @@ namespace umbriel {
 
   wlr_scene_tree* View::captureTree() const { return m_captureScene != nullptr ? &m_captureScene->tree : nullptr; }
 
+  void View::moveToWorkspace(Workspace* workspace, bool attachToLayout) {
+    m_displacedHome.reset();
+    setWorkspace(workspace, attachToLayout);
+  }
+
   void View::setWorkspace(Workspace* workspace, bool attachToLayout) {
     if (workspace != nullptr
         && m_server->scratchpadManager() != nullptr

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -90,7 +90,19 @@ namespace umbriel {
     // activation chrome the focus manager drives from outside.
     void setBorderFocused(bool focused);
     void setWorkspace(Workspace* workspace, bool attachToLayout = true);
+    // A move the user asked for: the view belongs where it lands, and any displaced home is dropped.
+    void moveToWorkspace(Workspace* workspace, bool attachToLayout = true);
     void detachWorkspace();
+
+    // The output and workspace the view sat on when its output went away; restoreDisplacedViews puts it back there.
+    struct DisplacedHome {
+      std::string outputName;
+      std::string workspaceName;
+    };
+    [[nodiscard]] const std::optional<DisplacedHome>& displacedHome() const { return m_displacedHome; }
+    void markDisplaced(DisplacedHome home) { m_displacedHome = std::move(home); }
+    void clearDisplaced() { m_displacedHome.reset(); }
+
     void setOnActiveWorkspace(bool active);
     void setScratchpadBorder(bool scratchpad);
     void animateTo(int x, int y);
@@ -316,6 +328,7 @@ namespace umbriel {
     wlr_output* m_foreignOutput = nullptr;
     wlr_ext_image_capture_source_v1* m_captureSource = nullptr;
     Workspace* m_workspace = nullptr;
+    std::optional<DisplacedHome> m_displacedHome;
     bool m_mapped = false;
     // Saved client state commonly requests maximization while the surface is
     // opening. Layout policy owns that transition; later requests are valid.

--- a/src/wlr.h
+++ b/src/wlr.h
@@ -6,7 +6,9 @@ extern "C" {
 #include <scenefx/render/fx_renderer/fx_renderer.h>
 #include <scenefx/types/wlr_scene.h>
 #include <wlr/backend.h>
+#include <wlr/backend/headless.h>
 #include <wlr/backend/libinput.h>
+#include <wlr/backend/multi.h>
 #include <wlr/backend/session.h>
 #include <wlr/backend/wayland.h>
 #include <wlr/interfaces/wlr_keyboard.h>

--- a/src/workspace/scratchpad.cpp
+++ b/src/workspace/scratchpad.cpp
@@ -308,6 +308,9 @@ namespace umbriel {
     }
     for (Entry& entry : m_entries) {
       if (entry.output == from) {
+        if (entry.displacedOutput.empty() && from != nullptr && from->wlr()->name != nullptr) {
+          entry.displacedOutput = from->wlr()->name;
+        }
         entry.output = to;
       }
     }
@@ -316,15 +319,29 @@ namespace umbriel {
     }
   }
 
-  void ScratchpadManager::adoptOrphans(Output* output) {
-    if (output == nullptr) {
-      return;
+  size_t ScratchpadManager::restoreDisplaced(Output* fallback) {
+    if (fallback == nullptr || m_server == nullptr) {
+      return 0;
     }
+    size_t restored = 0;
     for (Entry& entry : m_entries) {
-      if (entry.output == nullptr) {
-        entry.output = output;
+      Output* home = entry.displacedOutput.empty() ? nullptr : m_server->outputFromName(entry.displacedOutput);
+      if (home != nullptr) {
+        entry.displacedOutput.clear();
       }
+      Output* target = home != nullptr ? home : (entry.output == nullptr ? fallback : nullptr);
+      if (target == nullptr || target == entry.output) {
+        continue;
+      }
+      entry.output = target;
+      if (entry.view != nullptr) {
+        const bool visible = std::ranges::find(m_visibleOutputs, target) != m_visibleOutputs.end();
+        entry.view->setOnActiveWorkspace(visible);
+        entry.view->setNodeEnabled(visible);
+      }
+      ++restored;
     }
+    return restored;
   }
 
 } // namespace umbriel

--- a/src/workspace/scratchpad.cpp
+++ b/src/workspace/scratchpad.cpp
@@ -90,7 +90,7 @@ namespace umbriel {
         );
       }
     }
-    view->setWorkspace(nullptr);
+    view->moveToWorkspace(nullptr);
     wlr_scene_node_reparent(&view->sceneTree()->node, m_root);
     view->reparentShadow(m_shadowRoot);
     view->setScratchpadBorder(true);
@@ -261,7 +261,7 @@ namespace umbriel {
     }
     view->reparentShadow(nullptr);
     view->setScratchpadBorder(false);
-    view->setWorkspace(workspace, false);
+    view->moveToWorkspace(workspace, false);
     if (entry.returnTiled) {
       view->setFloating(false);
     } else {
@@ -313,6 +313,17 @@ namespace umbriel {
     }
     if (wasVisible && to != nullptr) {
       setVisible(to, true);
+    }
+  }
+
+  void ScratchpadManager::adoptOrphans(Output* output) {
+    if (output == nullptr) {
+      return;
+    }
+    for (Entry& entry : m_entries) {
+      if (entry.output == nullptr) {
+        entry.output = output;
+      }
     }
   }
 

--- a/src/workspace/scratchpad.h
+++ b/src/workspace/scratchpad.h
@@ -28,13 +28,15 @@ namespace umbriel {
     void restorePresentation(View* view);
     void remove(View* view);
     void moveOutput(Output* from, Output* to);
-    void adoptOrphans(Output* output);
+    // Return entries to the output they were parked on. Entries whose output is still gone park on `fallback`.
+    size_t restoreDisplaced(Output* fallback);
 
   private:
     struct Entry {
       View* view = nullptr;
       Output* output = nullptr;
       std::string returnOutput;
+      std::string displacedOutput;
       std::string returnWorkspace;
       bool returnTiled = false;
       bool lastFocused = false;

--- a/src/workspace/scratchpad.h
+++ b/src/workspace/scratchpad.h
@@ -28,6 +28,7 @@ namespace umbriel {
     void restorePresentation(View* view);
     void remove(View* view);
     void moveOutput(Output* from, Output* to);
+    void adoptOrphans(Output* output);
 
   private:
     struct Entry {

--- a/tests/harness/checks/620_output_disable.sh
+++ b/tests/harness/checks/620_output_disable.sh
@@ -71,4 +71,6 @@ if ! wait_for_log_since "$mark" "output 'HEADLESS-2': applied mode="; then
   exit 1
 fi
 
-echo "output disabled and re-enabled through live reload"
+wait_for_workspace 'HEADLESS-2:1'
+
+echo "output disabled and re-enabled through live reload, and its window came back"

--- a/tests/harness/checks/625_output_remove_restore.sh
+++ b/tests/harness/checks/625_output_remove_restore.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# harness: outputs=2
+# Windows stranded when every output goes away at once (as a suspend/resume cycle does) must return to their own output
+# and workspace once the monitors come back.
+set -euo pipefail
+
+readonly WORKSPACE="${UMBRIEL_WORKSPACE_CLIENT:-./build-debug/workspace-client}"
+
+BASELINE="$(< "$UMBRIEL_CONFIG")"$'\n[appearance]\nanimation_ms = 1'
+
+write_config() {
+  {
+    printf '%s\n' "$BASELINE"
+    if [[ -n $1 ]]; then
+      printf '\n%s\n' "$1"
+    fi
+  } > "$UMBRIEL_CONFIG"
+}
+
+log_mark() { wc -l < "$UMBRIEL_LOG"; }
+
+wait_for_log_since() {
+  local mark=$1 pattern=$2
+  for _ in $(seq 40); do
+    if tail -n +"$((mark + 1))" "$UMBRIEL_LOG" | grep -q "$pattern"; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+expect_log_since() {
+  local mark=$1 pattern=$2 message=$3
+  if wait_for_log_since "$mark" "$pattern"; then
+    return 0
+  fi
+  echo "$message"
+  tail -8 "$UMBRIEL_LOG" | sed 's/^/  | /'
+  exit 1
+}
+
+spawn_client() {
+  foot --title="$1" sh -c 'sleep 120' > /dev/null 2>&1 &
+}
+
+wait_for_count() {
+  local expected=$1 count=
+  for _ in $(seq 40); do
+    count=$("$UMBRIEL" windows --json | jq 'length')
+    [[ $count == "$expected" ]] && return 0
+    sleep 0.25
+  done
+  echo "expected $expected window(s), got $count"
+  return 1
+}
+
+field_of() {
+  "$UMBRIEL" windows --json | jq -r --arg title "$1" --arg field "$2" '.[] | select(.title == $title) | .[$field]'
+}
+
+workspace_of() { field_of "$1" workspace; }
+
+wait_for_workspace() {
+  local title=$1 expected=$2 workspace=
+  for _ in $(seq 40); do
+    workspace=$(workspace_of "$title")
+    [[ $workspace == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  echo "expected '$title' on workspace '$expected', got '$workspace'"
+  return 1
+}
+
+# A workspace id carries a serial that an output going away and coming back does not preserve. Names survive it:
+# assert on those.
+home_of() {
+  local workspace=
+  workspace=$(workspace_of "$1")
+  [[ -z $workspace ]] && return 0
+  printf '%s/%s' "${workspace%%:*}" "$("$WORKSPACE" --all | awk -F'\t' -v id="$workspace" '$1 == id { print $2 }')"
+}
+
+wait_for_home() {
+  local title=$1 expected=$2 home=
+  for _ in $(seq 40); do
+    home=$(home_of "$title")
+    [[ $home == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  echo "expected '$title' back on '$expected', got '$home'"
+  return 1
+}
+
+wait_for_output() {
+  local title=$1 output=$2 workspace=
+  for _ in $(seq 40); do
+    workspace=$(workspace_of "$title")
+    [[ $workspace == "$output":* ]] && return 0
+    sleep 0.1
+  done
+  echo "expected '$title' on an output '$output' workspace, got '$workspace'"
+  return 1
+}
+
+move_to_workspace() {
+  local title=$1 selector=$2
+  "$UMBRIEL" msg "window-focus:$(field_of "$title" id)" > /dev/null
+  "$UMBRIEL" msg "window-move-to-workspace:$selector" > /dev/null
+  wait_for_output "$title" "${selector#*/}"
+}
+
+# The setup below leans on three dynamic-group rules: an emptied workspace is reaped and the rest renumber, the active
+# workspace is never reaped, and a running slide suspends both.
+write_config ''
+"$UMBRIEL" msg config-reload > /dev/null
+
+# Two windows per output, each on its own dynamic workspace. HEADLESS-2's pair is spawned in reverse of the order its
+# workspaces are created in.
+spawn_client second-ws2
+wait_for_count 1
+spawn_client second-ws1
+wait_for_count 2
+move_to_workspace second-ws1 1/HEADLESS-2
+move_to_workspace second-ws2 2/HEADLESS-2
+spawn_client first-ws1
+wait_for_count 3
+move_to_workspace first-ws1 1/HEADLESS-1
+spawn_client first-ws2
+wait_for_count 4
+move_to_workspace first-ws2 2/HEADLESS-1
+
+declare -A HOME=()
+for window in first-ws1 first-ws2 second-ws1 second-ws2; do
+  HOME[$window]=$(home_of "$window")
+done
+if [[ $(printf '%s\n' "${HOME[@]}" | sort -u | wc -l) != 4 ]]; then
+  echo "windows did not settle on four separate workspaces: ${HOME[*]}"
+  exit 1
+fi
+
+# Windows are visited most-recently-focused first; this pins the order they leave in and come back in.
+for window in second-ws1 second-ws2 first-ws2 first-ws1; do
+  "$UMBRIEL" msg "window-focus:$(field_of "$window" id)" > /dev/null
+done
+# Off first-ws1's workspace: the active workspace is never reaped, and this one has to be.
+"$UMBRIEL" msg workspace-switch:3/HEADLESS-1 > /dev/null
+
+# Every monitor goes away at once, the way a suspend takes them; the windows have nowhere to go.
+mark=$(log_mark)
+write_config '[output.HEADLESS-1]
+enabled = false
+[output.HEADLESS-2]
+enabled = false'
+"$UMBRIEL" msg config-reload > /dev/null
+for output in HEADLESS-1 HEADLESS-2; do
+  expect_log_since "$mark" "output '$output': disabled by config" "$output was not disabled on reload"
+done
+for window in first-ws1 first-ws2 second-ws1 second-ws2; do
+  wait_for_workspace "$window" ''
+done
+
+# HEADLESS-1 comes back first and takes in the windows whose own output is still missing.
+mark=$(log_mark)
+write_config '[output.HEADLESS-2]
+enabled = false'
+"$UMBRIEL" msg config-reload > /dev/null
+expect_log_since "$mark" "output 'HEADLESS-1': applied mode=" "HEADLESS-1 was not re-enabled on reload"
+wait_for_home first-ws1 "${HOME[first-ws1]}"
+wait_for_home first-ws2 "${HOME[first-ws2]}"
+wait_for_output second-ws1 HEADLESS-1
+wait_for_output second-ws2 HEADLESS-1
+
+# A window that sat out on another output still knows where it belongs.
+mark=$(log_mark)
+write_config ''
+"$UMBRIEL" msg config-reload > /dev/null
+expect_log_since "$mark" "output 'HEADLESS-2': applied mode=" "HEADLESS-2 was not re-enabled on reload"
+for window in first-ws1 first-ws2 second-ws1 second-ws2; do
+  wait_for_home "$window" "${HOME[$window]}"
+done
+
+echo "windows stranded when every output went away came back to their own output and workspace"

--- a/tests/harness/checks/626_output_scratchpad_restore.sh
+++ b/tests/harness/checks/626_output_scratchpad_restore.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# harness: outputs=2
+# A scratchpad window is parked on an output rather than on a workspace, and it has to find its way back to that output
+# after every monitor goes away and returns.
+set -euo pipefail
+
+BASELINE=$(< "$UMBRIEL_CONFIG")
+
+write_config() {
+  {
+    printf '%s\n' "$BASELINE"
+    if [[ -n $1 ]]; then
+      printf '\n%s\n' "$1"
+    fi
+  } > "$UMBRIEL_CONFIG"
+}
+
+log_mark() { wc -l < "$UMBRIEL_LOG"; }
+
+wait_for_log_since() {
+  local mark=$1 pattern=$2
+  for _ in $(seq 40); do
+    if tail -n +"$((mark + 1))" "$UMBRIEL_LOG" | grep -q "$pattern"; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+expect_log_since() {
+  local mark=$1 pattern=$2 message=$3
+  if wait_for_log_since "$mark" "$pattern"; then
+    return 0
+  fi
+  echo "$message"
+  tail -8 "$UMBRIEL_LOG" | sed 's/^/  | /'
+  exit 1
+}
+
+reload_with() {
+  local mark=
+  mark=$(log_mark)
+  write_config "$1"
+  "$UMBRIEL" msg config-reload > /dev/null
+  shift
+  for expected in "$@"; do
+    expect_log_since "$mark" "${expected#*=}" "output ${expected%%=*} did not ${expected#*=} on reload"
+  done
+}
+
+wait_for_count() {
+  local expected=$1 count=
+  for _ in $(seq 40); do
+    count=$("$UMBRIEL" windows --json | jq 'length')
+    [[ $count == "$expected" ]] && return 0
+    sleep 0.25
+  done
+  echo "expected $expected window(s), got $count"
+  return 1
+}
+
+# The drawer only opens on the output holding the window, and focuses it when it does. Closed again either way.
+shows_scratchpad() {
+  local output=$1 active=
+  "$UMBRIEL" msg "scratchpad-toggle:$output" > /dev/null
+  for _ in $(seq 10); do
+    active=$("$UMBRIEL" windows --json | jq -r '.[] | select(.title == "scratch-restore") | .active')
+    [[ $active == true ]] && break
+    sleep 0.1
+  done
+  "$UMBRIEL" msg "scratchpad-toggle:$output" > /dev/null
+  [[ $active == true ]]
+}
+
+foot --title=scratch-restore sh -c 'sleep 120' > /dev/null 2>&1 &
+wait_for_count 1
+"$UMBRIEL" msg window-move-to-scratchpad:HEADLESS-2 > /dev/null
+if ! shows_scratchpad HEADLESS-2; then
+  echo "window was not parked on the HEADLESS-2 scratchpad"
+  exit 1
+fi
+
+# Every monitor goes away at once, the way a suspend takes them.
+reload_with '[output.HEADLESS-1]
+enabled = false
+[output.HEADLESS-2]
+enabled = false' "HEADLESS-1=output 'HEADLESS-1': disabled by config" "HEADLESS-2=output 'HEADLESS-2': disabled by config"
+
+# HEADLESS-1 comes back first and takes the window in, though it is not where it belongs.
+reload_with '[output.HEADLESS-2]
+enabled = false' "HEADLESS-1=output 'HEADLESS-1': applied mode="
+if ! shows_scratchpad HEADLESS-1; then
+  echo "scratchpad window was not rescued onto the one output that came back"
+  exit 1
+fi
+
+# HEADLESS-2 comes back and takes its window back.
+reload_with '' "HEADLESS-2=output 'HEADLESS-2': applied mode="
+if ! shows_scratchpad HEADLESS-2; then
+  echo "scratchpad window did not go back to HEADLESS-2"
+  exit 1
+fi
+if shows_scratchpad HEADLESS-1; then
+  echo "scratchpad window is still on HEADLESS-1 as well"
+  exit 1
+fi
+
+echo "a scratchpad window parked on an output was rescued while it was gone and went back when it returned"

--- a/tests/harness/checks/627_output_hotplug_restore.sh
+++ b/tests/harness/checks/627_output_hotplug_restore.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# harness: outputs=2
+# The monitors a suspend takes away are destroyed outright, not disabled, and they come back as new outputs carrying
+# the same names. Windows must find their way home across that too.
+set -euo pipefail
+
+readonly WORKSPACE="${UMBRIEL_WORKSPACE_CLIENT:-./build-debug/workspace-client}"
+
+spawn_client() {
+  foot --title="$1" sh -c 'sleep 120' > /dev/null 2>&1 &
+}
+
+wait_for_count() {
+  local expected=$1 count=
+  for _ in $(seq 40); do
+    count=$("$UMBRIEL" windows --json | jq 'length')
+    [[ $count == "$expected" ]] && return 0
+    sleep 0.25
+  done
+  echo "expected $expected window(s), got $count"
+  return 1
+}
+
+field_of() {
+  "$UMBRIEL" windows --json | jq -r --arg title "$1" --arg field "$2" '.[] | select(.title == $title) | .[$field]'
+}
+
+workspace_of() { field_of "$1" workspace; }
+
+home_of() {
+  local workspace=
+  workspace=$(workspace_of "$1")
+  [[ -z $workspace ]] && return 0
+  printf '%s/%s' "${workspace%%:*}" "$("$WORKSPACE" --all | awk -F'\t' -v id="$workspace" '$1 == id { print $2 }')"
+}
+
+wait_for_home() {
+  local title=$1 expected=$2 home=
+  for _ in $(seq 40); do
+    home=$(home_of "$title")
+    [[ $home == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  echo "expected '$title' on '$expected', got '$home'"
+  return 1
+}
+
+move_to_workspace() {
+  local title=$1 selector=$2
+  "$UMBRIEL" msg "window-focus:$(field_of "$title" id)" > /dev/null
+  "$UMBRIEL" msg "window-move-to-workspace:$selector" > /dev/null
+  wait_for_home "$title" "${selector#*/}/${selector%%/*}"
+}
+
+wait_for_output() {
+  local title=$1 output=$2 home=
+  for _ in $(seq 40); do
+    home=$(home_of "$title")
+    [[ $home == "$output"/* ]] && return 0
+    sleep 0.1
+  done
+  echo "expected '$title' on an output '$output' workspace, got '$home'"
+  return 1
+}
+
+# Two windows on one output and one on the other, the same shape 625 uses, on dynamic workspaces.
+spawn_client hotplug-first
+wait_for_count 1
+move_to_workspace hotplug-first 1/HEADLESS-1
+spawn_client hotplug-second
+wait_for_count 2
+move_to_workspace hotplug-second 2/HEADLESS-1
+spawn_client hotplug-other
+wait_for_count 3
+move_to_workspace hotplug-other 1/HEADLESS-2
+
+# Unplug everything. Destroying the last output leaves the windows with no workspace at all.
+"$UMBRIEL" output-destroy HEADLESS-1 > /dev/null
+"$UMBRIEL" output-destroy HEADLESS-2 > /dev/null
+for window in hotplug-first hotplug-second hotplug-other; do
+  wait_for_home "$window" ''
+done
+
+# Plug the monitors back in one at a time, under the names they had before.
+created=$("$UMBRIEL" output-create HEADLESS-2)
+if [[ $created != HEADLESS-2 ]]; then
+  echo "expected the new output to be named HEADLESS-2, got '$created'"
+  exit 1
+fi
+wait_for_home hotplug-other HEADLESS-2/1
+wait_for_output hotplug-first HEADLESS-2
+wait_for_output hotplug-second HEADLESS-2
+
+"$UMBRIEL" output-create HEADLESS-1 > /dev/null
+wait_for_home hotplug-first HEADLESS-1/1
+wait_for_home hotplug-second HEADLESS-1/2
+wait_for_home hotplug-other HEADLESS-2/1
+
+echo "windows came home across outputs being destroyed and recreated"

--- a/tests/harness/clients/workspace_client.cpp
+++ b/tests/harness/clients/workspace_client.cpp
@@ -11,6 +11,7 @@
 namespace {
   struct Workspace {
     ext_workspace_handle_v1* handle = nullptr;
+    std::string id;
     std::string name;
     uint32_t state = 0;
     bool removed = false;
@@ -24,7 +25,9 @@ namespace {
     bool done = false;
   };
 
-  void workspaceId(void*, ext_workspace_handle_v1*, const char*) {}
+  void workspaceId(void* data, ext_workspace_handle_v1*, const char* id) {
+    static_cast<Workspace*>(data)->id = id != nullptr ? id : "";
+  }
 
   void workspaceName(void* data, ext_workspace_handle_v1*, const char* name) {
     static_cast<Workspace*>(data)->name = name != nullptr ? name : "";
@@ -108,7 +111,9 @@ namespace {
   };
 } // namespace
 
-int main() {
+// Default output is the active workspace of each group, one per line. `--all` lists every workspace as "id<TAB>name".
+int main(int argc, char** argv) {
+  const bool listAll = argc > 1 && std::string_view(argv[1]) == "--all";
   wl_display* display = wl_display_connect(nullptr);
   if (display == nullptr) {
     std::println(stderr, "workspace-client: cannot connect to WAYLAND_DISPLAY");
@@ -126,8 +131,16 @@ int main() {
 
   int active = 0;
   for (const auto& workspace : state.workspaces) {
-    if (!workspace->removed && (workspace->state & EXT_WORKSPACE_HANDLE_V1_STATE_ACTIVE) != 0) {
-      std::println("{}", workspace->name);
+    if (workspace->removed) {
+      continue;
+    }
+    if (listAll) {
+      std::println("{}\t{}", workspace->id, workspace->name);
+    }
+    if ((workspace->state & EXT_WORKSPACE_HANDLE_V1_STATE_ACTIVE) != 0) {
+      if (!listAll) {
+        std::println("{}", workspace->name);
+      }
       ++active;
     }
   }
@@ -144,7 +157,7 @@ int main() {
   wl_registry_destroy(state.registry);
   wl_display_disconnect(display);
 
-  if (!state.done || active != 1) {
+  if (!state.done || (!listAll && active != 1)) {
     std::println(stderr, "workspace-client: expected one active workspace, got {}", active);
     return 1;
   }

--- a/tests/harness/verify.sh
+++ b/tests/harness/verify.sh
@@ -243,10 +243,9 @@ autostart = []
 EOF
 }
 
-# Output count is a backend property, fixed when the compositor starts, so a
-# check that needs a second monitor declares it in its header and the harness
-# boots that instance accordingly. Everything else gets one output, which is
-# what most geometry assertions are written against.
+# A check that needs a second monitor declares it in its header and the harness boots that instance accordingly.
+# Everything else gets one output, which is what most geometry assertions are written against. A check that needs
+# monitors to come and go uses `umbriel output-create` and `umbriel output-destroy` on top of what it declares here.
 check_outputs() {
   local declared
   declared=$(sed -n '2,12p' "$HARNESS_DIR/checks/$1.sh" |


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

A suspend & resume cycle destroys and recreates every output at once. When there's no outputs there's nowhere to move orphaned windows, so they were left with no workspace and stayed that way after the monitors came back, ignoring workspace switches, unable to be resized, and only fixed when moved by hand.

Views now remember the output and workspace they were displaced from, and an idle restore puts them back once outputs return. Also now with single monitor disabled windows pushed onto a surviving output return to their own output when it comes back, instead of staying where they were displaced to. I wasn't sure if that was intentional but it follows the same code path so this is basically free, but could be changed to keep the current behaviour.

The restore runs on idle rather than inline because outputs come back one at a time and their workspace groups are not wired up yet when the output is added.

Also added a new test that tests the case of all outputs being disabled (which happens on suspend/resume).

## Motivation

Locking and suspending, or turning a monitor off and on, left every window untracked with no way for the windows to get back to its workspace other than moving each one by hand.

Also [docs/user/outputs.md](https://github.com/noctalia-dev/umbriel/blob/8af073895d32bd93f0192c0092f76f40bd9d25a6/docs/user/outputs.md?plain=1#L9-L10) says windows stay without a workspace "until one becomes available" but that doesn't currently happen.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

`meson test` 19/19, `verify.sh` 42/42, `just format` no changes

I added a new test to cover the no output behaviour and added a line to 620 to verify the one output disabled case

| check | failure before the fix |
| --- | --- |
| `625_output_remove_restore` (new) | `expected 'remove-restore-a' on workspace 'HEADLESS-2:2', got ''` |
| `620_output_disable` (extended) | `expected window workspace 'HEADLESS-2:1', got 'HEADLESS-1:1'` |

625 puts one window on each of two outputs, disables both outputs through a live reload, asserts both windows lose their
workspace, then re-enables and asserts each returns to the workspace id it was on.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

tricky to get a video that would persist over suspend & wake

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->

`just lint` fails on `src/server/wine_color_manager.cpp` with six `readability-container-contains` errors but that was preexisting