### PR TITLE
fix(scratchpad): backdrop dim/blur stuck after restoring the last window

### DIFF
--- a/src/workspace/scratchpad.cpp
+++ b/src/workspace/scratchpad.cpp
@@ -143,6 +143,23 @@ namespace umbriel {
     return true;
   }
 
+  void ScratchpadManager::retargetBackdrop(Output* output, bool visible) {
+    if (output == nullptr) {
+      return;
+    }
+    const auto& animation = config().animation;
+    const auto& scratchpad = animation.scratchpad;
+    auto fadeIt = m_backdropFades.try_emplace(output, 0.0).first;
+    AnimatedValue& backdropFade = fadeIt->second;
+    const double fadeTarget = visible ? 1.0 : 0.0;
+    if (animation.enabled && scratchpad.enabled && (backdropFade.animating() || backdropFade.current() != fadeTarget)) {
+      backdropFade.retarget(fadeTarget, scratchpad.durationMs, scratchpad.curve);
+    } else {
+      backdropFade.snap(fadeTarget);
+    }
+    updateDimAndBlur(output);
+  }
+
   void ScratchpadManager::setVisible(Output* output, bool visible) {
     if (output == nullptr) {
       return;
@@ -160,14 +177,7 @@ namespace umbriel {
     }
     const auto& animation = config().animation;
     const auto& scratchpad = animation.scratchpad;
-    auto fadeIt = m_backdropFades.try_emplace(output, 0.0).first;
-    AnimatedValue& backdropFade = fadeIt->second;
-    const double fadeTarget = visible ? 1.0 : 0.0;
-    if (animation.enabled && scratchpad.enabled && (backdropFade.animating() || backdropFade.current() != fadeTarget)) {
-      backdropFade.retarget(fadeTarget, scratchpad.durationMs, scratchpad.curve);
-    } else {
-      backdropFade.snap(fadeTarget);
-    }
+    retargetBackdrop(output, visible);
 
     for (const Entry& entry : m_entries) {
       if (entry.output != output || entry.view == nullptr) {
@@ -449,6 +459,7 @@ namespace umbriel {
     m_entries.erase(it);
     if (std::ranges::none_of(m_entries, [output](const Entry& e) { return e.output == output; })) {
       std::erase(m_visibleOutputs, output);
+      retargetBackdrop(output, false);
     }
     if (m_focusedView == view) {
       m_focusedView = nullptr;
@@ -507,6 +518,7 @@ namespace umbriel {
     if (entryOutput != nullptr
         && std::ranges::none_of(m_entries, [entryOutput](const Entry& e) { return e.output == entryOutput; })) {
       std::erase(m_visibleOutputs, entryOutput);
+      retargetBackdrop(entryOutput, false);
     }
   }
 

--- a/src/workspace/scratchpad.h
+++ b/src/workspace/scratchpad.h
@@ -56,6 +56,8 @@ namespace umbriel {
     };
 
     void setVisible(Output* output, bool visible);
+    // Retarget the backdrop dim/blur fade for `output` and refresh its scene nodes.
+    void retargetBackdrop(Output* output, bool visible);
     wlr_scene_rect* dimRectFor(Output* output);
     wlr_scene_blur* blurNodeFor(Output* output);
     void updateDimAndBlur(Output* output);

--- a/tests/harness/checks/176_scratchpad_restore_dim_clears.sh
+++ b/tests/harness/checks/176_scratchpad_restore_dim_clears.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Regression for a stuck backdrop dim: restoring the last scratchpad window on an output (via
+# window-toggle-scratchpad, which calls ScratchpadManager::restoreFocused) must retarget the
+# backdrop fade to 0 and refresh the dim/blur nodes, same as ScratchpadManager::setVisible does
+# when the scratchpad is hidden through scratchpad-toggle. Before the fix, restoreFocused and
+# remove() dropped the output from m_visibleOutputs without touching the backdrop fade, so the
+# dim rect stayed at its last alpha forever once every scratchpad window on that output was gone.
+set -euo pipefail
+
+readonly BEFORE="$UMBRIEL_RUNTIME_DIR/scratchpad-restore-before.png"
+readonly AFTER="$UMBRIEL_RUNTIME_DIR/scratchpad-restore-after.png"
+
+sample_corner() {
+  # Top-left 20x20, well outside where a centered foot window lands on a 1280x720 output.
+  magick "$1" -crop 20x20+5+5 -format '%[fx:round(255*mean.r)]' info:
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[appearance]
+border_width = 0
+outer_border_width = 0
+corner_radius = 0
+backdrop_color = "#FFFFFFFF"
+
+[animation.scratchpad]
+dim = 0.6
+
+[[window_rule]]
+default_floating = true
+default_size = [300, 200]
+
+[window_rule.match]
+title = "^scratch-"
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+wait_for_count() {
+  local expected=$1 count=
+  for _ in $(seq 40); do
+    count=$("$UMBRIEL" windows --json | jq 'length')
+    [[ $count == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  echo "expected $expected window(s), got $count"
+  return 1
+}
+
+foot --title=scratch-a sh -c 'sleep 120' > /dev/null 2>&1 &
+wait_for_count 1
+"$UMBRIEL" msg window-move-to-scratchpad:HEADLESS-1 > /dev/null
+
+foot --title=scratch-b sh -c 'sleep 120' > /dev/null 2>&1 &
+wait_for_count 2
+"$UMBRIEL" msg window-move-to-scratchpad:HEADLESS-1 > /dev/null
+
+# Show both scratchpad windows: the backdrop dims.
+"$UMBRIEL" msg scratchpad-toggle:HEADLESS-1 > /dev/null
+sleep 0.3
+grim "$BEFORE"
+before=$(sample_corner "$BEFORE")
+if (( before > 200 )); then
+  echo "backdrop did not dim while the scratchpad was showing two windows: corner=$before"
+  exit 1
+fi
+
+# Restore the first (currently scratchpad-focused) window. One scratchpad window remains, so the
+# dim must stay.
+"$UMBRIEL" msg window-toggle-scratchpad:HEADLESS-1 > /dev/null
+sleep 0.3
+if ! wait_for_count 2; then
+  echo "restoring the first window changed the window count unexpectedly"
+  exit 1
+fi
+
+# Focus the remaining scratchpad window, then restore it too. The scratchpad is now empty on this
+# output, so the dim must clear.
+"$UMBRIEL" msg scratchpad-focus-next:HEADLESS-1 > /dev/null
+sleep 0.1
+"$UMBRIEL" msg window-toggle-scratchpad:HEADLESS-1 > /dev/null
+sleep 0.3
+
+grim "$AFTER"
+after=$(sample_corner "$AFTER")
+if (( after < 240 )); then
+  echo "backdrop dim remained stuck after every scratchpad window on the output was restored: before=$before after=$after"
+  exit 1
+fi
+
+echo "backdrop dim cleared once the last scratchpad window was restored: corner $before -> $after"


### PR DESCRIPTION
## What was happening

Move two windows into the scratchpad, show it, then pop them back out one at a time with `window-toggle-scratchpad`. The last window comes back fine, but the dim/blur backdrop behind it stays stuck on -- it never clears. Same thing if the last scratchpad window on an output is closed instead of restored. Since the leftover overlay sits on top of whatever the window reparents into, it also looks like focus never lands on the restored window.

## Root cause

`ScratchpadManager::setVisible()` is the only place that retargets the backdrop dim/blur fade to 0 and refreshes the dim rect / blur node when an output's scratchpad becomes empty. `restoreFocused()` (what `window-toggle-scratchpad` calls) and `remove()` (a scratchpad window closing) both drop the output from `m_visibleOutputs` the same way `setVisible()` does when hiding -- but neither one touches the backdrop fade or calls `updateDimAndBlur()`. So the dim rect/blur node just keep rendering at whatever alpha they were last set to, with nothing left to ever bring them back down.

## Fix

Pulled the fade-retarget-and-refresh logic already in `setVisible()` out into a small `retargetBackdrop()` helper, and call it from `restoreFocused()` and `remove()` whenever they empty out an output's scratchpad entries.

## Testing

Added `tests/harness/checks/176_scratchpad_restore_dim_clears.sh`: parks two windows in the scratchpad, restores them one at a time via `window-toggle-scratchpad`, and samples the backdrop before/after. Confirmed it fails on `main` (backdrop stays dimmed at the same value) and passes with this fix (backdrop clears back to the bare wallpaper). Full harness suite (63 checks) and unit tests (25) still pass.