### PR TITLE
fix(focus): restore previous focus when a floating window closes

### DIFF
--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -9,6 +9,7 @@
 #include "output/output.h"
 #include "overview/overview.h"
 #include "server/server.h"
+#include "view/registry.h"
 #include "view/view.h"
 #include "view/xdg_size.h"
 // clang-format off
@@ -580,9 +581,14 @@ namespace umbriel {
       }
     }
 
-    // Floating views sit outside the layout columns, so no layout successor exists here. nullptr makes closing one
-    // restore focus to the previously focused window.
+    // Floating views have no layout successor: hand focus back to the most recently focused mapped view on this
+    // workspace, since nothing else refocuses until a destroy-time fallback that unmap-only clients never reach.
     if (columnIndex < 0 || columnIndex >= static_cast<int>(columns.size())) {
+      for (const auto& entry : m_group->server()->registry().all()) {
+        if (entry.get() != view && entry->mapped() && entry->workspace() == this) {
+          return entry.get();
+        }
+      }
       return nullptr;
     }
 

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -580,30 +580,34 @@ namespace umbriel {
       }
     }
 
-    if (columnIndex >= 0 && columnIndex < static_cast<int>(columns.size())) {
-      const auto& column = columns[static_cast<size_t>(columnIndex)].views;
-      for (int row = rowIndex - 1; row >= 0; --row) {
-        if (View* candidate = column[static_cast<size_t>(row)]; mappedCandidate(candidate)) {
+    // Floating views sit outside the layout columns, so no layout successor exists here. nullptr makes closing one
+    // restore focus to the previously focused window.
+    if (columnIndex < 0 || columnIndex >= static_cast<int>(columns.size())) {
+      return nullptr;
+    }
+
+    const auto& column = columns[static_cast<size_t>(columnIndex)].views;
+    for (int row = rowIndex - 1; row >= 0; --row) {
+      if (View* candidate = column[static_cast<size_t>(row)]; mappedCandidate(candidate)) {
+        return candidate;
+      }
+    }
+    for (int row = rowIndex + 1; row < static_cast<int>(column.size()); ++row) {
+      if (View* candidate = column[static_cast<size_t>(row)]; mappedCandidate(candidate)) {
+        return candidate;
+      }
+    }
+    for (int targetColumn = columnIndex - 1; targetColumn >= 0; --targetColumn) {
+      for (View* candidate : columns[static_cast<size_t>(targetColumn)].views) {
+        if (mappedCandidate(candidate)) {
           return candidate;
         }
       }
-      for (int row = rowIndex + 1; row < static_cast<int>(column.size()); ++row) {
-        if (View* candidate = column[static_cast<size_t>(row)]; mappedCandidate(candidate)) {
+    }
+    for (int targetColumn = columnIndex + 1; targetColumn < static_cast<int>(columns.size()); ++targetColumn) {
+      for (View* candidate : columns[static_cast<size_t>(targetColumn)].views) {
+        if (mappedCandidate(candidate)) {
           return candidate;
-        }
-      }
-      for (int targetColumn = columnIndex - 1; targetColumn >= 0; --targetColumn) {
-        for (View* candidate : columns[static_cast<size_t>(targetColumn)].views) {
-          if (mappedCandidate(candidate)) {
-            return candidate;
-          }
-        }
-      }
-      for (int targetColumn = columnIndex + 1; targetColumn < static_cast<int>(columns.size()); ++targetColumn) {
-        for (View* candidate : columns[static_cast<size_t>(targetColumn)].views) {
-          if (mappedCandidate(candidate)) {
-            return candidate;
-          }
         }
       }
     }

--- a/tests/harness/checks/235_floating_close_focus.sh
+++ b/tests/harness/checks/235_floating_close_focus.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Closing a focused floating overlay must restore focus to the most recently focused window, not to whichever tiled
+# view precedes the overlay in insertion order. The overlay is asked to close and the client only unmaps without
+# destroying its surface, so no destroy-time cleanup can mask a missing unmap-time focus reassignment: the workspace
+# must be refocused while the overlay's View still exists as registered-but-unmapped.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
+
+wait_for_window_count() {
+  local want=$1
+  for _ in $(seq 60); do
+    [[ $("$UMBRIEL" windows --json | jq 'length') -eq $want ]] && return 0
+    sleep 0.1
+  done
+  echo "expected $want windows, got: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+wait_for_focus() {
+  local want=$1
+  for _ in $(seq 40); do
+    if [[ $("$UMBRIEL" windows --json | jq -r --arg id "$want" '.[] | select(.id == $id) | .focused') == true ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "expected $want to be focused: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[appearance]
+animation_ms = 1
+
+[layout]
+mode = "scrolling"
+
+[[window_rule]]
+match.app_id = "^float-close-overlay$"
+default_floating = true
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+"$CLIENT" "float-close-anchor" > "$UMBRIEL_RUNTIME_DIR/anchor.log" 2>&1 &
+wait_for_window_count 1
+"$CLIENT" "float-close-neighbor" > "$UMBRIEL_RUNTIME_DIR/neighbor.log" 2>&1 &
+wait_for_window_count 2
+
+windows=$("$UMBRIEL" windows --json)
+anchor_id=$(jq -r '.[] | select(.title == "float-close-anchor") | .id' <<< "$windows")
+neighbor_id=$(jq -r '.[] | select(.title == "float-close-neighbor") | .id' <<< "$windows")
+if [[ $(jq -r --arg id "$anchor_id" '.[] | select(.id == $id) | .floating' <<< "$windows") != false
+    || $(jq -r --arg id "$neighbor_id" '.[] | select(.id == $id) | .floating' <<< "$windows") != false ]]; then
+  echo "expected two tiles before opening the overlay: $windows"
+  exit 1
+fi
+
+# Make the most recently focused view differ from the overlay's insertion-order predecessor: refocusing the anchor
+# here means most-recently-focused order says anchor, while the reverse-insertion scan this check guards against
+# would hand back the neighbor.
+"$UMBRIEL" msg "window-focus:$anchor_id" > /dev/null
+wait_for_focus "$anchor_id"
+
+APP_ID=float-close-overlay "$CLIENT" "float-close-overlay" > "$UMBRIEL_RUNTIME_DIR/overlay.log" 2>&1 &
+overlay_pid=$!
+wait_for_window_count 3
+
+windows=$("$UMBRIEL" windows --json)
+overlay_id=$(jq -r '.[] | select(.title == "float-close-overlay") | .id' <<< "$windows")
+if [[ $(jq -r --arg id "$overlay_id" '.[] | select(.id == $id) | .floating' <<< "$windows") != true ]]; then
+  echo "overlay did not map floating: $windows"
+  exit 1
+fi
+wait_for_focus "$overlay_id"
+
+"$UMBRIEL" msg "window-close:$overlay_id" > /dev/null
+for _ in $(seq 40); do
+  grep -q '^unmapped$' "$UMBRIEL_RUNTIME_DIR/overlay.log" && break
+  sleep 0.1
+done
+if ! grep -q '^unmapped$' "$UMBRIEL_RUNTIME_DIR/overlay.log"; then
+  echo "overlay never unmapped in response to the close request: $(cat "$UMBRIEL_RUNTIME_DIR/overlay.log")"
+  exit 1
+fi
+# The unmapped overlay drops out of `windows` while its process is still alive, so reaching a count of two proves the
+# reassignment happened at unmap time with the View still registered. The overlay process must stay alive until after
+# every assertion below: killing it destroys the View and Server::removeView's destroy-time refocus would mask a
+# missing unmap-time reassignment. The very first observation must already show the anchor focused.
+wait_for_window_count 2
+windows=$("$UMBRIEL" windows --json)
+if [[ $(jq -r --arg id "$anchor_id" '.[] | select(.id == $id) | .focused' <<< "$windows") != true ]]; then
+  echo "focus was not restored to the previously focused window at unmap time: $windows"
+  exit 1
+fi
+
+echo "closing a focused floating overlay restores the previously focused window"

--- a/tests/harness/checks/235_floating_close_focus.sh
+++ b/tests/harness/checks/235_floating_close_focus.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-# Closing a focused floating overlay must restore focus to the most recently focused window, not to whichever tiled
-# view precedes the overlay in insertion order. The overlay is asked to close and the client only unmaps without
-# destroying its surface, so no destroy-time cleanup can mask a missing unmap-time focus reassignment: the workspace
-# must be refocused while the overlay's View still exists as registered-but-unmapped.
+# Floating overlay close should refocus the last focused window, not the neighbor.
+# Overlay only unmaps (View stays alive) so we can catch missing unmap-time refocus.
 set -euo pipefail
 
 readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
@@ -57,9 +55,7 @@ if [[ $(jq -r --arg id "$anchor_id" '.[] | select(.id == $id) | .floating' <<< "
   exit 1
 fi
 
-# Make the most recently focused view differ from the overlay's insertion-order predecessor: refocusing the anchor
-# here means most-recently-focused order says anchor, while the reverse-insertion scan this check guards against
-# would hand back the neighbor.
+# Focus anchor so MRU is anchor — correct restore is anchor, not neighbor.
 "$UMBRIEL" msg "window-focus:$anchor_id" > /dev/null
 wait_for_focus "$anchor_id"
 
@@ -67,10 +63,26 @@ APP_ID=float-close-overlay "$CLIENT" "float-close-overlay" > "$UMBRIEL_RUNTIME_D
 overlay_pid=$!
 wait_for_window_count 3
 
-windows=$("$UMBRIEL" windows --json)
-overlay_id=$(jq -r '.[] | select(.title == "float-close-overlay") | .id' <<< "$windows")
-if [[ $(jq -r --arg id "$overlay_id" '.[] | select(.id == $id) | .floating' <<< "$windows") != true ]]; then
-  echo "overlay did not map floating: $windows"
+# Window count 3 can race — wait until overlay is actually floating.
+overlay_id=""
+overlay_floating=""
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  overlay_id=$(jq -r '.[] | select(.title == "float-close-overlay") | .id // empty' <<< "$windows")
+  if [[ -n $overlay_id ]]; then
+    overlay_floating=$(jq -r --arg id "$overlay_id" '.[] | select(.id == $id) | .floating // empty' <<< "$windows")
+    if [[ $overlay_floating == true ]]; then
+      break
+    fi
+  fi
+  sleep 0.1
+done
+if [[ -z $overlay_id ]]; then
+  echo "overlay never appeared: $("$UMBRIEL" windows --json)"
+  exit 1
+fi
+if [[ $overlay_floating != true ]]; then
+  echo "overlay did not map floating: $("$UMBRIEL" windows --json)"
   exit 1
 fi
 wait_for_focus "$overlay_id"
@@ -84,14 +96,21 @@ if ! grep -q '^unmapped$' "$UMBRIEL_RUNTIME_DIR/overlay.log"; then
   echo "overlay never unmapped in response to the close request: $(cat "$UMBRIEL_RUNTIME_DIR/overlay.log")"
   exit 1
 fi
-# The unmapped overlay drops out of `windows` while its process is still alive, so reaching a count of two proves the
-# reassignment happened at unmap time with the View still registered. The overlay process must stay alive until after
-# every assertion below: killing it destroys the View and Server::removeView's destroy-time refocus would mask a
-# missing unmap-time reassignment. The very first observation must already show the anchor focused.
+# Must refocus at unmap — keep overlay alive so destroy fallback can't hide it.
 wait_for_window_count 2
+if ! kill -0 "$overlay_pid" 2>/dev/null; then
+  echo "overlay client exited instead of keeping the surface alive"
+  exit 1
+fi
+wait_for_focus "$anchor_id"
+sleep 0.1
 windows=$("$UMBRIEL" windows --json)
 if [[ $(jq -r --arg id "$anchor_id" '.[] | select(.id == $id) | .focused' <<< "$windows") != true ]]; then
   echo "focus was not restored to the previously focused window at unmap time: $windows"
+  exit 1
+fi
+if [[ $(jq -r --arg id "$neighbor_id" '.[] | select(.id == $id) | .focused' <<< "$windows") != false ]]; then
+  echo "neighbor view received focus after the overlay closed: $windows"
   exit 1
 fi
 

--- a/tests/harness/checks/235_floating_close_focus.sh
+++ b/tests/harness/checks/235_floating_close_focus.sh
@@ -41,29 +41,37 @@ default_floating = true
 EOF
 "$UMBRIEL" msg config-reload > /dev/null
 
-"$CLIENT" "float-close-anchor" > "$UMBRIEL_RUNTIME_DIR/anchor.log" 2>&1 &
+readonly FIRST_LOG="$UMBRIEL_RUNTIME_DIR/first.log"
+readonly ANCHOR_LOG="$UMBRIEL_RUNTIME_DIR/anchor.log"
+readonly NEIGHBOR_LOG="$UMBRIEL_RUNTIME_DIR/neighbor.log"
+
+"$CLIENT" "float-close-first" > "$FIRST_LOG" 2>&1 &
 wait_for_window_count 1
-"$CLIENT" "float-close-neighbor" > "$UMBRIEL_RUNTIME_DIR/neighbor.log" 2>&1 &
+"$CLIENT" "float-close-anchor" > "$ANCHOR_LOG" 2>&1 &
 wait_for_window_count 2
+"$CLIENT" "float-close-neighbor" > "$NEIGHBOR_LOG" 2>&1 &
+wait_for_window_count 3
 
 windows=$("$UMBRIEL" windows --json)
+first_id=$(jq -r '.[] | select(.title == "float-close-first") | .id' <<< "$windows")
 anchor_id=$(jq -r '.[] | select(.title == "float-close-anchor") | .id' <<< "$windows")
 neighbor_id=$(jq -r '.[] | select(.title == "float-close-neighbor") | .id' <<< "$windows")
-if [[ $(jq -r --arg id "$anchor_id" '.[] | select(.id == $id) | .floating' <<< "$windows") != false
+if [[ $(jq -r --arg id "$first_id" '.[] | select(.id == $id) | .floating' <<< "$windows") != false
+    || $(jq -r --arg id "$anchor_id" '.[] | select(.id == $id) | .floating' <<< "$windows") != false
     || $(jq -r --arg id "$neighbor_id" '.[] | select(.id == $id) | .floating' <<< "$windows") != false ]]; then
-  echo "expected two tiles before opening the overlay: $windows"
+  echo "expected three tiles before opening the overlay: $windows"
   exit 1
 fi
 
-# Focus anchor so MRU is anchor — correct restore is anchor, not neighbor.
+# Focus the middle-created window so MRU restore differs from creation order.
 "$UMBRIEL" msg "window-focus:$anchor_id" > /dev/null
 wait_for_focus "$anchor_id"
 
 APP_ID=float-close-overlay "$CLIENT" "float-close-overlay" > "$UMBRIEL_RUNTIME_DIR/overlay.log" 2>&1 &
 overlay_pid=$!
-wait_for_window_count 3
+wait_for_window_count 4
 
-# Window count 3 can race — wait until overlay is actually floating.
+# Window count 4 can race, so wait until the overlay is actually floating.
 overlay_id=""
 overlay_floating=""
 for _ in $(seq 60); do
@@ -96,8 +104,8 @@ if ! grep -q '^unmapped$' "$UMBRIEL_RUNTIME_DIR/overlay.log"; then
   echo "overlay never unmapped in response to the close request: $(cat "$UMBRIEL_RUNTIME_DIR/overlay.log")"
   exit 1
 fi
-# Must refocus at unmap — keep overlay alive so destroy fallback can't hide it.
-wait_for_window_count 2
+# Must refocus at unmap, and keep overlay alive so destroy fallback cannot hide it.
+wait_for_window_count 3
 if ! kill -0 "$overlay_pid" 2>/dev/null; then
   echo "overlay client exited instead of keeping the surface alive"
   exit 1
@@ -109,8 +117,9 @@ if [[ $(jq -r --arg id "$anchor_id" '.[] | select(.id == $id) | .focused' <<< "$
   echo "focus was not restored to the previously focused window at unmap time: $windows"
   exit 1
 fi
-if [[ $(jq -r --arg id "$neighbor_id" '.[] | select(.id == $id) | .focused' <<< "$windows") != false ]]; then
-  echo "neighbor view received focus after the overlay closed: $windows"
+if [[ $(jq -r --arg id "$first_id" '.[] | select(.id == $id) | .focused' <<< "$windows") != false
+    || $(jq -r --arg id "$neighbor_id" '.[] | select(.id == $id) | .focused' <<< "$windows") != false ]]; then
+  echo "an unrelated tile received focus after the overlay closed: $windows"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

This PR fixes the floating-window focus steal.  Floating window closing switch focus to other window, so now closing one (like the portal screen picker) refocuses the previously focused window.

## Motivation

Screen recording via the portal picker got weird. Share *and* Cancel both switch focus onto an unrelated
window when the picker closed.  Same for Noctalia Setting, default is floating so closing it switch focus to other window.

## Type of Change

- [x] Bug fix

## Related Issue

From discord support channel and I reproduced it too.

## Testing

- `just format`
- `just lint` - still 4 files related to wine color has errors
- New regression check 235_floating_close_focus:- two tiles + floating overlay closed via unmap-client, passes
- `just test` all 21/21 unit tests pass.
- Build and Installed the branch for native manual testing.

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`.
- [x] I ran the relevant build, test, lint, or verification commands.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [ ] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.