### PR TITLE
feat: add center_focused config in layout.scrolling

### DIFF
--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -14,7 +14,7 @@ width_presets = [0.333, 0.5, 0.667]
 direction = "horizontal"             # "horizontal" or "vertical"
 default_width_fraction = 0.5         # remove to let clients choose, 0.1-1.0
 center_underfull_strip = true
-always_center_focused = false
+center_focused = false
 
 [layout.dwindle]
 preserve_split = false              # keep each split direction fixed after it is created
@@ -39,7 +39,7 @@ Scrolling layout options:
 | `direction`              | string | `"horizontal"` | Scroll axis: `"horizontal"` stacks columns left to right; `"vertical"` stacks lanes top to bottom.                                |
 | `default_width_fraction` | float  | unset          | Initial scroll-axis extent assigned to new scrolling lanes (0.1-1.0). The packaged config sets `0.5`; when omitted, the client chooses its initial extent. |
 | `center_underfull_strip` | bool   | `true`         | Center the complete strip whenever it is shorter than the viewport. Disable to align it at the start edge.                        |
-| `always_center_focused`  | bool   | `false`        | Always center the focused column.                                                                                                 |
+| `center_focused`  | bool   | `false`        | Always center the focused column.                                                                                                 |
 
 Dwindle layout options:
 

--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -14,6 +14,7 @@ width_presets = [0.333, 0.5, 0.667]
 direction = "horizontal"             # "horizontal" or "vertical"
 default_width_fraction = 0.5         # remove to let clients choose, 0.1-1.0
 center_underfull_strip = true
+always_center_focused = false
 
 [layout.dwindle]
 preserve_split = false              # keep each split direction fixed after it is created
@@ -38,6 +39,7 @@ Scrolling layout options:
 | `direction`              | string | `"horizontal"` | Scroll axis: `"horizontal"` stacks columns left to right; `"vertical"` stacks lanes top to bottom.                                |
 | `default_width_fraction` | float  | unset          | Initial scroll-axis extent assigned to new scrolling lanes (0.1-1.0). The packaged config sets `0.5`; when omitted, the client chooses its initial extent. |
 | `center_underfull_strip` | bool   | `true`         | Center the complete strip whenever it is shorter than the viewport. Disable to align it at the start edge.                        |
+| `always_center_focused`  | bool   | `false`        | Always center the focused column.                                                                                                 |
 
 Dwindle layout options:
 

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -124,6 +124,7 @@ and numbered positions as those workspaces are created or removed.
 | `layout.width_presets` | float array | Widths used by the width-cycle action in every layout. |
 | `layout.scrolling.default_width_fraction` | float | Optional initial scrolling lane extent (0.1-1.0). When omitted globally and for the workspace, the client chooses its initial logical extent. |
 | `layout.scrolling.center_underfull_strip` | bool | Center the complete strip whenever it is narrower than the viewport. Disable to left-align underfull strips. |
+| `layout.scrolling.center_focused` | bool | Always center the focused column, including when the setting changes on config reload. |
 | `layout.scrolling.direction` | string | `"horizontal"` or `"vertical"` scroll axis. |
 | `layout.scrolling.expand_single_column` | bool | Fill the viewport for a workspace's lone tiled column, subject to client size hints and viewport bounds. Disable to keep the configured/default width. |
 | `layout.master.position` | string | Side occupied by the master area: `"left"` or `"right"`. |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -179,6 +179,7 @@ width_presets = [0.333, 0.5, 0.667] # shared by scrolling, dwindle, and master
 # direction = "horizontal"
 default_width_fraction = 0.5  # remove to let clients choose their initial width
 center_underfull_strip = true  # center the strip whenever it is narrower than the viewport
+always_center_focused = false # always center the focused column
 
 
 [layout.dwindle]

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -179,7 +179,7 @@ width_presets = [0.333, 0.5, 0.667] # shared by scrolling, dwindle, and master
 # direction = "horizontal"
 default_width_fraction = 0.5  # remove to let clients choose their initial width
 center_underfull_strip = true  # center the strip whenever it is narrower than the viewport
-always_center_focused = false # always center the focused column
+center_focused = false # always center the focused column
 
 
 [layout.dwindle]

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -371,7 +371,8 @@ namespace umbriel {
                 overrides.scrolling.direction = direction;
               }
               sc.real("default_width_fraction", 0.1, 1.0, overrides.scrolling.defaultWidthFraction)
-                  .boolean("center_underfull_strip", overrides.scrolling.centerUnderfullStrip);
+                  .boolean("center_underfull_strip", overrides.scrolling.centerUnderfullStrip)
+                  .boolean("always_center_focused", overrides.scrolling.alwaysCenterFocused);
             });
             s.sub("dwindle", [&](Section& sd) { sd.boolean("preserve_split", overrides.dwindle.preserveSplit); });
             s.sub("master", [&](Section& sm) {
@@ -850,7 +851,8 @@ namespace umbriel {
             loaded.layout.scrolling.direction = *direction;
           }
           sc.real("default_width_fraction", 0.1, 1.0, loaded.layout.scrolling.defaultWidthFraction)
-              .boolean("center_underfull_strip", loaded.layout.scrolling.centerUnderfullStrip);
+              .boolean("center_underfull_strip", loaded.layout.scrolling.centerUnderfullStrip)
+              .boolean("always_center_focused", loaded.layout.scrolling.alwaysCenterFocused);
         });
         s.sub("dwindle", [&](Section& sd) { sd.boolean("preserve_split", loaded.layout.dwindle.preserveSplit); });
         s.sub("master", [&](Section& sm) {

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -372,7 +372,7 @@ namespace umbriel {
               }
               sc.real("default_width_fraction", 0.1, 1.0, overrides.scrolling.defaultWidthFraction)
                   .boolean("center_underfull_strip", overrides.scrolling.centerUnderfullStrip)
-                  .boolean("always_center_focused", overrides.scrolling.alwaysCenterFocused);
+                  .boolean("center_focused", overrides.scrolling.centerFocused);
             });
             s.sub("dwindle", [&](Section& sd) { sd.boolean("preserve_split", overrides.dwindle.preserveSplit); });
             s.sub("master", [&](Section& sm) {
@@ -852,7 +852,7 @@ namespace umbriel {
           }
           sc.real("default_width_fraction", 0.1, 1.0, loaded.layout.scrolling.defaultWidthFraction)
               .boolean("center_underfull_strip", loaded.layout.scrolling.centerUnderfullStrip)
-              .boolean("always_center_focused", loaded.layout.scrolling.alwaysCenterFocused);
+              .boolean("center_focused", loaded.layout.scrolling.centerFocused);
         });
         s.sub("dwindle", [&](Section& sd) { sd.boolean("preserve_split", loaded.layout.dwindle.preserveSplit); });
         s.sub("master", [&](Section& sm) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -48,7 +48,7 @@ namespace umbriel {
     struct Scrolling {
       std::optional<double> defaultWidthFraction;
       std::optional<bool> centerUnderfullStrip;
-      std::optional<bool> alwaysCenterFocused;
+      std::optional<bool> centerFocused;
       std::optional<ScrollingDirection> direction;
       bool operator==(const Scrolling&) const = default;
     } scrolling;
@@ -82,7 +82,7 @@ namespace umbriel {
     struct Scrolling {
       std::optional<double> defaultWidthFraction;
       bool centerUnderfullStrip = true;
-      bool alwaysCenterFocused = false;
+      bool centerFocused = false;
       // Axis-agnostic layout state is preserved when config reload changes direction.
       ScrollingDirection direction = ScrollingDirection::Horizontal;
       bool operator==(const Scrolling&) const = default;
@@ -468,7 +468,7 @@ namespace umbriel {
       struct Scrolling {
         std::optional<double> defaultWidthFraction;
         bool centerUnderfullStrip = true;
-        bool alwaysCenterFocused = false;
+        bool centerFocused = false;
         ScrollingDirection direction = ScrollingDirection::Horizontal;
         bool operator==(const Scrolling&) const = default;
       } scrolling;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -48,6 +48,7 @@ namespace umbriel {
     struct Scrolling {
       std::optional<double> defaultWidthFraction;
       std::optional<bool> centerUnderfullStrip;
+      std::optional<bool> alwaysCenterFocused;
       std::optional<ScrollingDirection> direction;
       bool operator==(const Scrolling&) const = default;
     } scrolling;
@@ -81,6 +82,7 @@ namespace umbriel {
     struct Scrolling {
       std::optional<double> defaultWidthFraction;
       bool centerUnderfullStrip = true;
+      bool alwaysCenterFocused = false;
       // Axis-agnostic layout state is preserved when config reload changes direction.
       ScrollingDirection direction = ScrollingDirection::Horizontal;
       bool operator==(const Scrolling&) const = default;
@@ -466,6 +468,7 @@ namespace umbriel {
       struct Scrolling {
         std::optional<double> defaultWidthFraction;
         bool centerUnderfullStrip = true;
+        bool alwaysCenterFocused = false;
         ScrollingDirection direction = ScrollingDirection::Horizontal;
         bool operator==(const Scrolling&) const = default;
       } scrolling;

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -60,8 +60,8 @@ namespace umbriel {
       if (overrides.scrolling.centerUnderfullStrip) {
         resolved.scrolling.centerUnderfullStrip = *overrides.scrolling.centerUnderfullStrip;
       }
-      if (overrides.scrolling.alwaysCenterFocused) {
-        resolved.scrolling.alwaysCenterFocused = *overrides.scrolling.alwaysCenterFocused;
+      if (overrides.scrolling.centerFocused) {
+        resolved.scrolling.centerFocused = *overrides.scrolling.centerFocused;
       }
       if (overrides.dwindle.preserveSplit) {
         resolved.dwindle.preserveSplit = *overrides.dwindle.preserveSplit;
@@ -238,7 +238,7 @@ namespace umbriel {
     resolved.widthPresets = config.layout.widthPresets;
     resolved.scrolling.defaultWidthFraction = config.layout.scrolling.defaultWidthFraction;
     resolved.scrolling.centerUnderfullStrip = config.layout.scrolling.centerUnderfullStrip;
-    resolved.scrolling.alwaysCenterFocused = config.layout.scrolling.alwaysCenterFocused;
+    resolved.scrolling.centerFocused = config.layout.scrolling.centerFocused;
     resolved.scrolling.direction = config.layout.scrolling.direction;
     resolved.dwindle.preserveSplit = config.layout.dwindle.preserveSplit;
     resolved.master.defaultWidthFraction = config.layout.master.defaultWidthFraction;

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -60,6 +60,9 @@ namespace umbriel {
       if (overrides.scrolling.centerUnderfullStrip) {
         resolved.scrolling.centerUnderfullStrip = *overrides.scrolling.centerUnderfullStrip;
       }
+      if (overrides.scrolling.alwaysCenterFocused) {
+        resolved.scrolling.alwaysCenterFocused = *overrides.scrolling.alwaysCenterFocused;
+      }
       if (overrides.dwindle.preserveSplit) {
         resolved.dwindle.preserveSplit = *overrides.dwindle.preserveSplit;
       }
@@ -235,6 +238,7 @@ namespace umbriel {
     resolved.widthPresets = config.layout.widthPresets;
     resolved.scrolling.defaultWidthFraction = config.layout.scrolling.defaultWidthFraction;
     resolved.scrolling.centerUnderfullStrip = config.layout.scrolling.centerUnderfullStrip;
+    resolved.scrolling.alwaysCenterFocused = config.layout.scrolling.alwaysCenterFocused;
     resolved.scrolling.direction = config.layout.scrolling.direction;
     resolved.dwindle.preserveSplit = config.layout.dwindle.preserveSplit;
     resolved.master.defaultWidthFraction = config.layout.master.defaultWidthFraction;

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -534,7 +534,7 @@ namespace umbriel {
       const double cover = static_cast<double>(x) + static_cast<double>(width - viewportPrimary) / 2.0;
       return std::clamp(cover, 0.0, max);
     }
-    if (m_config->scrolling.alwaysCenterFocused) {
+    if (m_config->scrolling.centerFocused) {
       return static_cast<double>(x) - (viewportPrimary - width) / 2.0;
     }
     if (force) {
@@ -579,12 +579,12 @@ namespace umbriel {
 
   void ScrollingLayout::ensureVisible(int columnIndex, int viewportPrimary) {
     const double target = targetScrollForEnsureVisible(columnIndex, viewportPrimary, false);
-    m_centeredRest = m_config->scrolling.alwaysCenterFocused || (m_centeredRest && target == m_scroll);
+    m_centeredRest = m_config->scrolling.centerFocused || (m_centeredRest && target == m_scroll);
     m_scroll = target;
   }
 
   void ScrollingLayout::snapVisible(int columnIndex, int viewportPrimary) {
-    m_centeredRest = m_config->scrolling.alwaysCenterFocused;
+    m_centeredRest = m_config->scrolling.centerFocused;
     m_scroll = targetScrollForEnsureVisible(columnIndex, viewportPrimary, true);
   }
 

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -557,6 +557,15 @@ namespace umbriel {
     return true;
   }
 
+  void ScrollingLayout::reconcileFocusedColumn(int columnIndex, int viewportPrimary) {
+    if (m_config->scrolling.centerFocused) {
+      centerColumn(columnIndex, viewportPrimary);
+      return;
+    }
+    m_centeredRest = false;
+    ensureVisible(columnIndex, viewportPrimary);
+  }
+
   double ScrollingLayout::targetScrollForEnsureVisible(int columnIndex, int viewportPrimary, bool force) const {
     if (columnIndex < 0 || columnIndex >= static_cast<int>(m_columns.size()) || viewportPrimary <= 0) {
       return m_scroll;

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -534,6 +534,9 @@ namespace umbriel {
       const double cover = static_cast<double>(x) + static_cast<double>(width - viewportPrimary) / 2.0;
       return std::clamp(cover, 0.0, max);
     }
+    if (m_config->scrolling.alwaysCenterFocused) {
+      return static_cast<double>(x) - (viewportPrimary - width) / 2.0;
+    }
     if (force) {
       return std::clamp(static_cast<double>(x), 0.0, max);
     }
@@ -576,12 +579,12 @@ namespace umbriel {
 
   void ScrollingLayout::ensureVisible(int columnIndex, int viewportPrimary) {
     const double target = targetScrollForEnsureVisible(columnIndex, viewportPrimary, false);
-    m_centeredRest = m_centeredRest && target == m_scroll;
+    m_centeredRest = m_config->scrolling.alwaysCenterFocused || (m_centeredRest && target == m_scroll);
     m_scroll = target;
   }
 
   void ScrollingLayout::snapVisible(int columnIndex, int viewportPrimary) {
-    m_centeredRest = false;
+    m_centeredRest = m_config->scrolling.alwaysCenterFocused;
     m_scroll = targetScrollForEnsureVisible(columnIndex, viewportPrimary, true);
   }
 

--- a/src/layout/scrolling.h
+++ b/src/layout/scrolling.h
@@ -50,6 +50,7 @@ namespace umbriel {
     // Raw scroll mutation. `centeredRest` is true only when restoring a saved column-center resting position.
     void setScroll(double scroll, bool centeredRest = false);
     bool centerColumn(int columnIndex, int viewportPrimary);
+    void reconcileFocusedColumn(int columnIndex, int viewportPrimary);
     [[nodiscard]] bool centeredRest() const { return m_centeredRest; }
     // How much to subtract from the scroll offset when `columnIndex` is about
     // to lose its last view. Removing a lane closes the primary-axis space it

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1083,10 +1083,16 @@ namespace umbriel {
   }
 
   void Workspace::applyLayoutConfig(ResolvedLayoutConfig layoutConfig) {
+    const bool centerFocusedChanged = m_layoutConfig.scrolling.centerFocused != layoutConfig.scrolling.centerFocused;
     m_layoutConfig = std::move(layoutConfig);
     if (m_layout != nullptr && m_layout->mode() == m_layoutConfig.mode) {
       m_layout->setConfig(&m_layoutConfig);
       m_layout->setConstraints(&viewLayoutConstraints);
+      if (centerFocusedChanged) {
+        if (ScrollingLayout* scrolling = scrollingLayout(); scrolling != nullptr && m_focusedView != nullptr) {
+          scrolling->reconcileFocusedColumn(scrolling->columnOf(m_focusedView), scrollViewportExtent());
+        }
+      }
       markArrange(true);
       return;
     }

--- a/tests/harness/checks/110_scrolling_layout.sh
+++ b/tests/harness/checks/110_scrolling_layout.sh
@@ -19,12 +19,26 @@ wait_for_windows() {
   return 1
 }
 
+wait_for_x() {
+  local title=$1
+  local want=$2
+  local message=$3
+  local current=0
+  for _ in $(seq 40); do
+    current=$("$UMBRIEL" windows --json | jq -r --arg title "$title" '.[] | select(.title == $title) | .x')
+    [[ $current -eq $want ]] && return 0
+    sleep 0.1
+  done
+  echo "$message, got x=$current"
+  return 1
+}
+
 # Output is 1280x720 (WLR_HEADLESS_OUTPUTS default mode). With the shipped defaults (gap 8, border 2, no outer border) the derived layout metrics are: totalBorderWidth = 2, edgePad = gap + border = 10, totalGap = gap + 2*border = 12 viewport = 1280 - 2*edgePad = 1260, height = 720 - 2*edgePad = 700 A 0.5 fraction column is then: round(0.5 * (viewport + totalGap)) - totalGap = round(636) - 12 = 624
 readonly EXPECT_W=624
 readonly EXPECT_H=700
 readonly EXPECT_CENTER_X=$(( (1280 - EXPECT_W) / 2 ))
 
-printf '\n[layout.scrolling]\ndefault_width_fraction = 0.5\n' >> "$UMBRIEL_CONFIG"
+printf '\n[layout.scrolling]\ndefault_width_fraction = 0.5\ncenter_focused = false\n' >> "$UMBRIEL_CONFIG"
 "$UMBRIEL" msg config-reload > /dev/null
 
 spawn_client a
@@ -91,6 +105,16 @@ if [[ $center_x -ne $EXPECT_CENTER_X ]]; then
   echo "expected first column centered at x=$EXPECT_CENTER_X, got x=$center_x"
   exit 1
 fi
+
+# Reloading the focus policy applies it to the currently focused column.
+"$UMBRIEL" msg window-focus-right > /dev/null
+wait_for_x harness-b 646 "expected disabled center_focused to leave the last column at its bounded position"
+sed -i 's/center_focused = false/center_focused = true/' "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+wait_for_x harness-b "$EXPECT_CENTER_X" "enabling center_focused did not center the focused column on reload"
+sed -i 's/center_focused = true/center_focused = false/' "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+wait_for_x harness-b 646 "disabling center_focused did not restore the bounded focused-column position"
 
 # Floating toggle round trip: the focused window flips and comes back.
 "$UMBRIEL" msg window-toggle-floating > /dev/null

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -726,6 +726,46 @@ UMBRIEL_TEST(snapVisibleCentersFullWidthColumn) {
   CHECK_EQ(fixture.layout.scroll(), expected);
 }
 
+UMBRIEL_TEST(centerFocusedCentersAnInteriorColumn) {
+  Fixture fixture;
+  fixture.addColumns(3);
+  fixture.config.scrolling.centerFocused = true;
+
+  fixture.layout.ensureVisible(1, kViewport);
+
+  const int centeredX = fixture.layout.columnX(1, kViewport)
+      + fixture.layout.columnWidth(1, kViewport) / 2
+      - static_cast<int>(std::lround(fixture.layout.scroll()));
+  CHECK_EQ(centeredX, kViewport / 2);
+  CHECK(fixture.layout.centeredRest());
+}
+
+UMBRIEL_TEST(centerFocusedAllowsEdgeColumnsToOverscroll) {
+  Fixture fixture;
+  fixture.addColumns(3);
+  fixture.config.scrolling.centerFocused = true;
+
+  fixture.layout.ensureVisible(0, kViewport);
+  CHECK(fixture.layout.scroll() < 0.0);
+
+  fixture.layout.ensureVisible(2, kViewport);
+  CHECK(fixture.layout.scroll() > static_cast<double>(fixture.layout.maxScroll(kViewport)));
+}
+
+UMBRIEL_TEST(disablingCenterFocusedReturnsTheFocusedColumnToTheScrollRange) {
+  Fixture fixture;
+  fixture.addColumns(3);
+  fixture.config.scrolling.centerFocused = true;
+  fixture.layout.reconcileFocusedColumn(2, kViewport);
+  CHECK(fixture.layout.scroll() > static_cast<double>(fixture.layout.maxScroll(kViewport)));
+
+  fixture.config.scrolling.centerFocused = false;
+  fixture.layout.reconcileFocusedColumn(2, kViewport);
+
+  CHECK_EQ(fixture.layout.scroll(), static_cast<double>(fixture.layout.maxScroll(kViewport)));
+  CHECK(!fixture.layout.centeredRest());
+}
+
 UMBRIEL_TEST(ensureVisibleIsANoOpForAnAlreadyVisibleColumn) {
   Fixture fixture;
   fixture.addColumns(6);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add `center_focused` config in `[layout.scrolling]`.
Equivalent to `center-focused-column "always"` in niri.

## Motivation

<!-- What problem does this solve? -->
Feature requested on discord.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
