### PR TITLE
perf(layout): make scrolling arrange() and view registry rotation linear

### DIFF
--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -600,19 +600,21 @@ namespace umbriel {
     const auto viewport = static_cast<double>(viewportPrimary);
     m_scroll = std::clamp(m_scroll, -viewport, maxScroll + viewport);
 
+    const int gap = m_config->totalGap;
+    // columnX() re-sums every prior column each call; keep a running x instead of calling it per column.
+    int runningColumnX = centeringOffset(viewportPrimary);
     for (size_t columnIndex = 0; columnIndex < m_columns.size(); ++columnIndex) {
       Column& column = m_columns[columnIndex];
+      const int primarySize = columnWidth(static_cast<int>(columnIndex), viewportPrimary);
       if (column.views.empty()) {
+        runningColumnX += primarySize + gap;
         continue;
       }
       ensureWeightCount(column);
-      const int primarySize = columnWidth(static_cast<int>(columnIndex), viewportPrimary);
-      const int primary = (v ? usable.y : usable.x)
-          + edgePad
-          + columnX(static_cast<int>(columnIndex), viewportPrimary)
-          - static_cast<int>(std::lround(m_scroll));
+      const int primary =
+          (v ? usable.y : usable.x) + edgePad + runningColumnX - static_cast<int>(std::lround(m_scroll));
+      runningColumnX += primarySize + gap;
       const int rowCount = static_cast<int>(column.views.size());
-      const int gap = m_config->totalGap;
       const int gapsTotal = std::max(0, rowCount - 1) * gap;
       const int stackCross = std::max(rowCount, availableCross - gapsTotal);
       const double totalWeight = columnTotalWeight(column);

--- a/src/view/registry.cpp
+++ b/src/view/registry.cpp
@@ -32,14 +32,15 @@ namespace umbriel {
   }
 
   View* ViewRegistry::rotateToNext(const std::function<bool(const View&)>& accept) {
-    if (m_views.size() < 2) {
+    const size_t count = m_views.size();
+    if (count < 2) {
       return nullptr;
     }
-    for (size_t n = 0; n < m_views.size(); ++n) {
-      auto current = std::move(m_views.front());
-      m_views.erase(m_views.begin());
-      m_views.push_back(std::move(current));
-      if (accept(*m_views.front())) {
+    // Same result as rotating one element at a time and checking each new front, minus the O(n^2) erase(begin()).
+    for (size_t step = 1; step <= count; ++step) {
+      const size_t index = step % count;
+      if (accept(*m_views[index])) {
+        std::rotate(m_views.begin(), m_views.begin() + static_cast<std::ptrdiff_t>(index), m_views.end());
         return m_views.front().get();
       }
     }


### PR DESCRIPTION
## Summary

Fixed two spots doing O(n^2) work for no reason:

- `ScrollingLayout::arrange()` recomputed each column's x position from scratch by re-summing every column before it, every time. Now it just tracks a running x as it goes.
- `ViewRegistry::rotateToNext()` (alt-tab cycling) rotated the list one element at a time using `erase(begin())`, which is itself O(n). Swapped for one `std::rotate()`.

Same output either way, just less work.

## Type of Change

- [x] Refactoring

## Testing

- `just test` - all 26 pass, including the test that checks column x-positions
- Manually tiled 4 windows in a nested session, checked positions matched before/after

## Manual Coverage

- [x] Tested in a nested Umbriel session
- [x] Tested with the scrolling layout

## Checklist

- [x] I ran `just format`
- [x] I ran the unit test suite
- [x] I functionally verified compositor behavior
- [x] I self-reviewed the changes
- [x] I checked for new warnings or errors
