### PR TITLE
fix: insert hint above windows when releasing drag

### DIFF
--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -612,7 +612,7 @@ namespace umbriel {
 
   void Server::hideInsertHint() {
     if (m_insertHint != nullptr) {
-      m_insertHint->hide();
+      m_insertHint->hideImmediate();
     }
   }
 


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Use `hideImmediate` instead of `hide` to hide to insert hint, so it does not appear above the windows.
An alternative would be to put the hint below the window during the "replace" animation, but I don't think that's needed since I can't even see the hide animation.

## Motivation

<!-- What problem does this solve? -->
When a window is dragged, the insert hint is below the window, but when releasing the window it's over it.
Using `drag_opacity = 1` to make it clearer:

Before:

https://github.com/user-attachments/assets/96d1d1e3-2fa3-46e3-8c18-d1b9ed3e2c59

After:

https://github.com/user-attachments/assets/a8bab7f1-07e1-4de8-8b58-b96988fe9220

In dwindle layout it's even worse since the hint takes the whole window.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
