### PR TITLE
feat: add drag_opacity config

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -159,6 +159,7 @@ outer_border_color = "#1A1A1FFF"
 insert_hint_color = "#7FC8FF80"
 backdrop_color = "#000000FF"
 animation_ms = 200             # 1-10000
+drag_opacity = 0.75
 ```
 
 | Key                           | Type  | Default     | Description                                                                                                                                       |
@@ -175,6 +176,7 @@ animation_ms = 200             # 1-10000
 | `insert_hint_color`           | color | `#7FC8FF80` | Drop-target preview during drag.                                                                                                                  |
 | `backdrop_color`              | color | `#000000FF` | Background for fullscreen gaps and lock screen.                                                                                                   |
 | `animation_ms`                | int   | `200`       | Animation duration in milliseconds (1-10000).                                                                                                     |
+| `drag_opacity`                | float | `0.75`      | Opacity of the window while dragging.                                                                                                             |
 
 Colors are `#RRGGBB` or `#RRGGBBAA`.
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -45,6 +45,7 @@ border_width = 2               # 0-100
 outer_border_width = 0         # 0-100
 corner_radius = 10             # 0-100
 animation_ms = 250             # 1-10000
+drag_opacity = 0.75
 # border_focused = "#7AA3FFFF"
 # border_unfocused = "#292933FF"
 # scratchpad_border_focused = "#E5C07BFF"

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -504,6 +504,7 @@ namespace umbriel {
             .color("insert_hint_color", a.insertHintColor)
             .color("backdrop_color", a.backdropColor)
             .integer("animation_ms", 1, 10000, a.animationMs)
+            .real("drag_opacity", 0.0, 1.0, a.dragOpacity)
             .boolean("prefer_no_csd", a.preferNoCsd);
         s.sub("blur", [&](Section& blur) {
           blur.boolean("enabled", a.blur.enabled)

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -290,6 +290,7 @@ namespace umbriel {
       std::array<float, 4> insertHintColor{0.50F, 0.78F, 1.0F, 0.50F};
       std::array<float, 4> backdropColor{0.0F, 0.0F, 0.0F, 1.0F};
       int animationMs = 200;
+      double dragOpacity = 0.75;
       struct Blur {
         bool enabled = true;
         bool optimized = true;

--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -174,7 +174,7 @@ namespace umbriel {
       };
       wlr_scene_tree_set_clip(card.tree, &rowClip);
     }
-    const float cardOpacity = &card == m_dragCard ? View::kDragOpacity : 1.0F;
+    const float cardOpacity = &card == m_dragCard ? config().appearance.dragOpacity : 1.0F;
     const float presentedOpacity = view->presentedOpacity() * cardOpacity;
 
     const auto& appearance = config().appearance;

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -563,7 +563,7 @@ namespace umbriel {
 
   void View::enterDragPresentation() {
     cancelPositionAnimation();
-    m_dragOpacity = kDragOpacity;
+    m_dragOpacity = config().appearance.dragOpacity;
     setFadeAlpha(m_fadeAlpha);
     m_effectiveOpacityCommitPending = false;
     if (m_pinned) {

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -155,9 +155,6 @@ namespace umbriel {
     friend class Server;
     friend class Popup;
     friend class Overview;
-    // Keep the insertion preview legible beneath the window during every
-    // compositor-owned relocate drag, including overview card drags.
-    static constexpr float kDragOpacity = 0.75F;
 
     struct OpacitySurfaceWatch {
       View* view = nullptr;

--- a/tests/harness/checks/430_drag_opacity.sh
+++ b/tests/harness/checks/430_drag_opacity.sh
@@ -36,8 +36,8 @@ measure_drag_green() {
 
   local green
   # Read the pixel as encoded, deliberately without -colorspace RGB. The thresholds below are the composite this check
-  # reasons about, and that arithmetic lives in the same encoding grim wrote: an opaque card at kDragOpacity 0.75 over
-  # pure green leaves 255 * 0.25 = 64. Linearizing reads that very pixel as 13 and fails the check on correct output.
+  # reasons about, and that arithmetic lives in the same encoding grim wrote: an opaque card at the configured 0.5
+  # drag opacity over pure green leaves 255 * 0.5 = 128. Linearizing reads that pixel as 55 and fails a correct check.
   # The sibling checks linearize harmlessly: they sample saturated colors, where both encodings agree, or compare two
   # crops against each other, where any monotone transform cancels.
   green=$(magick "$screenshot" -crop 40x40+680+430 -format '%[fx:round(255*mean.g)]' info:)
@@ -58,6 +58,7 @@ cat >> "$UMBRIEL_CONFIG" <<'EOF'
 
 [appearance]
 insert_hint_color = "#FF0000FF"
+drag_opacity = 0.5
 
 [overview]
 background_tint = "#000000FF"
@@ -66,14 +67,14 @@ EOF
 "$UMBRIEL" msg config-reload > /dev/null
 
 opaque_green=$(measure_drag_green 1 drag-opaque)
-if (( opaque_green < 40 || opaque_green > 210 )); then
-  echo "opaque dragged card did not become semi-transparent: mean green=$opaque_green"
+if (( opaque_green < 110 || opaque_green > 145 )); then
+  echo "opaque dragged card did not use configured opacity: mean green=$opaque_green"
   exit 1
 fi
 
 transparent_green=$(measure_drag_green 0.5 drag-transparent)
-if (( transparent_green <= opaque_green + 25 || transparent_green > 220 )); then
-  echo "client alpha did not compose with drag opacity: opaque=$opaque_green transparent=$transparent_green"
+if (( transparent_green < 170 || transparent_green > 210 )); then
+  echo "client alpha did not compose with configured drag opacity: opaque=$opaque_green transparent=$transparent_green"
   exit 1
 fi
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add `drag_opacity` config in `[appearance]` that changes the opacity of a window when dragged.

## Motivation

<!-- What problem does this solve? -->
I found the drag a bit too transparent so I wanted to make it more opaque, but might as well make it a config so everyone is happy

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just format`
`just test`
`just lint`

## Manual Coverage

<!-- Mark what applies to this PR. -->
I tested it normally and in the overview.

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->