### PR TITLE
feat(scrolling): add expand_single_column for lone column viewport fill

### DIFF
--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -68,10 +68,12 @@ logical size chosen by the client. A numeric window-rule `default_width` still
 takes precedence for matching applications.
 
 `expand_single_column` only changes the display of a column while it is the only
-tiled column. It never rewrites the column's stored fraction, so each window's
-`default_width` (or the global `default_width_fraction`) still applies the moment
-a second column appears. Explicit `default_maximize` and
-`default_maximize_to_edges` window rules are unaffected and win.
+tiled column. Client size hints still constrain the expanded size, and the
+viewport bounds take precedence over a larger minimum. The option never rewrites
+the column's stored fraction, so each window's `default_width` (or the global
+`default_width_fraction`) still applies the moment a second column appears.
+Explicit `default_maximize` and `default_maximize_to_edges` window rules are
+unaffected and win.
 
 Directional focus and movement follow the screen: left and right operate within
 a vertical lane, while up and down walk or reorder lanes along the strip.

--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -14,6 +14,7 @@ width_presets = [0.333, 0.5, 0.667]
 direction = "horizontal"             # "horizontal" or "vertical"
 default_width_fraction = 0.5         # remove to let clients choose, 0.1-1.0
 center_underfull_strip = true
+expand_single_column = true           # fill lone column to viewport width
 
 [layout.master]
 position = "left"                   # "left" or "right"
@@ -35,6 +36,7 @@ Scrolling layout options:
 | `direction`              | string | `"horizontal"` | Scroll axis: `"horizontal"` stacks columns left to right; `"vertical"` stacks lanes top to bottom.                                |
 | `default_width_fraction` | float  | unset          | Initial scroll-axis extent assigned to new scrolling lanes (0.1-1.0). The packaged config sets `0.5`; when omitted, the client chooses its initial extent. |
 | `center_underfull_strip` | bool   | `true`         | Center the complete strip whenever it is shorter than the viewport. Disable to align it at the start edge.                        |
+| `expand_single_column`    | bool   | `false`        | Fill the viewport width for a workspace's lone tiled column. Disable to keep the configured/default width. |
 
 Master layout options:
 
@@ -55,6 +57,12 @@ start at half the viewport. When the option is removed, Umbriel leaves the
 scroll-axis dimension unconstrained in the initial configure and retains the
 logical size chosen by the client. A numeric window-rule `default_width` still
 takes precedence for matching applications.
+
+`expand_single_column` only changes the display of a column while it is the only
+tiled column. It never rewrites the column's stored fraction, so each window's
+`default_width` (or the global `default_width_fraction`) still applies the moment
+a second column appears. Explicit `default_maximize` and
+`default_maximize_to_edges` window rules are unaffected and win.
 
 Directional focus and movement follow the screen: left and right operate within
 a vertical lane, while up and down walk or reorder lanes along the strip.

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -119,7 +119,7 @@ and numbered positions as those workspaces are created or removed.
 | `layout.scrolling.default_width_fraction` | float | Optional initial scrolling lane extent (0.1-1.0). When omitted globally and for the workspace, the client chooses its initial logical extent. |
 | `layout.scrolling.center_underfull_strip` | bool | Center the complete strip whenever it is narrower than the viewport. Disable to left-align underfull strips. |
 | `layout.scrolling.direction` | string | `"horizontal"` or `"vertical"` scroll axis. |
-| `layout.scrolling.expand_single_column` | bool | Fill the viewport width for a workspace's lone tiled column. Disable to keep the configured/default width. |
+| `layout.scrolling.expand_single_column` | bool | Fill the viewport for a workspace's lone tiled column, subject to client size hints and viewport bounds. Disable to keep the configured/default width. |
 | `layout.master.position` | string | Side occupied by the master area: `"left"` or `"right"`. |
 | `layout.master.default_width_fraction` | float | Master area fraction when both areas exist (0.1-0.9). |
 | `layout.dwindle.preserve_split` | bool | Keep each Dwindle split direction fixed after it is created when true. |

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -119,6 +119,7 @@ and numbered positions as those workspaces are created or removed.
 | `layout.scrolling.default_width_fraction` | float | Optional initial scrolling lane extent (0.1-1.0). When omitted globally and for the workspace, the client chooses its initial logical extent. |
 | `layout.scrolling.center_underfull_strip` | bool | Center the complete strip whenever it is narrower than the viewport. Disable to left-align underfull strips. |
 | `layout.scrolling.direction` | string | `"horizontal"` or `"vertical"` scroll axis. |
+| `layout.scrolling.expand_single_column` | bool | Fill the viewport width for a workspace's lone tiled column. Disable to keep the configured/default width. |
 | `layout.master.position` | string | Side occupied by the master area: `"left"` or `"right"`. |
 | `layout.master.default_width_fraction` | float | Master area fraction when both areas exist (0.1-0.9). |
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -179,6 +179,7 @@ width_presets = [0.333, 0.5, 0.667] # shared by scrolling, dwindle, and master
 # direction = "horizontal"
 default_width_fraction = 0.5  # remove to let clients choose their initial width
 center_underfull_strip = true  # center the strip whenever it is narrower than the viewport
+expand_single_column = true # fill lone column to viewport width
 
 [layout.master]
 position = "left"              # "left" or "right"

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -370,6 +370,7 @@ namespace umbriel {
               if (const auto direction = readScrollingDirection(sc, layoutContext + ".scrolling")) {
                 overrides.scrolling.direction = direction;
               }
+              sc.boolean("expand_single_column", overrides.scrolling.expandSingleColumn);
               sc.real("default_width_fraction", 0.1, 1.0, overrides.scrolling.defaultWidthFraction)
                   .boolean("center_underfull_strip", overrides.scrolling.centerUnderfullStrip);
             });
@@ -848,6 +849,7 @@ namespace umbriel {
           if (const auto direction = readScrollingDirection(sc, "layout.scrolling")) {
             loaded.layout.scrolling.direction = *direction;
           }
+          sc.boolean("expand_single_column", loaded.layout.scrolling.expandSingleColumn);
           sc.real("default_width_fraction", 0.1, 1.0, loaded.layout.scrolling.defaultWidthFraction)
               .boolean("center_underfull_strip", loaded.layout.scrolling.centerUnderfullStrip);
         });

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -49,6 +49,7 @@ namespace umbriel {
       std::optional<double> defaultWidthFraction;
       std::optional<bool> centerUnderfullStrip;
       std::optional<ScrollingDirection> direction;
+      std::optional<bool> expandSingleColumn;
       bool operator==(const Scrolling&) const = default;
     } scrolling;
     struct Master {
@@ -79,6 +80,7 @@ namespace umbriel {
       bool centerUnderfullStrip = true;
       // Axis-agnostic layout state is preserved when config reload changes direction.
       ScrollingDirection direction = ScrollingDirection::Horizontal;
+      bool expandSingleColumn = false;
       bool operator==(const Scrolling&) const = default;
     } scrolling;
     struct Master {
@@ -459,6 +461,7 @@ namespace umbriel {
         std::optional<double> defaultWidthFraction;
         bool centerUnderfullStrip = true;
         ScrollingDirection direction = ScrollingDirection::Horizontal;
+        bool expandSingleColumn = false;
         bool operator==(const Scrolling&) const = default;
       } scrolling;
       struct Master {

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -63,6 +63,9 @@ namespace umbriel {
       if (overrides.scrolling.direction) {
         resolved.scrolling.direction = *overrides.scrolling.direction;
       }
+      if (overrides.scrolling.expandSingleColumn) {
+        resolved.scrolling.expandSingleColumn = *overrides.scrolling.expandSingleColumn;
+      }
       if (overrides.master.defaultWidthFraction) {
         resolved.master.defaultWidthFraction = *overrides.master.defaultWidthFraction;
       }
@@ -233,6 +236,7 @@ namespace umbriel {
     resolved.scrolling.defaultWidthFraction = config.layout.scrolling.defaultWidthFraction;
     resolved.scrolling.centerUnderfullStrip = config.layout.scrolling.centerUnderfullStrip;
     resolved.scrolling.direction = config.layout.scrolling.direction;
+    resolved.scrolling.expandSingleColumn = config.layout.scrolling.expandSingleColumn;
     resolved.master.defaultWidthFraction = config.layout.master.defaultWidthFraction;
     resolved.master.position = config.layout.master.position;
     const int borderWidth = config.appearance.totalBorderWidth();

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -107,6 +107,10 @@ namespace umbriel {
 
   bool ScrollingLayout::vertical() const { return m_config->scrolling.direction == ScrollingDirection::Vertical; }
 
+  bool ScrollingLayout::expandSingleColumn() const {
+    return m_config != nullptr && m_config->scrolling.expandSingleColumn;
+  }
+
   void ScrollingLayout::syncHeightWeights(Column& column) { ensureWeightCount(column); }
 
   int ScrollingLayout::columnOf(const View* view) const {
@@ -282,6 +286,10 @@ namespace umbriel {
     if (columnFillsViewport(column, *this)) {
       const int edgePad = m_config->edgePad;
       return std::max(1, viewportPrimary + 2 * edgePad);
+    }
+    // A lone tiled column fills the viewport per expand_single_column, without touching its stored fraction.
+    if (m_columns.size() == 1 && expandSingleColumn()) {
+      return std::max(1, viewportPrimary);
     }
     // Gap-aware: reserve one inter-lane gap per lane so fractions summing to 1
     // tile exactly across the viewport primary extent.
@@ -652,6 +660,10 @@ namespace umbriel {
   Layout::InitialSize
   ScrollingLayout::initialSize(const wlr_box& usable, std::optional<double> ruleWidthFraction) const {
     const wlr_box content = contentArea(usable);
+    // The first window of a lone-column workspace opens full so its first buffer matches what arrange() will assign.
+    if (m_columns.empty() && expandSingleColumn()) {
+      return {.width = content.width, .height = content.height};
+    }
     const std::optional<double> fraction =
         ruleWidthFraction ? ruleWidthFraction : m_config->scrolling.defaultWidthFraction;
     if (!fraction) {

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -287,14 +287,16 @@ namespace umbriel {
       const int edgePad = m_config->edgePad;
       return std::max(1, viewportPrimary + 2 * edgePad);
     }
-    // A lone tiled column fills the viewport per expand_single_column, without touching its stored fraction.
+    int width = 0;
     if (m_columns.size() == 1 && expandSingleColumn()) {
-      return std::max(1, viewportPrimary);
+      // Fill the viewport without touching the stored fraction. Client size hints still apply to tiled columns.
+      width = viewportPrimary;
+    } else {
+      // Gap-aware: reserve one inter-lane gap per lane so fractions summing to 1
+      // tile exactly across the viewport primary extent.
+      const int gap = m_config->totalGap;
+      width = static_cast<int>(std::lround(column.widthFrac * (viewportPrimary + gap) - gap));
     }
-    // Gap-aware: reserve one inter-lane gap per lane so fractions summing to 1
-    // tile exactly across the viewport primary extent.
-    const int gap = m_config->totalGap;
-    int width = static_cast<int>(std::lround(column.widthFrac * (viewportPrimary + gap) - gap));
     width = std::max(width, columnMinPrimaryPx(column, *this));
     const int maxWidth = columnMaxPrimaryPx(column, *this);
     if (maxWidth > 0) {

--- a/src/layout/scrolling.h
+++ b/src/layout/scrolling.h
@@ -96,6 +96,7 @@ namespace umbriel {
     [[nodiscard]] int centeringOffset(int viewportPrimary) const;
     [[nodiscard]] double targetScrollForEnsureVisible(int columnIndex, int viewportPrimary, bool force = false) const;
     [[nodiscard]] bool vertical() const;
+    [[nodiscard]] bool expandSingleColumn() const;
     void syncHeightWeights(Column& column);
 
     std::vector<Column> m_columns;

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1862,8 +1862,11 @@ namespace umbriel {
 
         const Layout::InitialSize initial =
             layout.initialSize(usable, rule.defaultWidth, target != nullptr ? target->focusedView() : nullptr);
-        const int width = rule.defaultSize ? (*rule.defaultSize)[0] : initial.width;
-        wlr_xdg_toplevel_set_size(m_toplevel, width, initial.height);
+        const XdgSizeHints hints = xdgSizeHints(m_toplevel);
+        const int requestedWidth = rule.defaultSize ? (*rule.defaultSize)[0] : initial.width;
+        const int width = requestedWidth > 0 ? clampXdgWidth(requestedWidth, hints) : requestedWidth;
+        const int height = initial.height > 0 ? clampXdgHeight(initial.height, hints) : initial.height;
+        wlr_xdg_toplevel_set_size(m_toplevel, width, height);
       } else {
         const XdgSizeHints hints = xdgSizeHints(m_toplevel);
         if (rule.defaultSize) {

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -249,6 +249,23 @@ UMBRIEL_TEST(scrollingDefaultWidthIsOptional) {
   CHECK(!store.config().layout.scrolling.defaultWidthFraction.has_value());
 }
 
+UMBRIEL_TEST(expandSingleColumnParsesAndDefaultsToFalse) {
+  const TempConfig file;
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  CHECK(store.reload().success);
+  CHECK(!store.config().layout.scrolling.expandSingleColumn);
+
+  file.write("[layout.scrolling]\nexpand_single_column = true\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().layout.scrolling.expandSingleColumn);
+
+  file.write("[layout.scrolling]\nexpand_single_column = false\n");
+  CHECK(store.reload().success);
+  CHECK(!store.config().layout.scrolling.expandSingleColumn);
+}
+
 UMBRIEL_TEST(modKeyIsUserConfigurable) {
   const TempConfig file;
   ConfigStore& store = umbriel::configStore();

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -254,6 +254,8 @@ UMBRIEL_TEST(expandSingleColumnParsesAndDefaultsToFalse) {
   ConfigStore& store = umbriel::configStore();
   store.setRootPath(file.path(), true);
 
+  file.write("");
+
   CHECK(store.reload().success);
   CHECK(!store.config().layout.scrolling.expandSingleColumn);
 

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -178,10 +178,18 @@ UMBRIEL_TEST(expandSingleColumnTrueFillsALoneColumn) {
   CHECK_EQ(fixture.layout.columnWidth(0, kViewport), kViewport);
 }
 
+UMBRIEL_TEST(expandSingleColumnTrueHonorsClientMaxWidth) {
+  Fixture fixture;
+  fixture.config.scrolling.expandSingleColumn = true;
+  fixture.layout.setConstraints([](const View*) { return LayoutConstraints{.maxWidth = 300}; });
+  fixture.addColumns(1);
+  CHECK_EQ(fixture.layout.columnWidth(0, kViewport), 300);
+}
+
 UMBRIEL_TEST(expandSingleColumnTrueSizesTheFirstConfigureFull) {
   Fixture fixture;
   fixture.config.scrolling.expandSingleColumn = true;
-  const Layout::InitialSize initial = fixture.layout.initialSize(kUsable, std::nullopt);
+  const Layout::InitialSize initial = fixture.layout.initialSize(kUsable, std::nullopt, nullptr);
   CHECK_EQ(initial.width, 1260);
   CHECK_EQ(initial.height, 700);
 }

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -25,7 +25,9 @@ namespace {
   // one. These are addresses, never dereferenced.
   View* stub(int id) { return reinterpret_cast<View*>(static_cast<uintptr_t>(0x1000 + (id * 0x10))); }
 
-  // Mirrors the shipped defaults: gap 8, border 2, no outer border.
+  // Mirrors the shipped defaults except expandSingleColumn: geometry tests pin
+  // false so they exercise the resting-width math, and the expand_single_column
+  // behavior is covered by its own tests that flip the value back to true.
   //   totalGap = gap + 2 * border = 12,  edgePad = gap + border = 10
   ResolvedLayoutConfig defaultConfig() {
     ResolvedLayoutConfig config;
@@ -34,6 +36,7 @@ namespace {
     config.edgePad = 10;
     config.scrolling.defaultWidthFraction = 0.5;
     config.scrolling.centerUnderfullStrip = true;
+    config.scrolling.expandSingleColumn = false;
     config.widthPresets = {1.0 / 3, 0.5, 2.0 / 3};
     return config;
   }
@@ -159,6 +162,37 @@ UMBRIEL_TEST(halfWidthColumnMatchesTheGapAwareFormula) {
   fixture.addColumns(1);
   // round(0.5 * (1260 + 12)) - 12 = 636 - 12 = 624
   CHECK_EQ(fixture.layout.columnWidth(0, kViewport), 624);
+}
+
+// expand_single_column
+UMBRIEL_TEST(expandSingleColumnFalseKeepsTheConfiguredWidth) {
+  Fixture fixture;
+  fixture.addColumns(1);
+  CHECK_EQ(fixture.layout.columnWidth(0, kViewport), 624);
+}
+
+UMBRIEL_TEST(expandSingleColumnTrueFillsALoneColumn) {
+  Fixture fixture;
+  fixture.config.scrolling.expandSingleColumn = true;
+  fixture.addColumns(1);
+  CHECK_EQ(fixture.layout.columnWidth(0, kViewport), kViewport);
+}
+
+UMBRIEL_TEST(expandSingleColumnTrueSizesTheFirstConfigureFull) {
+  Fixture fixture;
+  fixture.config.scrolling.expandSingleColumn = true;
+  const Layout::InitialSize initial = fixture.layout.initialSize(kUsable, std::nullopt);
+  CHECK_EQ(initial.width, 1260);
+  CHECK_EQ(initial.height, 700);
+}
+
+UMBRIEL_TEST(expandSingleColumnTrueReexpandsTheLastSurvivor) {
+  Fixture fixture;
+  fixture.config.scrolling.expandSingleColumn = true;
+  fixture.addColumns(2);
+  fixture.layout.removeView(stub(1));
+  CHECK_EQ(fixture.layout.columns().size(), size_t{1});
+  CHECK_EQ(fixture.layout.columnWidth(0, kViewport), kViewport);
 }
 
 UMBRIEL_TEST(twoHalfColumnsTileExactlyAcrossTheViewport) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Adds `layout.scrolling.expand_single_column` boolean option. When enabled, a workspace's lone tiled column expands to fill the viewport width without mutating its stored fraction. Default width still applies when a second column appears.

## Motivation

<!-- What problem does this solve? -->
Scrolling layout users often expect a single window to occupy the full viewport (Niri-like behavior). Currently, a lone column keeps its configured `default_width_fraction`, leaving unused space. This option provides that behavior as an opt-in.
## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
None

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
```
just build
just test # 25/25
just lint
```

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

https://github.com/user-attachments/assets/a24d6bb3-a4e1-40b4-97fd-560410b213d5

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
