### PR TITLE
feat(input): disable_while_typing

### DIFF
--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -59,12 +59,16 @@ tap = true
 natural_scroll = true
 # accel_profile = "adaptive"  # "flat", "adaptive", or a custom curve
 # sensitivity = 0.5           # -1.0 to 1.0
+# disable_while_typing = true
 ```
 
 Tap-to-click is enabled by default. Set `tap = false` to disable it globally,
-or use a per-device override below. `natural_scroll` remains unset by default,
-which preserves each device's libinput setting. Options are applied only when
-supported by the device.
+or use a per-device override below. `natural_scroll` and
+`disable_while_typing` remain unset by default, which preserves each device's
+corresponding libinput default. Set `disable_while_typing = false` to keep the
+touchpad active while typing. Removing either optional setting on reload
+restores the device default. Options are applied only when supported by the
+device; an explicitly configured unsupported option is reported in the log.
 
 `accel_profile` and `sensitivity` work like their `[input.mouse]` counterparts,
 including custom curves. Both remain unset by default, which uses each
@@ -121,6 +125,7 @@ tap = true
 natural_scroll = false
 accel_profile = "flat"
 sensitivity = 0.0
+disable_while_typing = false
 
 [[input.device]]
 name = "Acme Gaming Mouse"
@@ -130,10 +135,11 @@ sensitivity = 0.0
 
 Each rule inherits the matching class settings and overrides only the keys it
 contains. `layout`, `variant`, `options`, `repeat_rate`, and `repeat_delay`
-apply to keyboards. `tap` applies to touchpads. `natural_scroll` applies to
-touchpads and mice. `accel_profile` and `sensitivity` apply to mice and
-touchpads; for a touchpad the rule overrides `[input.touchpad]` rather than
-`[input.mouse]`. Unsupported libinput settings are reported in the log.
+apply to keyboards. `tap` and `disable_while_typing` apply to touchpads.
+`natural_scroll` applies to touchpads and mice. `accel_profile` and
+`sensitivity` apply to mice and touchpads; for a touchpad the rule overrides
+`[input.touchpad]` rather than `[input.mouse]`. Unsupported libinput settings
+are reported in the log.
 
 Rules match every attached device with the exact name. Device overrides also
 apply when a device is connected after startup and when the configuration is

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -219,6 +219,7 @@ tap = true                      # enabled by default; false disables tap-to-clic
 # natural_scroll = true
 # accel_profile = "adaptive"    # "flat", "adaptive", or "custom <step> <points...>"
 # sensitivity = 0.5             # pointer speed, -1.0 to 1.0
+# disable_while_typing = true   # omitted preserves the device's libinput default
 
 [input.mouse]
 # natural_scroll = false
@@ -227,15 +228,16 @@ sensitivity = 0.0              # pointer speed, -1.0 to 1.0
 scroll_wheel_step = 60         # 1-1000
 # Override only the listed settings for an exact, case-sensitive device name.
 # Applies per device kind: layout, variant, options, repeat_rate, and
-# repeat_delay to keyboards; tap to touchpads; natural_scroll, accel_profile,
-# and sensitivity to touchpads and mice. Find names with
-# `libinput list-devices`.
+# repeat_delay to keyboards; tap and disable_while_typing to touchpads;
+# natural_scroll, accel_profile, and sensitivity to touchpads and mice.
+# Find names with `libinput list-devices`.
 # [[input.device]]
 # name = "Acme Precision Touchpad"
 # tap = true
 # natural_scroll = false
 # accel_profile = "flat"
 # sensitivity = 0.0
+# disable_while_typing = false
 # [[input.device]]
 # name = "Gaming Mouse"
 # accel_profile = "flat"

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -981,7 +981,8 @@ namespace umbriel {
             .integer("repeat_delay", 0, 10000, device.repeatDelay)
             .boolean("tap", device.tap)
             .boolean("natural_scroll", device.naturalScroll)
-            .real("sensitivity", -1.0, 1.0, device.sensitivity);
+            .real("sensitivity", -1.0, 1.0, device.sensitivity)
+            .boolean("disable_while_typing", device.disableWhileTyping);
         device.accelProfile = readAccelProfile(keys, "accel_profile", "input.device");
 
         if (!validName) {
@@ -1036,7 +1037,8 @@ namespace umbriel {
         s.sub("touchpad", [&](Section& t) {
           t.boolean("tap", in.touchpad.tap)
               .boolean("natural_scroll", in.touchpad.naturalScroll)
-              .real("sensitivity", -1.0, 1.0, in.touchpad.sensitivity);
+              .real("sensitivity", -1.0, 1.0, in.touchpad.sensitivity)
+              .boolean("disable_while_typing", in.touchpad.disableWhileTyping);
           in.touchpad.accelProfile = readAccelProfile(t, "accel_profile", "input.touchpad");
         });
         s.sub("mouse", [&](Section& m) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -525,6 +525,7 @@ namespace umbriel {
         std::optional<bool> naturalScroll;
         std::optional<AccelProfile> accelProfile;
         std::optional<double> sensitivity;
+        std::optional<bool> disableWhileTyping;
         bool operator==(const Touchpad&) const = default;
       } touchpad;
 
@@ -575,6 +576,7 @@ namespace umbriel {
         std::optional<bool> naturalScroll;
         std::optional<AccelProfile> accelProfile;
         std::optional<double> sensitivity;
+        std::optional<bool> disableWhileTyping;
         bool operator==(const Device&) const = default;
       };
 

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -276,31 +276,30 @@ namespace umbriel {
           );
         }
 
-        const std::optional<bool> dwt = override != nullptr && override->disableWhileTyping
-            ? override->disableWhileTyping
-            : input.touchpad.disableWhileTyping;
-        if (dwt) {
-          if (libinput_device_config_dwt_is_available(libinputDevice)) {
-            const auto dwtState =
-                dwt.value_or(libinput_device_config_dwt_get_default_enabled(libinputDevice) == LIBINPUT_CONFIG_DWT_ENABLED)
-                ? LIBINPUT_CONFIG_DWT_ENABLED
-                : LIBINPUT_CONFIG_DWT_DISABLED;
-            if (libinput_device_config_dwt_set_enabled(libinputDevice, dwtState) != LIBINPUT_CONFIG_STATUS_SUCCESS) {
-              kLog.warn(
-                  "input: failed to apply {} to '{}'",
-                  override != nullptr && override->disableWhileTyping ? "input.device.disable_while_typing"
-                                                                       : "input.touchpad.disable_while_typing",
-                  deviceName(device)
-              );
+        const bool hasDwtOverride = override != nullptr && override->disableWhileTyping.has_value();
+        const std::optional<bool>& dwt =
+            hasDwtOverride ? override->disableWhileTyping : input.touchpad.disableWhileTyping;
+        const std::string_view dwtSetting =
+            hasDwtOverride ? "input.device.disable_while_typing" : "input.touchpad.disable_while_typing";
+        if (libinput_device_config_dwt_is_available(libinputDevice)) {
+          const auto dwtState =
+              dwt.value_or(
+                  libinput_device_config_dwt_get_default_enabled(libinputDevice) == LIBINPUT_CONFIG_DWT_ENABLED
+              )
+              ? LIBINPUT_CONFIG_DWT_ENABLED
+              : LIBINPUT_CONFIG_DWT_DISABLED;
+          if (libinput_device_config_dwt_set_enabled(libinputDevice, dwtState) != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+            if (dwt) {
+              kLog.warn("input: failed to apply {} to '{}'", dwtSetting, deviceName(device));
+            } else {
+              kLog.warn("input: failed to restore default disable-while-typing for '{}'", deviceName(device));
             }
-          } else {
-            kLog.warn(
-                "input: could not apply {} to '{}': device does not support disable-when-typing",
-                override != nullptr && override->disableWhileTyping ? "input.device.disable_while_typing"
-                                                                     : "input.touchpad.disable_while_typing",
-                deviceName(device)
-            );
           }
+        } else if (dwt) {
+          kLog.warn(
+              "input: could not apply {} to '{}': device does not support disable-while-typing", dwtSetting,
+              deviceName(device)
+          );
         }
       }
 

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -275,6 +275,33 @@ namespace umbriel {
               override != nullptr && override->tap ? "input.device.tap" : "input.touchpad.tap", deviceName(device)
           );
         }
+
+        const std::optional<bool> dwt = override != nullptr && override->disableWhileTyping
+            ? override->disableWhileTyping
+            : input.touchpad.disableWhileTyping;
+        if (dwt) {
+          if (libinput_device_config_dwt_is_available(libinputDevice)) {
+            const auto dwtState =
+                dwt.value_or(libinput_device_config_dwt_get_default_enabled(libinputDevice) == LIBINPUT_CONFIG_DWT_ENABLED)
+                ? LIBINPUT_CONFIG_DWT_ENABLED
+                : LIBINPUT_CONFIG_DWT_DISABLED;
+            if (libinput_device_config_dwt_set_enabled(libinputDevice, dwtState) != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+              kLog.warn(
+                  "input: failed to apply {} to '{}'",
+                  override != nullptr && override->disableWhileTyping ? "input.device.disable_while_typing"
+                                                                       : "input.touchpad.disable_while_typing",
+                  deviceName(device)
+              );
+            }
+          } else {
+            kLog.warn(
+                "input: could not apply {} to '{}': device does not support disable-when-typing",
+                override != nullptr && override->disableWhileTyping ? "input.device.disable_while_typing"
+                                                                     : "input.touchpad.disable_while_typing",
+                deviceName(device)
+            );
+          }
+        }
       }
 
       const std::optional<bool>& naturalScroll = override != nullptr && override->naturalScroll

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -80,6 +80,12 @@ UMBRIEL_TEST(eachSectionIsReportedOnItsOwn) {
   }
   {
     Config after;
+    after.input.touchpad.disableWhileTyping = false;
+    CHECK(ConfigChange::between(before, after).input);
+    CHECK(ConfigEffects::between(before, after).input);
+  }
+  {
+    Config after;
     after.input.middleClickPaste = !after.input.middleClickPaste;
     const ConfigChange change = ConfigChange::between(before, after);
     CHECK(change.input);

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -695,6 +695,7 @@ tap = true
 natural_scroll = true
 accel_profile = "adaptive"
 sensitivity = 0.1
+disable_while_typing = true
 
 [input.mouse]
 accel_profile = "custom 0.2 0.0 0.5 1.0 2.0"
@@ -713,6 +714,7 @@ tap = false
 natural_scroll = false
 accel_profile = "flat"
 sensitivity = -0.5
+disable_while_typing = false
 
 [[input.device]]
 name = "Acme Gaming Mouse"
@@ -736,6 +738,7 @@ sensitivity = -0.5
     CHECK(input.touchpad.accelProfile->kind == umbriel::AccelProfile::Kind::Adaptive);
   }
   CHECK(input.touchpad.sensitivity == std::optional<double>(0.1));
+  CHECK(input.touchpad.disableWhileTyping == std::optional<bool>(true));
   CHECK_EQ(input.devices.size(), size_t{3});
 
   const auto* keyboard = input.findDevice("Acme Split Keyboard");
@@ -757,6 +760,7 @@ sensitivity = -0.5
       CHECK(touchpad->accelProfile->kind == umbriel::AccelProfile::Kind::Flat);
     }
     CHECK(touchpad->sensitivity == std::optional<double>(-0.5));
+    CHECK(touchpad->disableWhileTyping == std::optional<bool>(false));
   }
 
   const auto* mouse = input.findDevice("Acme Gaming Mouse");
@@ -781,6 +785,11 @@ UMBRIEL_TEST(touchpadAccelerationDefaultsToUnset) {
   const umbriel::Config defaults;
   CHECK(!defaults.input.touchpad.accelProfile.has_value());
   CHECK(!defaults.input.touchpad.sensitivity.has_value());
+}
+
+UMBRIEL_TEST(touchpadDisableWhileTypingDefaultsToUnset) {
+  const umbriel::Config defaults;
+  CHECK(!defaults.input.touchpad.disableWhileTyping.has_value());
 }
 
 UMBRIEL_TEST(touchpadTapDefaultsToEnabled) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [ ] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
