### PR TITLE
fix(workspace): insert floating window next to last focused tiled window

### DIFF
--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -226,7 +226,18 @@ namespace umbriel {
     if (view == nullptr || !view->mapped() || !view->tiled() || m_layout->columnOf(view) >= 0) {
       return;
     }
-    const int focusedColumn = m_layout->columnOf(m_focusedView);
+    int focusedColumn = m_layout->columnOf(m_focusedView);
+    if (focusedColumn < 0 && m_group != nullptr) {
+      for (const auto& entry : m_group->server()->registry().all()) {
+        View* candidate = entry.get();
+        if (candidate != view && candidate->mapped() && candidate->tiled() && candidate->workspace() == this) {
+          focusedColumn = m_layout->columnOf(candidate);
+          if (focusedColumn >= 0) {
+            break;
+          }
+        }
+      }
+    }
     const int index = focusedColumn >= 0 ? focusedColumn + 1 : static_cast<int>(m_layout->columns().size());
     m_layout->insertView(view, index);
     if (ScrollingLayout* scrolling = scrollingLayout(); scrolling != nullptr) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Insert the floating window next to the last focused tiled window.

## Motivation

<!-- What problem does this solve? -->
When a floating window is tiled, it goes to the end of the workspace at the last position.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Discord

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
