### PR TITLE
feat(input): add scroll_factor for touchpad

### DIFF
--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -59,6 +59,7 @@ tap = true
 natural_scroll = true
 # accel_profile = "adaptive"  # "flat", "adaptive", or a custom curve
 # sensitivity = 0.5           # -1.0 to 1.0
+# scroll_factor = 1.5         # touchpad scroll speed, 0.1 to 10.0
 # disable_while_typing = true
 ```
 
@@ -75,6 +76,13 @@ including custom curves. Both remain unset by default, which uses each
 touchpad's libinput default profile and speed. Removing either setting on reload
 restores the corresponding default. `sensitivity` alone adjusts pointer speed
 under the device's default profile.
+
+`scroll_factor` multiplies the smooth two-finger scroll a touchpad sends to the
+focused window, so `2.0` scrolls twice as fast and `0.5` half as fast. It
+remains unset by default (identity, `1.0`) and takes the next scroll event on
+reload. It applies only to the continuous scroll delta: discrete notches,
+overview wheel stepping, and three-finger-swipe strip travel keep their own
+counting semantics.
 
 ### Mouse
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -234,6 +234,7 @@ tap = true                      # enabled by default; false disables tap-to-clic
 # natural_scroll = true
 # accel_profile = "adaptive"    # "flat", "adaptive", or "custom <step> <points...>"
 # sensitivity = 0.5             # pointer speed, -1.0 to 1.0
+# scroll_factor = 1.5           # touchpad scroll speed, 0.1 to 10.0
 # disable_while_typing = true   # omitted preserves the device's libinput default
 
 [input.mouse]

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1121,6 +1121,7 @@ namespace umbriel {
           t.boolean("tap", in.touchpad.tap)
               .boolean("natural_scroll", in.touchpad.naturalScroll)
               .real("sensitivity", -1.0, 1.0, in.touchpad.sensitivity)
+              .real("scroll_factor", 0.1, 10.0, in.touchpad.scrollFactor)
               .boolean("disable_while_typing", in.touchpad.disableWhileTyping);
           in.touchpad.accelProfile = readAccelProfile(t, "accel_profile", "input.touchpad");
         });

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -544,6 +544,7 @@ namespace umbriel {
         std::optional<bool> naturalScroll;
         std::optional<AccelProfile> accelProfile;
         std::optional<double> sensitivity;
+        std::optional<double> scrollFactor;
         std::optional<bool> disableWhileTyping;
         bool operator==(const Touchpad&) const = default;
       } touchpad;

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -47,6 +47,20 @@ namespace umbriel {
       return surface != nullptr && wlr_xdg_popup_try_from_wlr_surface(wlr_surface_get_root_surface(surface)) != nullptr;
     }
 
+    // `[input.touchpad] scroll_factor` scales a touchpad's smooth scroll delta before it reaches the focused client.
+    // Reads the live config per event so a successful reload applies on the very next axis; non-touchpads and unset
+    // values stay at identity (1.0). Only the continuous delta is scaled, never the discrete value120 notches.
+    double touchpadScrollFactor(wlr_pointer* pointer) {
+      if (pointer == nullptr || !wlr_input_device_is_libinput(&pointer->base)) {
+        return 1.0;
+      }
+      libinput_device* device = wlr_libinput_get_device_handle(&pointer->base);
+      if (device == nullptr || libinput_device_config_tap_get_finger_count(device) == 0) {
+        return 1.0;
+      }
+      return config().input.touchpad.scrollFactor.value_or(1.0);
+    }
+
     bool surfaceLocalCoordinates(wlr_scene* scene, wlr_surface* target, double lx, double ly, double* sx, double* sy) {
       if (target == nullptr) {
         return false;
@@ -951,8 +965,9 @@ namespace umbriel {
     const int orientation = isVertical ? 0 : 1;
     if (!armed) {
       m_wheelAccum[orientation] = 0;
+      const double scale = touchpadScrollFactor(event->pointer);
       wlr_seat_pointer_notify_axis(
-          m_server->seat()->wlr(), event->time_msec, event->orientation, event->delta, event->delta_discrete,
+          m_server->seat()->wlr(), event->time_msec, event->orientation, event->delta * scale, event->delta_discrete,
           event->source, event->relative_direction
       );
       return;

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -80,6 +80,12 @@ UMBRIEL_TEST(eachSectionIsReportedOnItsOwn) {
   }
   {
     Config after;
+    after.input.touchpad.scrollFactor = 1.5;
+    CHECK(ConfigChange::between(before, after).input);
+    CHECK(ConfigEffects::between(before, after).input);
+  }
+  {
+    Config after;
     after.input.touchpad.disableWhileTyping = false;
     CHECK(ConfigChange::between(before, after).input);
     CHECK(ConfigEffects::between(before, after).input);

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -766,6 +766,7 @@ tap = true
 natural_scroll = true
 accel_profile = "adaptive"
 sensitivity = 0.1
+scroll_factor = 1.5
 disable_while_typing = true
 
 [input.mouse]
@@ -809,6 +810,7 @@ sensitivity = -0.5
     CHECK(input.touchpad.accelProfile->kind == umbriel::AccelProfile::Kind::Adaptive);
   }
   CHECK(input.touchpad.sensitivity == std::optional<double>(0.1));
+  CHECK(input.touchpad.scrollFactor == std::optional<double>(1.5));
   CHECK(input.touchpad.disableWhileTyping == std::optional<bool>(true));
   CHECK_EQ(input.devices.size(), size_t{3});
 
@@ -856,6 +858,11 @@ UMBRIEL_TEST(touchpadAccelerationDefaultsToUnset) {
   const umbriel::Config defaults;
   CHECK(!defaults.input.touchpad.accelProfile.has_value());
   CHECK(!defaults.input.touchpad.sensitivity.has_value());
+}
+
+UMBRIEL_TEST(touchpadScrollFactorDefaultsToUnset) {
+    const umbriel::Config defaults;
+    CHECK(!defaults.input.touchpad.scrollFactor.has_value());
 }
 
 UMBRIEL_TEST(touchpadDisableWhileTypingDefaultsToUnset) {


### PR DESCRIPTION
## Summary

This PR add `scroll_factor` for touchpad.

## Motivation

Mouse have this option but was missing for touchpad. Let user have control on their touchpad scroll

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

Feature request from discord

## Testing

- `just format`, `just test` all clean
- `just lint` is failing on overview related files, not related to my files, my files are clean
- `just install` the branch to test it nativaly 

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos


https://github.com/user-attachments/assets/6b449cef-2058-478a-99ff-747ff4c3f76b



## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`.
- [x] I ran the relevant build, test, lint, or verification commands.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
