### PR TITLE
feat(nix): initialize finixModules.default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,5 +54,9 @@
       nixosModules.default = withDefaultPackage (
         import ./nix/nixos-module.nix { inherit xdg-desktop-portal-umbriel; }
       );
+
+      finixModules.default = withDefaultPackage (
+        import ./nix/finix-module.nix { inherit xdg-desktop-portal-umbriel; }
+      );
     };
 }

--- a/nix/finix-module.nix
+++ b/nix/finix-module.nix
@@ -1,0 +1,79 @@
+{ xdg-desktop-portal-umbriel }:
+{
+  config,
+  pkgs,
+  lib,
+  modulesPath,
+  ...
+}:
+let
+  cfg = config.programs.umbriel;
+in
+{
+  options.programs.umbriel = {
+    enable = lib.mkEnableOption "Umbriel, a Wayland compositor built on wlroots and SceneFX.";
+
+    package = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      description = "The umbriel package to install.";
+    };
+
+    portalPackage = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = xdg-desktop-portal-umbriel.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      defaultText = lib.literalExpression "the xdg-desktop-portal-umbriel flake's package";
+      description = ''
+        The xdg-desktop-portal-umbriel package to install.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        hardware.graphics.enable = lib.mkDefault true;
+
+        assertions = [
+          {
+            assertion = cfg.package != null;
+            message = "programs.umbriel.package cannot be null when programs.umbriel.enable is true";
+          }
+        ];
+      }
+
+      (lib.mkIf (cfg.package != null) {
+        environment.systemPackages = [
+          cfg.package
+          # So `just debug` / meson outside `nix develop` can find headers via pkg-config.
+          pkgs.tomlplusplus
+          # this is required by finix to be able to run umbriel as session
+          (lib.hiPrio (
+            pkgs.writeTextDir "share/wayland-sessions/umbriel.desktop" ''
+              [Desktop Entry]
+              Encoding=UTF-8
+              Name=Umbriel
+              DesktopNames=umbriel;wlroots
+              Comment=Umbrel, a Wayland compositor built on wlroots and SceneFX
+              Exec=${lib.getExe' pkgs.dbus "dbus-run-session"} -- ${lib.getExe' cfg.package "start-umbriel"}
+              Type=Application
+            ''
+          ))
+        ];
+      })
+
+      (lib.mkIf (cfg.portalPackage != null) {
+        xdg.portal = {
+          enable = lib.mkDefault true;
+          # finix follows config.xdg.portals = []; logic
+          # for extraPortals from nixos
+          portals = [ cfg.portalPackage ];
+          config.umbriel.default = lib.mkDefault [
+            "umbriel"
+            "gtk"
+          ];
+        };
+      })
+    ]
+  );
+}

--- a/nix/hjem-module.nix
+++ b/nix/hjem-module.nix
@@ -3,22 +3,26 @@
   pkgs,
   lib,
   ...
-}: let
+}:
+let
   inherit (lib.modules) mkIf;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.lists) optional;
 
   cfg = config.programs.umbriel;
-  tomlFormat = pkgs.formats.toml {};
-  generateConfig = format: name: value:
-    if lib.isString value
-    then pkgs.writeText name value
-    else if builtins.isPath value || lib.isStorePath value
-    then value
-    else format.generate name value;
+  tomlFormat = pkgs.formats.toml { };
+  generateConfig =
+    format: name: value:
+    if lib.isString value then
+      pkgs.writeText name value
+    else if builtins.isPath value || lib.isStorePath value then
+      value
+    else
+      format.generate name value;
 
   generateToml = generateConfig tomlFormat;
-in {
+in
+{
   options.programs.umbriel = {
     enable = mkEnableOption "Umbriel, a Wayland compositor built on wlroots and SceneFX.";
 
@@ -33,7 +37,8 @@ in {
       description = "Validate the configuration file at build time.";
     };
     settings = mkOption {
-      type = with lib.types;
+      type =
+        with lib.types;
         nullOr (oneOf [
           tomlFormat.type
           str
@@ -72,16 +77,17 @@ in {
     packages = optional (cfg.package != null) cfg.package;
 
     xdg.config.files = mkIf (cfg.settings != null) {
-      "umbriel/config.toml".source = let
-        rawConfig = generateToml "umbriel-config.toml" cfg.settings;
-      in
-        if cfg.validateConfig && cfg.package != null
-        then
-          pkgs.runCommand "umbriel-config" {} ''
+      "umbriel/config.toml".source =
+        let
+          rawConfig = generateToml "umbriel-config.toml" cfg.settings;
+        in
+        if cfg.validateConfig && cfg.package != null then
+          pkgs.runCommand "umbriel-config" { } ''
             ${lib.getExe cfg.package} validate -c ${rawConfig}
             cp ${rawConfig} $out
           ''
-        else rawConfig;
+        else
+          rawConfig;
     };
   };
 

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -3,19 +3,23 @@
   pkgs,
   lib,
   ...
-}: let
+}:
+let
   cfg = config.programs.umbriel;
-  tomlFormat = pkgs.formats.toml {};
+  tomlFormat = pkgs.formats.toml { };
 
-  generateConfig = format: name: value:
-    if lib.isString value
-    then pkgs.writeText name value
-    else if builtins.isPath value || lib.isStorePath value
-    then value
-    else format.generate name value;
+  generateConfig =
+    format: name: value:
+    if lib.isString value then
+      pkgs.writeText name value
+    else if builtins.isPath value || lib.isStorePath value then
+      value
+    else
+      format.generate name value;
 
   generateToml = generateConfig tomlFormat;
-in {
+in
+{
   options.programs.umbriel = {
     enable = lib.mkEnableOption "Umbriel, a Wayland compositor built on wlroots and SceneFX.";
 
@@ -26,7 +30,8 @@ in {
     };
 
     settings = lib.mkOption {
-      type = with lib.types;
+      type =
+        with lib.types;
         nullOr (oneOf [
           tomlFormat.type
           str
@@ -70,16 +75,17 @@ in {
 
     xdg.configFile = lib.mkIf (cfg.settings != null) {
       "umbriel/config.toml" = {
-        source = let
-          rawConfig = generateToml "umbriel-config.toml" cfg.settings;
-        in
-          if cfg.validateConfig && cfg.package != null
-          then
-            pkgs.runCommand "noctalia-config" {} ''
+        source =
+          let
+            rawConfig = generateToml "umbriel-config.toml" cfg.settings;
+          in
+          if cfg.validateConfig && cfg.package != null then
+            pkgs.runCommand "noctalia-config" { } ''
               ${lib.getExe cfg.package} validate -c ${rawConfig}
               cp ${rawConfig} $out
             ''
-          else rawConfig;
+          else
+            rawConfig;
         force = true;
       };
     };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,16 +26,20 @@
   makeBinaryWrapper,
 }:
 let
-  inherit (builtins) baseNameOf head match readFile;
-  source =
-    lib.throwIf (!builtins.pathExists (../. + "/subprojects/scenefx/meson.build")) ''
-      umbriel: subprojects/scenefx is missing.
+  inherit (builtins)
+    baseNameOf
+    head
+    match
+    readFile
+    ;
+  source = lib.throwIf (!builtins.pathExists (../. + "/subprojects/scenefx/meson.build")) ''
+    umbriel: subprojects/scenefx is missing.
 
-      This flake needs a Git submodule, which the `github:` fetcher cannot
-      fetch because it downloads a tarball. Use the Git fetcher instead:
+    This flake needs a Git submodule, which the `github:` fetcher cannot
+    fetch because it downloads a tarball. Use the Git fetcher instead:
 
-        inputs.umbriel.url = "git+https://github.com/noctalia-dev/umbriel";
-    '' ../.;
+      inputs.umbriel.url = "git+https://github.com/noctalia-dev/umbriel";
+  '' ../.;
   version = head (match ".*\n  version: '([0-9][^']+)'.*" (readFile ../meson.build));
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

add `finixModules.default `to `flake.nix`

## Motivation

make umbriel accessible on `finix` 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging
- [ ] Documentation

## Related Issue


## Testing

required

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [ ] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [ ] I ran `just format`, or this PR has no C++ changes.
- [ ] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [ ] I functionally verified compositor behavior where automated checks are insufficient.
- [ ] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [ ] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

not sure about changes in `docs/` yet bc this PR not tested atm; 
