### PR TITLE
fix(lockscreen): suppress input-method key grab while locked

### DIFF
--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -126,6 +126,13 @@ namespace umbriel {
     m_server->notifyKeyboardLayoutIpc();
   }
 
+  wlr_input_method_keyboard_grab_v2* Keyboard::activeInputMethodGrab() const {
+    if (m_server->sessionLocked()) {
+      return nullptr;
+    }
+    return m_server->inputMethodRelay()->grabForKeyboard(m_keyboard);
+  }
+
   Keyboard::~Keyboard() {
     if (m_repeatTimer != nullptr) {
       wl_event_source_remove(m_repeatTimer);
@@ -160,7 +167,7 @@ namespace umbriel {
     cancelRepeat();
     m_server->notifyIdleActivity();
     wlr_seat* seat = m_server->seat()->wlr();
-    wlr_input_method_keyboard_grab_v2* grab = m_server->inputMethodRelay()->grabForKeyboard(m_keyboard);
+    wlr_input_method_keyboard_grab_v2* grab = activeInputMethodGrab();
     if (grab != nullptr) {
       wlr_input_method_keyboard_grab_v2_set_keyboard(grab, m_keyboard);
       wlr_input_method_keyboard_grab_v2_send_modifiers(grab, &m_keyboard->modifiers);
@@ -273,7 +280,7 @@ namespace umbriel {
     }
 
     if (!handled) {
-      wlr_input_method_keyboard_grab_v2* grab = m_server->inputMethodRelay()->grabForKeyboard(m_keyboard);
+      wlr_input_method_keyboard_grab_v2* grab = activeInputMethodGrab();
       if (grab != nullptr) {
         wlr_input_method_keyboard_grab_v2_set_keyboard(grab, m_keyboard);
         wlr_input_method_keyboard_grab_v2_send_key(grab, event->time_msec, event->keycode, event->state);

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -7,6 +7,7 @@
 #include <xkbcommon/xkbcommon.h>
 
 struct wlr_input_device;
+struct wlr_input_method_keyboard_grab_v2;
 struct wlr_keyboard;
 
 namespace umbriel {
@@ -41,6 +42,9 @@ namespace umbriel {
     // Fire the IPC keyboard-layout event when the effective group changed since the last notification. A single
     // keyboard drives the event stream, so the tracked index is per-keyboard and the first notification always fires.
     void notifyLayoutIfChanged();
+    // The input-method grab for this keyboard, or null when none applies. Always null while locked, so an IME cannot
+    // keylog the lock screen.
+    [[nodiscard]] wlr_input_method_keyboard_grab_v2* activeInputMethodGrab() const;
     void armRepeat(const Keybind& bind, uint32_t keycode);
     void cancelRepeat();
     static int onRepeatTimer(void* data);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Input-method grabs intercept keys ahead of the seat, so while the session was locked an IME client could read every keypress on the lock screen. Now this returns no active grab while locked, so keys reach only the lock screen surface.

## Motivation

Any input-method client could keylog the lock screen

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

- `just format`
- `just check` (all pass)
- builds fine with no new warnings

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [ ] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

Compositor keybinds are unaffected (they resolve before the grab path) so media keys keep working from the lock screen.
