### PR TITLE
feat: add empty_above config that adds an empty workspace at the start

### DIFF
--- a/docs/design/workspace-lifecycle.md
+++ b/docs/design/workspace-lifecycle.md
@@ -7,10 +7,12 @@ in [`outputs.md`](../../user/outputs.md).
 
 A dynamic output maintains numbered workspaces with these invariants:
 
-- It always has at least one workspace.
-- Outside a workspace slide or overview session, an occupied last workspace
-  causes Umbriel to append a new empty workspace.
-- Empty inactive workspaces are removed.
+- It always has a trailing empty workspace.
+- With `workspaces.empty_above` enabled, it also has a distinct leading empty
+  workspace, including before the first view maps.
+- Outside a workspace slide or overview session, an occupied sentinel causes
+  Umbriel to add a new empty workspace at that edge.
+- Other empty inactive workspaces are removed.
 - Remaining workspaces are renamed and reindexed from `1` in their current
   order.
 - Workspace layout rules are resolved again after renumbering.
@@ -59,8 +61,8 @@ Empty static workspaces remain in the inventory.
 
 Switching from a static inventory to dynamic workspaces keeps every populated
 workspace and the active workspace. Other empty workspaces are removed. The
-survivors are renumbered, and Umbriel appends an empty workspace when needed.
-
+survivors are renumbered, and Umbriel restores the trailing empty workspace plus
+the optional leading empty workspace.
 Switching to a static inventory follows the normal name-first, position-second
 matching process.
 
@@ -79,9 +81,12 @@ inventory change.
 
 Configuration resolution and change classification are covered by
 [`tests/unit/config_resolve.cpp`](../../tests/unit/config_resolve.cpp) and
-[`tests/unit/config_change.cpp`](../../tests/unit/config_change.cpp). Live workspace
-selection is exercised by
+[`tests/unit/config_change.cpp`](../../tests/unit/config_change.cpp). Live
+workspace selection is exercised by
 [`tests/harness/checks/210_workspace_selectors.sh`](../../tests/harness/checks/210_workspace_selectors.sh).
+Leading and trailing dynamic sentinels, including renumbering after workspace
+movement, are covered by
+[`tests/harness/checks/215_empty_above.sh`](../../tests/harness/checks/215_empty_above.sh).
 Pointer isolation during a wheel-triggered workspace transition is covered by
 [`tests/harness/checks/220_workspace_transition_focus.sh`](../../tests/harness/checks/220_workspace_transition_focus.sh).
 Modifier-wheel switching and the resulting keyboard-focus handoff through an

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -8,6 +8,7 @@ rules.
 ```toml
 [workspaces]
 back_and_forth = true
+empty_above = false
 ```
 
 | Key              | Type | Default | Description                                                                                     |

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -13,6 +13,7 @@ back_and_forth = true
 | Key              | Type | Default | Description                                                                                     |
 | ---------------- | ---- | ------- | ----------------------------------------------------------------------------------------------- |
 | `back_and_forth` | bool | `false` | Re-selecting the active workspace jumps back to the previously active workspace on that output. |
+| `empty_above` | bool | `false` | Add an empty workspace at the start, in addition to the workspace at the end. |
 
 Output workspaces are dynamic by default. The workspace models and rules are
 documented below.

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -14,7 +14,7 @@ empty_above = false
 | Key              | Type | Default | Description                                                                                     |
 | ---------------- | ---- | ------- | ----------------------------------------------------------------------------------------------- |
 | `back_and_forth` | bool | `false` | Re-selecting the active workspace jumps back to the previously active workspace on that output. |
-| `empty_above` | bool | `false` | Add an empty workspace at the start, in addition to the workspace at the end. |
+| `empty_above`    | bool | `false` | Add an empty workspace at the start, in addition to the workspace at the end.                    |
 
 Output workspaces are dynamic by default. The workspace models and rules are
 documented below.
@@ -25,11 +25,15 @@ Each output can use dynamic or static workspaces.
 
 ### Dynamic workspaces
 
-Omit `workspaces` or set it to `"dynamic"`. The output starts with one empty
-workspace named `"1"`. When the last workspace gains a window, Umbriel adds
-another empty workspace.
+Omit `workspaces` or set it to `"dynamic"`. By default, the output starts with
+one empty workspace named `"1"`. With `empty_above = true`, it starts with
+distinct leading and trailing empty workspaces named `"1"` and `"2"`.
 
-After you leave an empty workspace, Umbriel removes it unless it is still
+When the last workspace gains a window, Umbriel adds another empty workspace.
+With `empty_above = true`, it also adds a new leading empty workspace when the
+first workspace gains a window.
+
+After you leave any other empty workspace, Umbriel removes it unless it is still
 active. The remaining workspaces are renumbered. If you switch to a workspace
 number beyond the current count, Umbriel uses the last workspace.
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -25,6 +25,7 @@ honor_restored_maximize = false # let apps restore their saved maximized state
 
 [workspaces]
 back_and_forth = false
+empty_above = false
 
 # Colors ---------------------------------------------------------------------
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -585,7 +585,10 @@ namespace umbriel {
     }
 
     void readWorkspaceSettings(Section& root, Config& loaded) {
-      root.sub("workspaces", [&](Section& s) { s.boolean("back_and_forth", loaded.workspaces.backAndForth); });
+      root.sub("workspaces", [&](Section& s) {
+        s.boolean("back_and_forth", loaded.workspaces.backAndForth)
+            .boolean("empty_above", loaded.workspaces.emptyAbove);
+      });
     }
 
     void readGeneral(Section& root, Config& loaded) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -378,6 +378,7 @@ namespace umbriel {
     struct Workspaces {
       // Re-selecting the active workspace jumps back to the previous one.
       bool backAndForth = false;
+      bool emptyAbove = false;
       bool operator==(const Workspaces&) const = default;
     } workspaces;
 

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -259,7 +259,12 @@ namespace umbriel {
     ResolvedWorkspaceSet result;
     if (!names) {
       result.dynamic = true;
-      result.workspaces.push_back({"1", resolveWorkspaceLayout(config, outputName, "1", 0)});
+      const size_t count = config.workspaces.emptyAbove ? 2 : 1;
+      result.workspaces.reserve(count);
+      for (size_t index = 0; index < count; ++index) {
+        const std::string name = std::to_string(index + 1);
+        result.workspaces.push_back({name, resolveWorkspaceLayout(config, outputName, name, index)});
+      }
       return result;
     }
 

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1030,6 +1030,16 @@ namespace umbriel {
     return result;
   }
 
+  Workspace* WorkspaceGroup::prependDynamicWorkspace() {
+    const std::string name = "1";
+    const char* outputName = m_output->wlr()->name != nullptr ? m_output->wlr()->name : "output";
+    ResolvedLayoutConfig layout = resolveWorkspaceLayout(config(), outputName, name, 0);
+    auto workspace = createConfiguredWorkspace({name, std::move(layout)}, 0);
+    Workspace* result = workspace.get();
+    m_workspaces.insert(m_workspaces.begin(), std::move(workspace));
+    return result;
+  }
+
   void WorkspaceGroup::refreshDynamicWorkspaceMetadata() {
     const char* outputName = m_output->wlr()->name != nullptr ? m_output->wlr()->name : "output";
     for (size_t index = 0; index < m_workspaces.size(); ++index) {
@@ -1080,11 +1090,18 @@ namespace umbriel {
     if (target < 0 || target >= static_cast<std::ptrdiff_t>(m_workspaces.size())) {
       return false;
     }
-    if (m_dynamic && direction > 0) {
-      const bool targetIsTrailingEmpty = static_cast<size_t>(target) == m_workspaces.size() - 1
-          && !m_workspaces[static_cast<size_t>(target)]->hasViews();
-      if (targetIsTrailingEmpty) {
-        return false;
+    if (m_dynamic) {
+      if (direction > 0) {
+        const bool targetIsTrailingEmpty = static_cast<size_t>(target) == m_workspaces.size() - 1
+            && !m_workspaces[static_cast<size_t>(target)]->hasViews();
+        if (targetIsTrailingEmpty) {
+          return false;
+        }
+      } else if (config().workspaces.emptyAbove) {
+        const bool targetIsLeadingEmpty = target == 0 && !m_workspaces[0]->hasViews();
+        if (targetIsLeadingEmpty) {
+          return false;
+        }
       }
     }
     slideFinish();
@@ -1093,6 +1110,9 @@ namespace umbriel {
       refreshDynamicWorkspaceMetadata();
       if (m_workspaces.back()->hasViews()) {
         appendDynamicWorkspace();
+      }
+      if (config().workspaces.emptyAbove && m_workspaces.front()->hasViews()) {
+        prependDynamicWorkspace();
       }
     } else {
       for (const size_t slot : {index, static_cast<size_t>(target)}) {
@@ -1115,7 +1135,7 @@ namespace umbriel {
     if (m_dynamic) {
       auto old = std::move(m_workspaces);
       m_workspaces.clear();
-      m_workspaces.reserve(old.size() + 1);
+      m_workspaces.reserve(old.size() + 2);
       for (auto& workspace : old) {
         if (workspace != nullptr && (workspace->hasViews() || workspace.get() == m_active)) {
           m_workspaces.push_back(std::move(workspace));
@@ -1127,6 +1147,9 @@ namespace umbriel {
 
       if (m_workspaces.empty() || m_workspaces.back()->hasViews()) {
         appendDynamicWorkspace();
+      }
+      if (config().workspaces.emptyAbove && m_workspaces.front()->hasViews()) {
+        prependDynamicWorkspace();
       }
       for (size_t index = 0; index < m_workspaces.size(); ++index) {
         m_workspaces[index]->rename(std::to_string(index + 1), index);
@@ -1235,21 +1258,35 @@ namespace umbriel {
     // Dynamic groups keep exactly one empty workspace. Prefer an empty active workspace so closing its last window does
     // not destroy the workspace the user is currently viewing; otherwise retain the last existing empty one to avoid
     // replacing its protocol identity on every reconciliation.
-    Workspace* emptyKeeper = m_active != nullptr && !m_active->hasViews() ? m_active : nullptr;
-    if (emptyKeeper == nullptr && !m_workspaces.empty() && !m_workspaces.back()->hasViews()) {
-      emptyKeeper = m_workspaces.back().get();
+    Workspace* backKeeper = m_active != nullptr && !m_active->hasViews() ? m_active : nullptr;
+    if (backKeeper == nullptr && !m_workspaces.empty() && !m_workspaces.back()->hasViews()) {
+      backKeeper = m_workspaces.back().get();
     }
+
+    // workspaces.emptyAbove asks for the same guarantee at the front. Unlike the back keeper this is purely
+    // positional: whatever already sits at index 0 keeps its identity if it is empty. A workspace that already serves
+    // as the back keeper (the group has collapsed to a single empty workspace) already satisfies both roles and does
+    // not need a second one.
+    const bool emptyAbove = config().workspaces.emptyAbove;
+    Workspace* frontKeeper = nullptr;
+    if (emptyAbove && !m_workspaces.empty() && !m_workspaces.front()->hasViews()) {
+      frontKeeper = m_workspaces.front().get();
+    }
+
     for (size_t index = m_workspaces.size(); index-- > 0;) {
       Workspace* workspace = m_workspaces[index].get();
-      if (!workspace->hasViews() && workspace != emptyKeeper) {
+      if (!workspace->hasViews() && workspace != backKeeper && workspace != frontKeeper) {
         if (m_previous == workspace) {
           m_previous = nullptr;
         }
         m_workspaces.erase(m_workspaces.begin() + static_cast<std::ptrdiff_t>(index));
       }
     }
-    if (emptyKeeper == nullptr) {
+    if (backKeeper == nullptr) {
       appendDynamicWorkspace();
+    }
+    if (emptyAbove && m_workspaces.front()->hasViews()) {
+      prependDynamicWorkspace();
     }
 
     refreshDynamicWorkspaceMetadata();

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1107,18 +1107,12 @@ namespace umbriel {
     slideFinish();
     std::swap(m_workspaces[index], m_workspaces[static_cast<size_t>(target)]);
     if (m_dynamic) {
-      refreshDynamicWorkspaceMetadata();
-      if (m_workspaces.back()->hasViews()) {
-        appendDynamicWorkspace();
-      }
-      if (config().workspaces.emptyAbove && m_workspaces.front()->hasViews()) {
-        prependDynamicWorkspace();
-      }
-    } else {
-      for (const size_t slot : {index, static_cast<size_t>(target)}) {
-        Workspace* moved = m_workspaces[slot].get();
-        moved->rename(moved->name(), slot);
-      }
+      reconcileDynamic();
+      return true;
+    }
+    for (const size_t slot : {index, static_cast<size_t>(target)}) {
+      Workspace* moved = m_workspaces[slot].get();
+      moved->rename(moved->name(), slot);
     }
     if (Overview* overview = m_server->overview(); overview != nullptr && overview->active()) {
       overview->onWorkspaceInventoryChanged(this);
@@ -1133,30 +1127,7 @@ namespace umbriel {
     m_dynamic = resolvedSet.dynamic;
 
     if (m_dynamic) {
-      auto old = std::move(m_workspaces);
-      m_workspaces.clear();
-      m_workspaces.reserve(old.size() + 2);
-      for (auto& workspace : old) {
-        if (workspace != nullptr && (workspace->hasViews() || workspace.get() == m_active)) {
-          m_workspaces.push_back(std::move(workspace));
-        } else if (workspace.get() == m_previous) {
-          m_previous = nullptr;
-        }
-      }
-      old.clear();
-
-      if (m_workspaces.empty() || m_workspaces.back()->hasViews()) {
-        appendDynamicWorkspace();
-      }
-      if (config().workspaces.emptyAbove && m_workspaces.front()->hasViews()) {
-        prependDynamicWorkspace();
-      }
-      for (size_t index = 0; index < m_workspaces.size(); ++index) {
-        m_workspaces[index]->rename(std::to_string(index + 1), index);
-      }
-      if (m_previous == m_active) {
-        m_previous = nullptr;
-      }
+      reconcileDynamic();
       kLog.info("reconciled {} to {} workspaces (0 windows relocated)", outputName, m_workspaces.size());
       return;
     }
@@ -1255,22 +1226,26 @@ namespace umbriel {
       return;
     }
 
-    // Dynamic groups keep exactly one empty workspace. Prefer an empty active workspace so closing its last window does
-    // not destroy the workspace the user is currently viewing; otherwise retain the last existing empty one to avoid
-    // replacing its protocol identity on every reconciliation.
-    Workspace* backKeeper = m_active != nullptr && !m_active->hasViews() ? m_active : nullptr;
-    if (backKeeper == nullptr && !m_workspaces.empty() && !m_workspaces.back()->hasViews()) {
-      backKeeper = m_workspaces.back().get();
-    }
-
-    // workspaces.emptyAbove asks for the same guarantee at the front. Unlike the back keeper this is purely
-    // positional: whatever already sits at index 0 keeps its identity if it is empty. A workspace that already serves
-    // as the back keeper (the group has collapsed to a single empty workspace) already satisfies both roles and does
-    // not need a second one.
+    // Dynamic groups keep one trailing empty workspace. Prefer an empty active workspace so closing its last window
+    // does not destroy the workspace the user is currently viewing; otherwise retain the existing trailing empty to
+    // avoid replacing its protocol identity on every reconciliation.
     const bool emptyAbove = config().workspaces.emptyAbove;
     Workspace* frontKeeper = nullptr;
     if (emptyAbove && !m_workspaces.empty() && !m_workspaces.front()->hasViews()) {
       frontKeeper = m_workspaces.front().get();
+    }
+
+    // The optional leading empty and the trailing empty are distinct inventory entries, including before the first
+    // view maps. A leading empty therefore cannot also serve as the trailing keeper.
+    Workspace* backKeeper = nullptr;
+    if (m_active != nullptr && !m_active->hasViews() && m_active != frontKeeper) {
+      backKeeper = m_active;
+    }
+    if (backKeeper == nullptr
+        && !m_workspaces.empty()
+        && !m_workspaces.back()->hasViews()
+        && m_workspaces.back().get() != frontKeeper) {
+      backKeeper = m_workspaces.back().get();
     }
 
     for (size_t index = m_workspaces.size(); index-- > 0;) {
@@ -1285,7 +1260,7 @@ namespace umbriel {
     if (backKeeper == nullptr) {
       appendDynamicWorkspace();
     }
-    if (emptyAbove && m_workspaces.front()->hasViews()) {
+    if (emptyAbove && frontKeeper == nullptr) {
       prependDynamicWorkspace();
     }
 

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -209,6 +209,7 @@ namespace umbriel {
   private:
     std::unique_ptr<Workspace> createConfiguredWorkspace(ResolvedWorkspace workspace, size_t index);
     Workspace* appendDynamicWorkspace();
+    Workspace* prependDynamicWorkspace();
     void refreshDynamicWorkspaceMetadata();
 
     struct Slide {

--- a/tests/harness/checks/215_empty_above.sh
+++ b/tests/harness/checks/215_empty_above.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# empty_above keeps distinct leading and trailing empty workspaces. Moving the active leading empty workspace must
+# preserve that inventory and renumber every surviving workspace.
+set -euo pipefail
+
+readonly WORKSPACE="${UMBRIEL_WORKSPACE_CLIENT:-./build-debug/workspace-client}"
+
+workspace_names() {
+  "$WORKSPACE" --all | cut -f2 | sort -n | paste -sd ' ' -
+}
+
+workspace_name_for_window() {
+  local workspace_id
+  workspace_id=$("$UMBRIEL" windows --json | jq -r '.[0].workspace')
+  "$WORKSPACE" --all | awk -F'\t' -v id="$workspace_id" '$1 == id { print $2 }'
+}
+
+printf '\n[workspaces]\nempty_above = true\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+foot --title=empty-above-view sh -c 'sleep 120' > /dev/null 2>&1 &
+for _ in $(seq 40); do
+  [[ $("$UMBRIEL" windows --json | jq 'length') -eq 1 ]] && break
+  sleep 0.1
+done
+if [[ $("$UMBRIEL" windows --json | jq 'length') -ne 1 ]]; then
+  echo "expected one window, got: $("$UMBRIEL" windows --json)"
+  exit 1
+fi
+if [[ $(workspace_names) != "1 2 3" || $(workspace_name_for_window) != "2" ]]; then
+  echo "mapped view did not land between both empty sentinels: names=$(workspace_names), view=$(workspace_name_for_window)"
+  exit 1
+fi
+
+"$UMBRIEL" msg workspace-switch:1 > /dev/null
+"$UMBRIEL" msg workspace-move-down > /dev/null
+
+if [[ $(workspace_names) != "1 2 3" ]]; then
+  echo "moving the leading empty workspace left stale or duplicate names: $(workspace_names)"
+  exit 1
+fi
+if [[ $("$WORKSPACE") != "3" || $(workspace_name_for_window) != "2" ]]; then
+  echo "workspace identities were not renumbered after the move: active=$("$WORKSPACE"), view=$(workspace_name_for_window)"
+  exit 1
+fi
+
+echo "empty_above keeps distinct sentinels and renumbers after workspace movement"

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -116,6 +116,15 @@ UMBRIEL_TEST(workspaceInventoryResolvesStaticAndDynamicOutputs) {
   CHECK(dynamicSet.dynamic);
   CHECK_EQ(dynamicSet.workspaces.size(), size_t{1});
   CHECK_EQ(dynamicSet.workspaces[0].name, std::string{"1"});
+
+  config.workspaces.emptyAbove = true;
+  const auto dynamicSetWithEmptyAbove = umbriel::resolveWorkspacesForOutput(config, "DP-2");
+  CHECK(dynamicSetWithEmptyAbove.dynamic);
+  CHECK_EQ(dynamicSetWithEmptyAbove.workspaces.size(), size_t{2});
+  if (dynamicSetWithEmptyAbove.workspaces.size() == 2) {
+    CHECK_EQ(dynamicSetWithEmptyAbove.workspaces[0].name, std::string{"1"});
+    CHECK_EQ(dynamicSetWithEmptyAbove.workspaces[1].name, std::string{"2"});
+  }
 }
 
 UMBRIEL_TEST(fixedWorkspacePositionSelectsItsUniqueOutput) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add `empty_above` to the workspaces config. It adds an empty workspace at the start in addition to the workspace at the end.

## Motivation

<!-- What problem does this solve? -->
That feature was requested on discord and is a feature in niri.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Discord

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
In niri the config name is `empty-workspace-above-first` but `empty_above` is more minimal and fits better with `back_and_forth`.
`empty_above_first` would be more explicit though.