### PR TITLE
feat(scratchpad): add maximize and maximize_to_edges options

### DIFF
--- a/docs/user/animation.md
+++ b/docs/user/animation.md
@@ -46,7 +46,8 @@ curve = "easeout"
 dim = 0.5             # 0.0-1.0
 blur = false          # requires appearance.blur.enabled
 scale = 0.0           # 0 preserves geometry; 0.1-1.0 sizes and centers on entry
-maximize = false      # maximize to edges on entry
+maximize = false      # maximize to usable area on entry
+maximize_to_edges = false # maximize to edges on entry
 fullscreen = false    # fullscreen on entry
 
 [animation.border]
@@ -86,14 +87,14 @@ fields are specific to individual event tables:
 | `[animation.windows_move]` | None                                                                                                               | Window move and resize.                             |
 | `[animation.workspaces]`   | None                                                                                                               | Workspace switch.                                   |
 | `[animation.overview]`     | None                                                                                                               | Overview open, close, and row settling.             |
-| `[animation.scratchpad]`   | `dim` (0.0-1.0); `blur`; `scale` (0.0-1.0); `maximize`; `fullscreen`                                             | Scratchpad show, hide, and backdrop.                |
+| `[animation.scratchpad]`   | `dim` (0.0-1.0); `blur`; `scale` (0.0-1.0); `maximize`; `maximize_to_edges`; `fullscreen`                         | Scratchpad show, hide, and backdrop.                |
 | `[animation.border]`       | None                                                                                                               | Focus-ring color transition in OkLab color space.   |
 | `[animation.dim_unfocused]` | `dim` (0.0-1.0)                                                                                                 | Unfocused-window opacity. `dim = 0` disables it.    |
 | `[animation.layers]`       | None                                                                                                               | Layer-shell surface map and unmap fades.            |
 
 An event's `enabled = false` makes only that transition instant. Scratchpad
 `dim` and `blur` remain active, without a fade, when animation is disabled.
-Scratchpad `scale`, `maximize`, and `fullscreen` apply when a window enters the
+Scratchpad `scale`, `maximize`, `maximize_to_edges`, and `fullscreen` apply when a window enters the
 scratchpad.
 
 ## Curves

--- a/docs/user/scratchpad.md
+++ b/docs/user/scratchpad.md
@@ -94,10 +94,10 @@ If the original output no longer exists, Umbriel restores the window on the
 output targeted by the action. If the original workspace no longer exists, it
 uses that output's active workspace.
 
-Fullscreen, pinned, and maximize-to-edges state are cleared when a window enters
-the scratchpad and are not restored automatically. The optional
-`animation.scratchpad.fullscreen` or `animation.scratchpad.maximize` setting can
-apply a new state on entry.
+Fullscreen, pinned, maximized, and maximize-to-edges state are cleared when a
+window enters the scratchpad and are not restored automatically. The optional
+`animation.scratchpad.fullscreen`, `animation.scratchpad.maximize_to_edges`, or
+`animation.scratchpad.maximize` setting can apply a new state on entry.
 
 ## Moving scratchpad windows
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -79,7 +79,8 @@ curve = "easeout"
 dim = 0.5                      # 0.0-1.0
 blur = false
 scale = 0.0                    # 0 preserves the window geometry
-maximize = false
+maximize = false               # maximize to usable area on entry
+maximize_to_edges = false      # maximize to edges on entry
 fullscreen = false
 
 [animation.border]

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -729,6 +729,7 @@ namespace umbriel {
             .boolean("blur", animation.scratchpad.blur)
             .real("scale", 0.0, 1.0, animation.scratchpad.scale)
             .boolean("maximize", animation.scratchpad.maximize)
+            .boolean("maximize_to_edges", animation.scratchpad.maximizeToEdges)
             .boolean("fullscreen", animation.scratchpad.fullscreen);
         readCurve(section, "animation.scratchpad", animation.scratchpad.curve);
       });

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -394,6 +394,7 @@ namespace umbriel {
         bool blur = false;
         double scale = 0.0;
         bool maximize = false;
+        bool maximizeToEdges = false;
         bool fullscreen = false;
         bool operator==(const Scratchpad&) const = default;
       } scratchpad;

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -153,6 +153,7 @@ namespace umbriel {
     // Compositor-driven fullscreen toggle (keybind); client requests use handleRequestFullscreen.
     void toggleFullscreen();
     void applyDeferredUnfullscreen();
+    void setMaximized(bool maximized);
     void setMaximizedToEdges(bool maximized);
     void toggleMaximizedToEdges();
     // Detach from the scrolling layout (float) or re-insert as a tiled column.
@@ -179,6 +180,7 @@ namespace umbriel {
     friend class Server;
     friend class Popup;
     friend class Overview;
+    friend class ScratchpadManager;
 
     struct OpacitySurfaceWatch {
       View* view = nullptr;
@@ -215,7 +217,6 @@ namespace umbriel {
     void handleRequestMove();
     void handleRequestResize(void* data);
     void handleRequestMaximize();
-    void setMaximized(bool maximized);
     void handleRequestFullscreen();
     void setFullscreen(bool fullscreen);
     void handleSetTitle();

--- a/src/workspace/scratchpad.cpp
+++ b/src/workspace/scratchpad.cpp
@@ -105,6 +105,9 @@ namespace umbriel {
     if (view->maximizedToEdges()) {
       view->setMaximizedToEdges(false);
     }
+    if (view->toplevel()->scheduled.maximized || view->toplevel()->current.maximized) {
+      view->setMaximized(false);
+    }
     view->setFloating(true);
     view->cancelPositionAnimation();
 
@@ -117,8 +120,19 @@ namespace umbriel {
       if (!view->toplevel()->scheduled.fullscreen && !view->toplevel()->current.fullscreen) {
         view->toggleFullscreen();
       }
+    } else if (spCfg.maximizeToEdges) {
+      view->setMaximizedToEdges(true);
     } else if (spCfg.maximize) {
-      view->toggleMaximizedToEdges();
+      // Size to usable area minus one layout gap per side. No Wayland maximize state:
+      // some clients strip their own chrome in response and that looks wrong here.
+      const int gap = config().layoutGap();
+      if (gap >= 0 && targetArea.width > 2 * gap && targetArea.height > 2 * gap) {
+        view->requestFloatingSize(targetArea.width - 2 * gap, targetArea.height - 2 * gap);
+        view->setPosition(targetArea.x + gap, targetArea.y + gap);
+      } else {
+        view->requestFloatingSize(targetArea.width, targetArea.height);
+        view->setPosition(targetArea.x, targetArea.y);
+      }
     } else if (spCfg.scale > 0.0 && spCfg.scale <= 1.0 && targetArea.width > 0 && targetArea.height > 0) {
       const int targetW = std::max(100, static_cast<int>(std::lround(targetArea.width * spCfg.scale)));
       const int targetH = std::max(100, static_cast<int>(std::lround(targetArea.height * spCfg.scale)));

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -954,6 +954,8 @@ curve = "custom"
 [animation.scratchpad]
 dim = 0.4
 blur = true
+maximize = true
+maximize_to_edges = true
 )");
 
   ConfigStore& store = umbriel::configStore();
@@ -978,6 +980,8 @@ blur = true
   CHECK_EQ(animation.windowsMove.durationMs, 320);
   CHECK_EQ(animation.scratchpad.dim, 0.4);
   CHECK(animation.scratchpad.blur);
+  CHECK(animation.scratchpad.maximize);
+  CHECK(animation.scratchpad.maximizeToEdges);
 
   file.write(R"(
 [appearance.animations]


### PR DESCRIPTION
## Summary

Adds two distinct options for sizing and state when a window enters the scratchpad:
- `maximize`: standard maximization to the usable area while keeping window borders, shadows, and title decorations visible.
- `maximize_to_edges`: edge-to-edge maximization with window borders and decorations disabled.

Prior to this change, setting `maximize = true` in `[animation.scratchpad]` triggered `toggleMaximizedToEdges()`, which stripped decorations unexpectedly. This split makes the naming accurate and gives users the choice between regular maximize and edge-to-edge mode.

## Motivation

The previous `maximize` option in scratchpad configuration was misleading because it actually invoked maximize-to-edges, removing all window borders. Having both options allows users to choose whether scratchpad windows should keep their decorations or expand borderless to screen edges.

## Type of Change

- [x] New feature
- [x] Documentation

## Testing

- Ran full Meson unit test suite (`just test`): 25/25 passed.
- Ran headless compositor test harness (`just check scratchpad`): 2/2 passed.
- Formatted all files with `just format`.

## Manual Coverage

- [x] Tested in a nested Umbriel session
- [x] Tested with native Wayland applications
- [x] Tested with the scrolling layout

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`.
- [x] I ran the relevant build, test, lint, or verification commands.
- [x] I functionally verified compositor behavior in a nested session.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.