### PR TITLE
feat(rules): allow default_width and default_height to fraction-size floating windows

### DIFF
--- a/docs/user/rules.md
+++ b/docs/user/rules.md
@@ -43,7 +43,8 @@ opening settings do not overwrite user changes made in the meantime.
 | `default_floating` | bool | Force floating (`true`) or force tiling (`false`). |
 | `default_size` | `[w, h]` | Initial size in pixels, clamped to the client's min/max hints. Floats use both, then own their size and honor client resizes; tiled windows ignore height. |
 | `default_position` | table | Initial position for floating windows: `{ x = int, y = int, anchor = string }`. Ignored for tiled windows. |
-| `default_width` | float | Scrolling only. Lane scroll-axis extent fraction (0.1-1.0), which is height on a vertical workspace. Gap-aware: fractions that sum to 1 tile exactly. Overrides `layout.scrolling.default_width_fraction`. Dragging the lane within or between scrolling workspaces retains its current fraction. Ignored in dwindle and master. |
+| `default_width` | float | Two meanings. Tiled:- lane scroll-axis extent fraction (0.1-1.0) for the scrolling layout, which is height on a vertical workspace, gap-aware; overrides `layout.scrolling.default_width_fraction`, dragging the lane within or between scrolling workspaces retains its current fraction; ignored in dwindle and master. Floating:- initial width as a fraction of the usable area. |
+| `default_height` | float | Initial height for floating windows as a fraction of the usable area (0.1-1.0). Ignored for tiled windows. |
 | `default_workspace` | int | Place on workspace N from 1 to 64. On dynamic outputs, values beyond the current count clamp to the last workspace. |
 | `default_fullscreen` | bool | Open in fullscreen. |
 | `default_maximize_to_edges` | bool | Explicitly open maximized to edges, expanding the window to the usable area's edges without gaps or borders. Layer-shell exclusive zones stay visible. Takes precedence over `default_maximize`; when combined with `default_fullscreen` the window opens fullscreen and returns to maximized to edges once fullscreen is cleared. |
@@ -54,6 +55,10 @@ opening settings do not overwrite user changes made in the meantime.
 If neither `default_width` nor a matching
 `layout.scrolling.default_width_fraction` is set, a scrolling window chooses
 its initial logical extent.
+
+For floating windows, when both `default_size` and the fractions are set, the
+pixel pair wins entirely, otherwise each axis falls back independently — its
+fraction if present, else the client's own choice.
 
 Without `default_output`, a numbered workspace owned by exactly one fixed output
 inventory also selects that output. For example, if only `DP-1` has a fourth

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -337,6 +337,13 @@ match.app_id = "^dev.noctalia.UmbrielSharePicker$"
 default_floating = true
 default_size = [800, 600]
 
+# Float ghostty at half the screen's width and sixty percent of its height
+[[window_rule]]
+match.app_id = "^com\\.mitchellh\\.ghostty$"
+default_floating = true
+default_width = 0.5
+default_height = 0.6
+
 # [[window_rule]]
 # match.app_id = "firefox"
 # match.title = "^Library$"

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1485,18 +1485,22 @@ namespace umbriel {
           }
         }
 
-        if (const toml::node* n = keys.take("default_width")) {
-          const auto value = n->value<double>();
-          if (!value || std::isnan(*value)) {
-            warnAt(n->source(), "ignoring window_rule.default_width (expected number 0.1-1.0)");
-          } else {
-            const double used = std::clamp(*value, 0.1, 1.0);
-            if (used != *value) {
-              warnAt(n->source(), "window_rule.default_width = {} out of range, clamped to {}", *value, used);
+        const auto readRuleFraction = [&](const std::string_view key, std::optional<double>& target) {
+          if (const toml::node* n = keys.take(key)) {
+            const auto value = n->value<double>();
+            if (!value || std::isnan(*value)) {
+              warnAt(n->source(), "ignoring window_rule.{} (expected number 0.1-1.0)", key);
+            } else {
+              const double used = std::clamp(*value, 0.1, 1.0);
+              if (used != *value) {
+                warnAt(n->source(), "window_rule.{} = {} out of range, clamped to {}", key, *value, used);
+              }
+              target = used;
             }
-            rule.defaultWidth = used;
           }
-        }
+        };
+        readRuleFraction("default_width", rule.defaultWidth);
+        readRuleFraction("default_height", rule.defaultHeight);
 
         if (const toml::node* n = keys.take("default_workspace")) {
           const auto value = n->value<std::int64_t>();

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -194,6 +194,7 @@ namespace umbriel {
     std::optional<std::array<int, 2>> defaultSize; // [width, height]
     std::optional<WindowPosition> defaultPosition;
     std::optional<double> defaultWidth;  // column width fraction override
+    std::optional<double> defaultHeight; // usable-area height fraction override
     std::optional<int> defaultWorkspace; // 1-64
     std::optional<bool> defaultFullscreen;
     std::optional<bool> defaultMaximizeToEdges;
@@ -223,6 +224,7 @@ namespace umbriel {
           && defaultSize == other.defaultSize
           && defaultPosition == other.defaultPosition
           && defaultWidth == other.defaultWidth
+          && defaultHeight == other.defaultHeight
           && defaultWorkspace == other.defaultWorkspace
           && defaultFullscreen == other.defaultFullscreen
           && defaultMaximizeToEdges == other.defaultMaximizeToEdges
@@ -248,6 +250,7 @@ namespace umbriel {
     std::optional<std::array<int, 2>> defaultSize;
     std::optional<WindowPosition> defaultPosition;
     std::optional<double> defaultWidth;
+    std::optional<double> defaultHeight;
     std::optional<int> defaultWorkspace;
     std::optional<bool> defaultFullscreen;
     std::optional<bool> defaultMaximizeToEdges;

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -146,6 +146,9 @@ namespace umbriel {
       if (rule.defaultWidth) {
         resolved.defaultWidth = rule.defaultWidth;
       }
+      if (rule.defaultHeight) {
+        resolved.defaultHeight = rule.defaultHeight;
+      }
       if (rule.defaultWorkspace) {
         resolved.defaultWorkspace = rule.defaultWorkspace;
       }

--- a/src/view/floating.h
+++ b/src/view/floating.h
@@ -6,6 +6,7 @@ extern "C" {
 }
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <optional>
 
@@ -68,6 +69,25 @@ namespace umbriel {
     return {
         .x = usable.x + (usable.width - width) / 2,
         .y = usable.y + (usable.height - height) / 2,
+    };
+  }
+
+  struct FloatingInitialSize {
+    int width;
+    int height;
+  };
+
+  // Fractions arrive pre-clamped to [0.1, 1.0] by the rule parser.
+  [[nodiscard]] inline FloatingInitialSize floatingInitialSize(
+      const std::optional<std::array<int, 2>>& sizePx, std::optional<double> widthFraction,
+      std::optional<double> heightFraction, const wlr_box& usable
+  ) {
+    const auto extent = [](const std::optional<double>& fraction, int available) {
+      return fraction && available > 0 ? static_cast<int>(std::lround(*fraction * static_cast<double>(available))) : 0;
+    };
+    return {
+        .width = sizePx ? (*sizePx)[0] : extent(widthFraction, usable.width),
+        .height = sizePx ? (*sizePx)[1] : extent(heightFraction, usable.height),
     };
   }
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1870,7 +1870,11 @@ namespace umbriel {
         if (rule.defaultSize || rule.defaultWidth || rule.defaultHeight) {
           const FloatingInitialSize initial =
               floatingInitialSize(rule.defaultSize, rule.defaultWidth, rule.defaultHeight, usable);
-          requestFloatingSize(clampXdgWidth(initial.width, hints), clampXdgHeight(initial.height, hints));
+          // A 0 axis from floatingInitialSize means "leave it to the client"; only decided sizes are clamped.
+          requestFloatingSize(
+              initial.width > 0 ? clampXdgWidth(initial.width, hints) : 0,
+              initial.height > 0 ? clampXdgHeight(initial.height, hints) : 0
+          );
         } else {
           requestFloatingSize(0, 0);
         }
@@ -2560,7 +2564,11 @@ namespace umbriel {
       const XdgSizeHints hints = xdgSizeHints(m_toplevel);
       const FloatingInitialSize initial =
           floatingInitialSize(rule.defaultSize, rule.defaultWidth, rule.defaultHeight, floatingUsableArea());
-      requestFloatingSize(clampXdgWidth(initial.width, hints), clampXdgHeight(initial.height, hints));
+      // A 0 axis from floatingInitialSize means "leave it to the client"; only decided sizes are clamped.
+      requestFloatingSize(
+          initial.width > 0 ? clampXdgWidth(initial.width, hints) : 0,
+          initial.height > 0 ? clampXdgHeight(initial.height, hints) : 0
+      );
       placeInUsableArea();
     }
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1826,6 +1826,17 @@ namespace umbriel {
           m_toplevel, wantTiled ? WLR_EDGE_TOP | WLR_EDGE_RIGHT | WLR_EDGE_BOTTOM | WLR_EDGE_LEFT : 0
       );
 
+      // Usable area is resolved once and shared by the tiled and floating branches below.
+      wlr_box usable = targetOutput != nullptr
+          ? targetOutput->usableArea()
+          : m_server->usableAreaAt(m_server->cursor()->wlr()->x, m_server->cursor()->wlr()->y);
+      if (targetOutput != nullptr && (usable.width <= 0 || usable.height <= 0)) {
+        wlr_output_layout_get_box(m_server->outputLayout(), targetOutput->wlr(), &usable);
+      }
+      if (usable.width <= 0 || usable.height <= 0) {
+        usable = m_server->usableAreaAt(m_server->cursor()->wlr()->x, m_server->cursor()->wlr()->y);
+      }
+
       if (m_toplevel->requested.fullscreen) {
         // xwayland-satellite can request fullscreen while creating the xdg role, before the initial surface commit.
         // The request event is too early to configure, but wlroots preserves it in requested state for us to honor now.
@@ -1839,15 +1850,6 @@ namespace umbriel {
           wlr_xdg_toplevel_set_size(m_toplevel, fullArea.width, fullArea.height);
         }
       } else if (wantTiled) {
-        wlr_box usable = targetOutput != nullptr
-            ? targetOutput->usableArea()
-            : m_server->usableAreaAt(m_server->cursor()->wlr()->x, m_server->cursor()->wlr()->y);
-        if (targetOutput != nullptr && (usable.width <= 0 || usable.height <= 0)) {
-          wlr_output_layout_get_box(m_server->outputLayout(), targetOutput->wlr(), &usable);
-        }
-        if (usable.width <= 0 || usable.height <= 0) {
-          usable = m_server->usableAreaAt(m_server->cursor()->wlr()->x, m_server->cursor()->wlr()->y);
-        }
 
         // No workspace yet (no output, or none active): fall back to a throwaway layout built from the global config,
         // so the sizing rule stays the layout's either way.
@@ -1865,10 +1867,10 @@ namespace umbriel {
         wlr_xdg_toplevel_set_size(m_toplevel, width, initial.height);
       } else {
         const XdgSizeHints hints = xdgSizeHints(m_toplevel);
-        if (rule.defaultSize) {
-          requestFloatingSize(
-              clampXdgWidth((*rule.defaultSize)[0], hints), clampXdgHeight((*rule.defaultSize)[1], hints)
-          );
+        if (rule.defaultSize || rule.defaultWidth || rule.defaultHeight) {
+          const FloatingInitialSize initial =
+              floatingInitialSize(rule.defaultSize, rule.defaultWidth, rule.defaultHeight, usable);
+          requestFloatingSize(clampXdgWidth(initial.width, hints), clampXdgHeight(initial.height, hints));
         } else {
           requestFloatingSize(0, 0);
         }
@@ -2551,9 +2553,14 @@ namespace umbriel {
       }
     }
 
-    if (changedInitialRule(rule.defaultSize, initiallyApplied.defaultSize) && !m_tiled) {
+    const bool floatSizingChanged = changedInitialRule(rule.defaultSize, initiallyApplied.defaultSize)
+        || changedInitialRule(rule.defaultWidth, initiallyApplied.defaultWidth)
+        || changedInitialRule(rule.defaultHeight, initiallyApplied.defaultHeight);
+    if (floatSizingChanged && !m_tiled) {
       const XdgSizeHints hints = xdgSizeHints(m_toplevel);
-      requestFloatingSize(clampXdgWidth((*rule.defaultSize)[0], hints), clampXdgHeight((*rule.defaultSize)[1], hints));
+      const FloatingInitialSize initial =
+          floatingInitialSize(rule.defaultSize, rule.defaultWidth, rule.defaultHeight, floatingUsableArea());
+      requestFloatingSize(clampXdgWidth(initial.width, hints), clampXdgHeight(initial.height, hints));
       placeInUsableArea();
     }
 

--- a/tests/harness/checks/146_floating_rule_fraction.sh
+++ b/tests/harness/checks/146_floating_rule_fraction.sh
@@ -66,6 +66,11 @@ default_floating = true
 default_size = [600, 400]
 default_width = 0.9
 default_height = 0.9
+
+[[window_rule]]
+match.app_id = "^float-half$"
+default_floating = true
+default_width = 0.5
 EOF
 "$UMBRIEL" msg config-reload > /dev/null
 
@@ -90,8 +95,16 @@ APP_ID=float-pixel "$CLIENT" "float-pixel" > "$UMBRIEL_RUNTIME_DIR/pixel.log" 2>
 poll_geometry "float-pixel" "600x400"
 expect_floating "float-pixel"
 
+# A single width fraction must size that axis and leave the other to the client:
+# subsurface-client keeps its default 480 height when a configure sends 0.
+readonly HALF_SIZE="$(round_scaled "$full_w" 0.5)x480"
+APP_ID=float-half "$CLIENT" "float-half" > "$UMBRIEL_RUNTIME_DIR/half.log" 2>&1 &
+poll_geometry "float-half" "$HALF_SIZE"
+expect_floating "float-half"
+
 # Opening later windows must not disturb either rule's outcome.
 poll_geometry "float-full" "$FULL_SIZE"
 poll_geometry "float-fraction" "$FRACTION_SIZE"
+poll_geometry "float-half" "$HALF_SIZE"
 
-echo "fractions sized from a ${FULL_SIZE} usable area -> $FRACTION_SIZE; pixels kept 600x400"
+echo "fractions sized from a ${FULL_SIZE} usable area -> $FRACTION_SIZE; pixels kept 600x400; unset axis left to client -> $HALF_SIZE"

--- a/tests/harness/checks/146_floating_rule_fraction.sh
+++ b/tests/harness/checks/146_floating_rule_fraction.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Floating windows open at fractions of the usable area when their rule carries
+# default_width/default_height, and pixel default_size beats those fractions.
+# A full-extent probe calibrates the usable area instead of hardcoding it.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_SUBSURFACE_CLIENT:-./build-debug/subsurface-client}"
+
+geometry() {
+  local title=$1
+  "$UMBRIEL" windows --json | jq -r --arg title "$title" '.[] | select(.title == $title) | "\(.w)x\(.h)"'
+}
+
+poll_geometry() {
+  local title=$1 expected=${2:-} previous=""
+  for _ in $(seq 60); do
+    local current
+    current=$(geometry "$title")
+    if [[ -n $expected ]]; then
+      [[ $current == "$expected" ]] && return 0
+    elif [[ -n $current && $current == "$previous" ]]; then
+      echo "$current"
+      return 0
+    fi
+    previous=$current
+    sleep 0.1
+  done
+  if [[ -n $expected ]]; then
+    echo "expected $title sized $expected, got: $("$UMBRIEL" windows --json)"
+  else
+    echo "geometry never stabilized for $title" >&2
+  fi
+  return 1
+}
+
+expect_floating() {
+  local title=$1 floating
+  floating=$("$UMBRIEL" windows --json | jq -r --arg title "$title" '.[] | select(.title == $title) | .floating')
+  if [[ $floating != true ]]; then
+    echo "expected $title to be floating: $("$UMBRIEL" windows --json)"
+    return 1
+  fi
+}
+
+round_scaled() {
+  awk -v extent="$1" -v factor="$2" 'BEGIN { printf "%d", int(factor * extent + 0.5) }'
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[[window_rule]]
+match.app_id = "^float-full$"
+default_floating = true
+default_width = 1.0
+default_height = 1.0
+
+[[window_rule]]
+match.app_id = "^float-fraction$"
+default_floating = true
+default_width = 0.5
+default_height = 0.6
+
+[[window_rule]]
+match.app_id = "^float-pixel$"
+default_floating = true
+default_size = [600, 400]
+default_width = 0.9
+default_height = 0.9
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+APP_ID=float-full "$CLIENT" "float-full" > "$UMBRIEL_RUNTIME_DIR/full.log" 2>&1 &
+readonly FULL_SIZE=$(poll_geometry "float-full")
+full_w=${FULL_SIZE%x*}
+full_h=${FULL_SIZE#*x}
+if ((full_w <= 0 || full_h <= 0)); then
+  echo "calibration probe reported unusable extents: $FULL_SIZE"
+  exit 1
+fi
+
+expect_floating "float-full"
+readonly FRACTION_SIZE="$(round_scaled "$full_w" 0.5)x$(round_scaled "$full_h" 0.6)"
+
+APP_ID=float-fraction "$CLIENT" "float-fraction" > "$UMBRIEL_RUNTIME_DIR/fraction.log" 2>&1 &
+poll_geometry "float-fraction" "$FRACTION_SIZE"
+expect_floating "float-fraction"
+
+# Pixels win wherever default_size is present, even alongside fractions.
+APP_ID=float-pixel "$CLIENT" "float-pixel" > "$UMBRIEL_RUNTIME_DIR/pixel.log" 2>&1 &
+poll_geometry "float-pixel" "600x400"
+expect_floating "float-pixel"
+
+# Opening later windows must not disturb either rule's outcome.
+poll_geometry "float-full" "$FULL_SIZE"
+poll_geometry "float-fraction" "$FRACTION_SIZE"
+
+echo "fractions sized from a ${FULL_SIZE} usable area -> $FRACTION_SIZE; pixels kept 600x400"

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -1,4 +1,5 @@
 #include "check.h"
+#include "config/resolve.h"
 #include "config/store.h"
 
 #include <cstdlib>
@@ -1014,6 +1015,48 @@ UMBRIEL_TEST(packagedAnimationDefaultsMatchCompiledDefaults) {
 
   CHECK(result.success);
   CHECK(store.config().animation == umbriel::Config{}.animation);
+}
+
+UMBRIEL_TEST(windowRulesParseFractionalSizesClampAndOverride) {
+  const TempConfig file;
+  file.write(R"(
+[[window_rule]]
+match.app_id = "^util$"
+default_floating = true
+default_width = 0.5
+default_height = 0.6
+
+[[window_rule]]
+default_height = 3.5
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+  const umbriel::ConfigReloadResult result = store.reload();
+
+  CHECK(result.success);
+  CHECK_EQ(store.config().windowRules.size(), size_t{2});
+  const umbriel::WindowRule& sized = store.config().windowRules[0];
+  CHECK(sized.defaultFloating.value_or(false));
+  CHECK(sized.defaultWidth.has_value());
+  CHECK_EQ(*sized.defaultWidth, 0.5);
+  CHECK(sized.defaultHeight.has_value());
+  CHECK_EQ(*sized.defaultHeight, 0.6);
+  const umbriel::WindowRule& overRange = store.config().windowRules[1];
+  CHECK(!overRange.defaultWidth.has_value());
+  CHECK(overRange.defaultHeight.has_value());
+  CHECK_EQ(*overRange.defaultHeight, 1.0);
+  CHECK(containsDiagnostic(store, "window_rule.default_height = 3.5 out of range, clamped to 1"));
+  CHECK(!containsDiagnostic(store, "unknown key window_rule.default_height"));
+
+  // The second rule has no matchers, so it matches everything and must override default_height while leaving the
+  // fields it never set untouched.
+  const umbriel::ResolvedWindowRule resolved = umbriel::resolveWindowRules(store.config(), "util", "", false);
+  CHECK(resolved.defaultFloating.value_or(false));
+  CHECK(resolved.defaultWidth.has_value());
+  CHECK_EQ(*resolved.defaultWidth, 0.5);
+  CHECK(resolved.defaultHeight.has_value());
+  CHECK_EQ(*resolved.defaultHeight, 1.0);
 }
 
 int main() { return RUN_TESTS(); }

--- a/tests/unit/floating.cpp
+++ b/tests/unit/floating.cpp
@@ -6,6 +6,8 @@ using umbriel::anchoredContentOrigin;
 using umbriel::centeredOrigin;
 using umbriel::clampFloatingOrigin;
 using umbriel::FloatingGeometry;
+using umbriel::floatingInitialSize;
+using umbriel::FloatingInitialSize;
 using umbriel::floatingKeepVisible;
 using umbriel::FloatingPoint;
 using umbriel::serialSettled;
@@ -249,6 +251,49 @@ UMBRIEL_TEST(centeringHonoursAnOffsetUsableArea) {
   const FloatingPoint origin = centeredOrigin(usable, 800, 600);
   CHECK_EQ(origin.x, 1920 + 560);
   CHECK_EQ(origin.y, 40 + 220);
+}
+
+// Rule-driven initial sizing
+UMBRIEL_TEST(fractionsTurnIntoPixelsOfTheUsableArea) {
+  const FloatingInitialSize sized = floatingInitialSize(std::nullopt, 0.5, 0.6, kUsable);
+  CHECK_EQ(sized.width, 960);
+  CHECK_EQ(sized.height, 648);
+}
+
+UMBRIEL_TEST(fractionsRoundHalfAwayFromZero) {
+  const wlr_box portrait{0, 0, 1000, 1081};
+  const FloatingInitialSize sized = floatingInitialSize(std::nullopt, 1.0 / 3, 0.333, portrait);
+  CHECK_EQ(sized.width, 333);  // 333.333 stays
+  CHECK_EQ(sized.height, 360); // 359.973 rounds up
+}
+
+UMBRIEL_TEST(pixelDefaultsBeatFractions) {
+  const auto sized = floatingInitialSize(std::array<int, 2>{800, 600}, 0.9, 0.9, kUsable);
+  CHECK_EQ(sized.width, 800);
+  CHECK_EQ(sized.height, 600);
+}
+
+UMBRIEL_TEST(anUnsetAxisIsLeftToTheClient) {
+  const auto halfWidth = floatingInitialSize(std::nullopt, 0.5, std::nullopt, kUsable);
+  CHECK_EQ(halfWidth.width, 960);
+  CHECK_EQ(halfWidth.height, 0);
+
+  const auto untouched = floatingInitialSize(std::nullopt, std::nullopt, std::nullopt, kUsable);
+  CHECK_EQ(untouched.width, 0);
+  CHECK_EQ(untouched.height, 0);
+}
+
+UMBRIEL_TEST(aDegenerateAxisLeavesOnlyThatAxisToTheClient) {
+  // Width has no extent to scale against, but the height fraction still applies to its own valid extent.
+  const FloatingInitialSize sized = floatingInitialSize(std::nullopt, 0.5, 0.6, {10, 10, 0, 480});
+  CHECK_EQ(sized.width, 0);
+  CHECK_EQ(sized.height, 288);
+}
+
+UMBRIEL_TEST(anEmptyUsableAreaLeavesEveryAxisToTheClient) {
+  const FloatingInitialSize sized = floatingInitialSize(std::nullopt, 0.5, 0.6, wlr_box{});
+  CHECK_EQ(sized.width, 0);
+  CHECK_EQ(sized.height, 0);
 }
 
 int main() { return RUN_TESTS(); }


### PR DESCRIPTION
## Summary

This PR allows default_width to fractional size floating windows and add default_height too. 

- `default_height`:- new key:- initial floating height as a usable-area fraction (0.1–1.0).
- `default_width` reused for floats as the initial width fraction
- Backwards-compatible precedence:- `default_size` as a whole pixel pair when present, otherwise each axis independently uses its fraction, else the client decides.

Example:-
[[window_rule]]
match.app_id = "^com\\.mitchellh\\.ghostty$"
default_floating = true
default_width = 0.5
default_height = 0.6

## Motivation

Let user configure their windows width height etc for floating using fraction. Independent width/height fractions make floating sizing flexible, matching how tiled widths already work.

## Type of Change

- [x] New feature

## Related Issue

From discord

## Testing

- `just format && just lint && just test` all passed.
- `just check` 146 - new harness check pass
- `just check 145 150 151 160 235` - regression slice of neighboring sizing/float/maximize behavior, all pass.
- Build the branch for native testing and everything seems good.

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos


https://github.com/user-attachments/assets/c5e79e7d-6f52-4720-9a70-c35cc1801444


## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`.
- [x] I ran the relevant build, test, lint, or verification commands.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
