### PR TITLE
feat: add window-toggle-scratchpad action

### DIFF
--- a/docs/user/keybinds.md
+++ b/docs/user/keybinds.md
@@ -228,6 +228,7 @@ remaining on a workspace.
 | `window-move-to-scratchpad` | Move the focused window from its workspace into the scratchpad. |
 | `scratchpad-toggle` | Show or hide the output's scratchpad windows. |
 | `window-restore-from-scratchpad` | Return the focused scratchpad window to its saved workspace. |
+| `window-toggle-scratchpad` | Move the focused window into the scratchpad, or restore it if it's already the scratchpad's focused window. |
 | `scratchpad-focus-next` | Focus the next visible scratchpad window. |
 
 Add `:<output>` to any action to target a specific output, for example

--- a/src/config/keybind_parse.cpp
+++ b/src/config/keybind_parse.cpp
@@ -211,6 +211,8 @@ namespace umbriel {
         {"window-toggle-maximize", "", KeybindAction::ToggleMaximize},
         {"window-toggle-maximize-to-edges", "", KeybindAction::ToggleMaximizeToEdges},
         {"window-toggle-pinned", "", KeybindAction::TogglePinned},
+        {"window-toggle-scratchpad", "[<output>]", KeybindAction::WindowToggleScratchpad,
+         ActionArgKind::OptionalOutput},
         {"workspace-move-down", "", KeybindAction::WorkspaceMoveDown},
         {"workspace-move-to-output-down", "", KeybindAction::WorkspaceMoveToOutputDown},
         {"workspace-move-to-output-left", "", KeybindAction::WorkspaceMoveToOutputLeft},

--- a/src/config/keybind_parse.h
+++ b/src/config/keybind_parse.h
@@ -66,6 +66,7 @@ namespace umbriel {
     WindowMoveToScratchpad,
     ScratchpadToggle,
     WindowRestoreFromScratchpad,
+    WindowToggleScratchpad,
     ScratchpadFocusNext,
     Submap,
     WindowFocusId,

--- a/src/server/actions.cpp
+++ b/src/server/actions.cpp
@@ -886,6 +886,26 @@ namespace umbriel {
       return scratchpad != nullptr && scratchpad->restoreFocused(output);
     }
 
+    // Toggles the focused window's scratchpad membership: if the focused
+    // window is currently the scratchpad's focused entry, restore it (same as
+    // actionRestoreFromScratchpad); otherwise move it into the scratchpad
+    // (same as actionMoveToScratchpad).
+    bool actionToggleScratchpad(Server& server, const Keybind& bind, std::string* error) {
+      Output* output = scratchpadOutput(server, bind, error);
+      if (output == nullptr) {
+        return false;
+      }
+      ScratchpadManager* scratchpad = server.scratchpadManager();
+      if (scratchpad == nullptr) {
+        return false;
+      }
+      if (scratchpad->hasFocus(output)) {
+        return scratchpad->restoreFocused(output);
+      }
+      Workspace* workspace = activeWorkspace(server);
+      return workspace != nullptr && scratchpad->moveToScratchpad(workspace->focusedView(), output);
+    }
+
     bool actionScratchpadFocusNext(Server& server, const Keybind& bind, std::string* error) {
       Output* output = scratchpadOutput(server, bind, error);
       if (output == nullptr) {
@@ -939,6 +959,7 @@ namespace umbriel {
         &actionMoveToScratchpad,
         &actionScratchpadToggle,
         &actionRestoreFromScratchpad,
+        &actionToggleScratchpad,
         &actionScratchpadFocusNext,
         &actionSubmap,
         &actionWindowFocusId,

--- a/tests/unit/keybind_parse.cpp
+++ b/tests/unit/keybind_parse.cpp
@@ -408,6 +408,8 @@ UMBRIEL_TEST(parsesOptionalOutputActions) {
   CHECK(bind.action == KeybindAction::WindowMoveToScratchpad);
   CHECK(parseAction("window-restore-from-scratchpad:eDP-1", bind));
   CHECK_EQ(outputOf(bind), std::string{"eDP-1"});
+  CHECK(parseAction("window-toggle-scratchpad", bind));
+  CHECK(bind.action == KeybindAction::WindowToggleScratchpad);
   CHECK(parseAction("scratchpad-focus-next", bind));
 
   CHECK(parseAction("dpms-off", bind));


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds the `window-toggle-scratchpad` keybind action to toggle a window's scratchpad membership. It moves the focused window into the scratchpad, or restores it if it is currently the scratchpad's focused entry.

## Motivation

Allows users to bind a single key shortcut to both move a window to scratchpad and out of the scratchpad, eliminating the need to configure separate keybinds for `window-move-to-scratchpad` and `window-restore-from-scratchpad`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

N/A

## Testing

- Added unit tests in `tests/unit/keybind_parse.cpp` to verify parsing of `window-toggle-scratchpad`.
- Verified build and unit test suite pass cleanly.
`just lint`
`just format`

## Manual Coverage

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

N/A

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

None