### PR TITLE
add allow_when_locked option to the bind table

### DIFF
--- a/docs/user/keybinds.md
+++ b/docs/user/keybinds.md
@@ -249,6 +249,8 @@ Binds repeat while held, using `input.keyboard.repeat_rate` and
 Scratchpad visibility and cycling actions never repeat, even if their binding
 does not set `repeat = false`.
 
+Binds with `allow_when_locked = true` continue repeating while the session is locked.
+
 ## Allow when locked
 
 Binds are blocked by default when the session is locked. Opt in per bind

--- a/docs/user/keybinds.md
+++ b/docs/user/keybinds.md
@@ -249,6 +249,15 @@ Binds repeat while held, using `input.keyboard.repeat_rate` and
 Scratchpad visibility and cycling actions never repeat, even if their binding
 does not set `repeat = false`.
 
+## Allow when locked
+
+Binds are blocked by default when the session is locked. Opt in per bind
+with the table form:
+
+```toml
+"XF86MonBrightnessDown" = { action = "spawn:noctalia msg brightness-down 10", allow_when_locked = true }
+```
+
 ## Submaps
 
 Submaps are temporary keybind layers that can be nested. Enter with

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -234,6 +234,8 @@ follows_mouse = false
 # "XF86AudioPlay"       = "spawn:playerctl play-pause"
 # "XF86AudioNext"       = "spawn:playerctl next"
 # "XF86AudioPrev"       = "spawn:playerctl prev"
+# Controls intended to remain usable while the session is locked use the table form.
+# "XF86MonBrightnessDown" = { action = "spawn:noctalia msg brightness-down 10", allow_when_locked = true }
 
 # Window and layer rules (see docs/user/rules.md) ---------------------------
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -984,12 +984,14 @@ namespace umbriel {
         const std::string chord(key.str());
         std::string actionStr;
         bool repeatBind = true;
+        bool allowWhenLocked = false;
 
         if (const auto* tbl = entry.as_table()) {
           Section bind(*tbl, "keybinds." + chord, configStore().mutableDiagnostics());
           // Read `repeat` before validating the action: an entry rejected for a
           // bad action must not also be told its `repeat` key is unknown.
           bind.boolean("repeat", repeatBind);
+          bind.boolean("allow_when_locked", allowWhenLocked);
           const toml::node* actionNode = bind.take("action");
           if (actionNode == nullptr) {
             warnAt(entry.source(), "ignoring keybind '{}' (table needs an 'action' string)", chord);
@@ -1020,6 +1022,7 @@ namespace umbriel {
           continue;
         }
         binding.repeat = binding.modifierOnly ? false : repeatBind;
+        binding.allowWhenLocked = allowWhenLocked;
         if (!parseAction(actionStr, binding)) {
           warnAt(key.source(), "ignoring keybind '{}' (unknown action '{}')", chord, actionStr);
           continue;

--- a/src/config/keybind_parse.h
+++ b/src/config/keybind_parse.h
@@ -147,6 +147,7 @@ namespace umbriel {
     WheelDirection wheel = WheelDirection::None;
     uint32_t mouseButton = 0; // evdev BTN_* code, 0 = not a mouse bind
     bool repeat = true;
+    bool allowWhenLocked = false;
 
     // What it does.
     KeybindAction action = KeybindAction::None;

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -688,7 +688,7 @@ namespace umbriel {
 
     // Config mouse binds win over the overview and the built-in Mod+drag / Mod+resize grabs. Presses consumed here
     // swallow their paired release so clients never see an unmatched release.
-    if (state == WL_POINTER_BUTTON_STATE_PRESSED && !m_server->sessionLocked() && isPassthrough()) {
+    if (state == WL_POINTER_BUTTON_STATE_PRESSED && isPassthrough()) {
       const uint32_t modifiers = m_server->keyboardModifiers();
       const Keybind* bound = m_server->handleMouseBind(button, modifiers);
       // Any press dismisses the cheatsheet, as any key press does, except one that just ran a cheatsheet action. Unlike

--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -344,7 +344,7 @@ namespace umbriel {
     if (!self->m_repeatArmed) {
       return 0;
     }
-    if (self->m_server->sessionLocked()) {
+    if (self->m_server->sessionLocked() && !self->m_repeatBind.allowWhenLocked) {
       self->cancelRepeat();
       return 0;
     }

--- a/src/server/server_keybinds.cpp
+++ b/src/server/server_keybinds.cpp
@@ -91,7 +91,7 @@ namespace umbriel {
 
   void
   Server::armModifierTap(const void* source, uint32_t keycode, std::span<const uint32_t> keysyms, uint32_t modifiers) {
-    if (m_modifierTap.cancelForKeyPress() || m_sessionLocked) {
+    if (m_modifierTap.cancelForKeyPress()) {
       return;
     }
 
@@ -108,6 +108,9 @@ namespace umbriel {
       if (!bind.modifierOnly) {
         continue;
       }
+      if (m_sessionLocked && !bind.allowWhenLocked) {
+        continue;
+      }
       if (bind.submap != currentSubmap) {
         if (m_activeSubmaps.empty() || !bind.submap.empty() || !isSubmapResetBind(bind)) {
           continue;
@@ -122,18 +125,14 @@ namespace umbriel {
   }
 
   std::optional<Keybind> Server::releaseModifierTap(const void* source, uint32_t keycode) {
-    if (m_sessionLocked) {
-      m_modifierTap.cancel();
+    std::optional<Keybind> bind = m_modifierTap.release(source, keycode);
+    if (bind && m_sessionLocked && !bind->allowWhenLocked) {
       return std::nullopt;
     }
-    return m_modifierTap.release(source, keycode);
+    return bind;
   }
 
   const Keybind* Server::matchKeybind(uint32_t keysym, uint32_t rawKeysym, uint32_t modifiers) const {
-    if (m_sessionLocked) {
-      return nullptr;
-    }
-
     const uint32_t effective = modifiers & ~(WLR_MODIFIER_CAPS | WLR_MODIFIER_MOD2);
     const uint32_t lowered = xkb_keysym_to_lower(keysym);
     const std::string_view currentSubmap = m_activeSubmaps.empty() ? std::string_view{} : m_activeSubmaps.back();
@@ -147,6 +146,9 @@ namespace umbriel {
         } else {
           continue;
         }
+      }
+      if (m_sessionLocked && !bind.allowWhenLocked) {
+        continue;
       }
       if (bind.modifierOnly) {
         continue;
@@ -183,15 +185,14 @@ namespace umbriel {
   }
 
   bool Server::handleWheelBind(WheelDirection direction, uint32_t modifiers) {
-    if (m_sessionLocked) {
-      return false;
-    }
-
     const uint32_t effective = modifiers & ~(WLR_MODIFIER_CAPS | WLR_MODIFIER_MOD2);
     const std::string_view currentSubmap = m_activeSubmaps.empty() ? std::string_view{} : m_activeSubmaps.back();
 
     for (const Keybind& bind : config().keybinds) {
       if (bind.submap != currentSubmap) {
+        continue;
+      }
+      if (m_sessionLocked && !bind.allowWhenLocked) {
         continue;
       }
       if (bind.wheel != direction) {
@@ -208,15 +209,14 @@ namespace umbriel {
   }
 
   const Keybind* Server::handleMouseBind(uint32_t button, uint32_t modifiers) {
-    if (m_sessionLocked) {
-      return nullptr;
-    }
-
     const uint32_t effective = modifiers & ~(WLR_MODIFIER_CAPS | WLR_MODIFIER_MOD2);
     const std::string_view currentSubmap = m_activeSubmaps.empty() ? std::string_view{} : m_activeSubmaps.back();
 
     for (const Keybind& bind : config().keybinds) {
       if (bind.submap != currentSubmap) {
+        continue;
+      }
+      if (m_sessionLocked && !bind.allowWhenLocked) {
         continue;
       }
       // Non-mouse binds carry 0 here, which never equals a BTN_* code.

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -229,6 +229,30 @@ UMBRIEL_TEST(modKeyIsUserConfigurable) {
   CHECK(containsDiagnostic(store, "unknown general.mod_key"));
 }
 
+UMBRIEL_TEST(keybindTableLoadsAllowWhenLocked) {
+  const TempConfig file;
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  file.write(
+      "[keybinds]\n"
+      "\"XF86AudioRaiseVolume\" = { action = \"spawn:volume-up\", allow_when_locked = true }\n"
+      "\"XF86AudioLowerVolume\" = \"spawn:volume-down\"\n"
+  );
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().keybinds.size(), size_t{2});
+
+  bool allowedWhenLocked = false;
+  bool defaultsToBlocked = false;
+  for (const auto& bind : store.config().keybinds) {
+    allowedWhenLocked = allowedWhenLocked || bind.allowWhenLocked;
+    defaultsToBlocked = defaultsToBlocked || !bind.allowWhenLocked;
+  }
+  CHECK(allowedWhenLocked);
+  CHECK(defaultsToBlocked);
+  CHECK(!containsDiagnostic(store, "allow_when_locked"));
+}
+
 UMBRIEL_TEST(hotCornersLoadActionsAndValidate) {
   const TempConfig file;
   ConfigStore& store = umbriel::configStore();


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add `allow_when_locked` option to the bind table, allowing binds to be executed when the session is locked.
The default is false.

## Motivation

<!-- What problem does this solve? -->
That's an option in niri and I want to be able to change the luminosity while the screen is locked.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just format`
`just test`
`just lint`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
