### PR TITLE
feat(nix): wire the portal into the NixOS module and some other module improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,14 +200,10 @@ Declarative configuration uses Nix attrsets serialized to TOML with `pkgs.format
 ```nix
 # flake inputs
 umbriel.url = "git+https://github.com/noctalia-dev/umbriel";
-xdg-desktop-portal-umbriel.url = "github:noctalia-dev/xdg-desktop-portal-umbriel";
 
 # NixOS
 imports = [ inputs.umbriel.nixosModules.default ];
-programs.umbriel = {
-  enable = true;
-  portalPackage = inputs.xdg-desktop-portal-umbriel.packages.${pkgs.stdenv.hostPlatform.system}.default;
-};
+programs.umbriel.enable = true;
 
 # home-manager
 imports = [ inputs.umbriel.homeModules.default ];
@@ -226,9 +222,10 @@ programs.umbriel = {
 };
 ```
 
-The portal lives in [a separate repository](https://github.com/noctalia-dev/xdg-desktop-portal-umbriel) and can
-be used via a separate flake input. Setting `portalPackage` will configure the `xdg.portal` backend and install
-the portal configuration, which is required for screencasting.
+The portal lives in [a separate repository](https://github.com/noctalia-dev/xdg-desktop-portal-umbriel) and comes
+with the NixOS module: enabling Umbriel installs it, configures it as the `xdg.portal` backend, and writes the
+portal configuration screencasting needs. You can set `programs.umbriel.portalPackage` to null if you don't want
+the portal.
 
 When `settings` is omitted, the Home Manager and hjem modules leave the user path untouched so Umbriel loads its
 packaged configuration. Home Manager also accepts a raw TOML string or a path. The hjem module is exported as

--- a/flake.lock
+++ b/flake.lock
@@ -15,7 +15,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "xdg-desktop-portal-umbriel": "xdg-desktop-portal-umbriel"
+      }
+    },
+    "xdg-desktop-portal-umbriel": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580138,
+        "narHash": "sha256-fqU58lZeFchlY5aqyQgIfrN5ec/jqbhXNwNxyL2lp/g=",
+        "owner": "noctalia-dev",
+        "repo": "xdg-desktop-portal-umbriel",
+        "rev": "515c9f70f13ba4b4b9e19930b3e899c4ac8a50a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "xdg-desktop-portal-umbriel",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,10 +4,19 @@
   inputs = {
     self.submodules = true;
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
+    xdg-desktop-portal-umbriel = {
+      url = "github:noctalia-dev/xdg-desktop-portal-umbriel";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
-    { self, nixpkgs, ... }:
+    {
+      self,
+      nixpkgs,
+      xdg-desktop-portal-umbriel,
+      ...
+    }:
     let
       systems = [
         "x86_64-linux"
@@ -42,6 +51,8 @@
 
       homeModules.default = withDefaultPackage ./nix/home-module.nix;
       hjemModules.default = withDefaultPackage ./nix/hjem-module.nix;
-      nixosModules.default = withDefaultPackage ./nix/nixos-module.nix;
+      nixosModules.default = withDefaultPackage (
+        import ./nix/nixos-module.nix { inherit xdg-desktop-portal-umbriel; }
+      );
     };
 }

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -58,7 +58,10 @@ in
         xdg.portal = {
           enable = lib.mkDefault true;
           extraPortals = [ cfg.portalPackage ];
-          configPackages = [ cfg.portalPackage ];
+          config.umbriel.default = lib.mkDefault [
+            "umbriel"
+            "gtk"
+          ];
         };
       })
     ]

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -3,6 +3,7 @@
   config,
   pkgs,
   lib,
+  modulesPath,
   ...
 }:
 let
@@ -71,6 +72,12 @@ in
             "gtk"
           ];
         };
+      })
+
+      (import "${modulesPath}/programs/wayland/wayland-session.nix" {
+        inherit lib pkgs;
+        enableXWayland = false;
+        enableWlrPortal = false;
       })
     ]
   );

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,3 +1,4 @@
+{ xdg-desktop-portal-umbriel }:
 {
   config,
   pkgs,
@@ -22,7 +23,8 @@ in
 
     portalPackage = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
-      default = null;
+      default = xdg-desktop-portal-umbriel.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      defaultText = lib.literalExpression "the xdg-desktop-portal-umbriel flake's package";
       description = ''
         The xdg-desktop-portal-umbriel package to install.
       '';

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -52,6 +52,12 @@ in
         # Required for greetd / noctalia-greeter to discover the session (Name=Umbriel).
         # Plain systemPackages .desktop files are not enough; NixOS aggregates via this.
         services.displayManager.sessionPackages = [ cfg.package ];
+
+        systemd.packages = [ cfg.package ];
+        systemd.user.services.umbriel = {
+          restartIfChanged = false;
+          enableDefaultPath = false;
+        };
       })
 
       (lib.mkIf (cfg.portalPackage != null) {


### PR DESCRIPTION
## Summary

four nixos fixes/changes:

- add `xdg-desktop-portal-umbriel` as a flake input and default `portalPackage` to it
- write umbriel's portal preferences to `/etc/xdg/xdg-desktop-portal/umbriel-portals.conf` instead of relying on `configPackages`
- install the package's systemd user units (`systemd.packages`), so `umbriel-session.target` exists
- import nixpkgs' `wayland-session.nix`, matching the nixpkgs module

## Motivation

adding the portal as a flake input and wiring it to the module by default means all you now need to use umbriel with the portal via the flake is
```
imports = [ inputs.umbriel.nixosModules.default ];
programs.umbriel.enable = true;
```
it's still overridable via `portalPackage` and i updated the readme to reflect this

`configPackages` puts the portal's preferences in a data dir, and xdg-desktop-portal reads config dirs first, falling back to the generic `portals.conf` in `/etc/xdg` before it ever looks there. any other compositor module setting `xdg.portal.config.common` took over the portal config, and the umbriel backend was never started.

the units were just missing, the compositor starts `umbriel-session.target` at startup but nothing installed it, so `graphical-session.target` was never reached.

also these changes bring the flake module in line with the nixpkgs one. the units and the `wayland-session.nix` import were nixpkgs-only, so moving between the two changed behaviour. they now differ only in the flake-specific parts and the portal config fix (which i'm going to add to the nixpkgs module)

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging
- [x] Documentation

## Testing

- `nix flake check --no-build`
- evaluated a `nixosSystem` with only `programs.umbriel.enable = true`: `portalPackage` resolves to the flake portal, `extraPortals` is `[umbriel, gtk]`, the `/etc` conf reads `default=umbriel;gtk`, `systemd.packages` carries umbriel, `services.graphical-desktop.enable` is true
- checked the same with a foreign `xdg.portal.config.common.default = ["gnome"]` present (the umbriel config still wins) and with an explicit `xdg.portal.config.umbriel` (the user's wins over `mkDefault`)
- `nixos-rebuild switch` on a two-monitor machine, now running it

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

`nix/nixos-module.nix` takes the portal input as an argument now, so importing that path directly needs `import ./nix/nixos-module.nix { xdg-desktop-portal-umbriel = ...; }`

also existing configs setting `portalPackage` are unaffected apart from carrying a second portal input