### PR TITLE
feat(rules): add named scrolling columns

### DIFF
--- a/docs/user/rules.md
+++ b/docs/user/rules.md
@@ -64,8 +64,8 @@ opening settings do not overwrite user changes made in the meantime.
 | `default_width` | float | For floating windows, the initial width as a fraction (0.1-1.0) of the usable area. This includes windows that float without `default_floating`, such as dialogs that declare a parent. For tiled windows, scrolling only: lane scroll-axis extent fraction (0.1-1.0), which is height on a vertical workspace. Gap-aware: fractions that sum to 1 tile exactly. Overrides `layout.scrolling.default_width_fraction`. Dragging the lane within or between scrolling workspaces retains its current fraction. Ignored in dwindle and master. |
 | `default_height` | float | Floating windows only, on the same terms as `default_width`. Initial height as a fraction (0.1-1.0) of the usable area. Ignored for tiled windows. |
 | `default_workspace` | int | Place on workspace N from 1 to 64. On dynamic outputs, values beyond the current count clamp to the last workspace. |
-| `default_column` | string | Scrolling only. Place windows with the same non-empty name in one column. Floating windows and other layout modes ignore it. |
-| `default_column_order` | int | Position within `default_column`, independent of launch timing. Lower values open higher in horizontal scrolling and farther left in vertical scrolling. Windows without an order follow ordered windows. |
+| `default_scrolling_column` | string | Scrolling only. Place windows with the same non-empty name in one column. Floating windows and other layout modes ignore it. |
+| `default_scrolling_column_order` | int | Position within `default_scrolling_column`, independent of launch timing. Lower values open higher in horizontal scrolling and farther left in vertical scrolling. Windows without an order follow ordered windows. |
 | `default_fullscreen` | bool | Open in fullscreen. |
 | `default_maximize_to_edges` | bool | Explicitly open maximized to edges. The initial configure fills the usable area without gaps or borders, so the window does not open at its normal size first. Layer-shell exclusive zones stay visible. Takes precedence over `default_maximize`; when combined with `default_fullscreen` the window opens fullscreen and returns to maximized to edges once fullscreen is cleared. |
 | `default_maximize` | bool | Explicitly open maximized. Parented transient dialogs keep their natural size. The initial configure uses the layout's final full-width target, so the window does not open at its normal size first. Umbriel ignores client maximization requested before the first buffer maps unless `general.honor_restored_maximize` is enabled, but always honors requests sent after mapping. Tiled windows expand their column to full width without changing the layout; floating windows fill the usable area. |
@@ -83,28 +83,28 @@ was launched from another output. If several fixed outputs contain that
 position, Umbriel keeps the launch output. An explicit `default_output` always
 scopes the workspace lookup to that output.
 
-#### Named columns
+#### Named scrolling columns
 
-Assign the same `default_column` to applications that should share a scrolling
-column. The first matching window opens a column. Later matches on the same
-workspace join it.
+Assign the same `default_scrolling_column` to applications that should share a
+scrolling column. The first matching window opens a column. Later matches on the
+same workspace join it.
 
 ```toml
 [[window_rule]]
 match.app_id = "^firefox$"
-default_column = "browsers"
-default_column_order = 10
+default_scrolling_column = "browsers"
+default_scrolling_column_order = 10
 
 [[window_rule]]
 match.app_id = "^chromium$"
-default_column = "browsers"
-default_column_order = 20
+default_scrolling_column = "browsers"
+default_scrolling_column_order = 20
 ```
 
-The name is local to a workspace. If a named column has been split manually,
+The name is local to a workspace. If a named scrolling column has been split manually,
 new windows join the first column containing that name. The first window also
-sets the column width. `default_column_order` has no effect without
-`default_column`.
+sets the column width. `default_scrolling_column_order` has no effect without
+`default_scrolling_column`.
 
 #### Floating position
 

--- a/docs/user/rules.md
+++ b/docs/user/rules.md
@@ -64,6 +64,8 @@ opening settings do not overwrite user changes made in the meantime.
 | `default_width` | float | For floating windows, the initial width as a fraction (0.1-1.0) of the usable area. This includes windows that float without `default_floating`, such as dialogs that declare a parent. For tiled windows, scrolling only: lane scroll-axis extent fraction (0.1-1.0), which is height on a vertical workspace. Gap-aware: fractions that sum to 1 tile exactly. Overrides `layout.scrolling.default_width_fraction`. Dragging the lane within or between scrolling workspaces retains its current fraction. Ignored in dwindle and master. |
 | `default_height` | float | Floating windows only, on the same terms as `default_width`. Initial height as a fraction (0.1-1.0) of the usable area. Ignored for tiled windows. |
 | `default_workspace` | int | Place on workspace N from 1 to 64. On dynamic outputs, values beyond the current count clamp to the last workspace. |
+| `default_column` | string | Scrolling only. Place windows with the same non-empty name in one column. Floating windows and other layout modes ignore it. |
+| `default_column_order` | int | Position within `default_column`, independent of launch timing. Lower values open higher in horizontal scrolling and farther left in vertical scrolling. Windows without an order follow ordered windows. |
 | `default_fullscreen` | bool | Open in fullscreen. |
 | `default_maximize_to_edges` | bool | Explicitly open maximized to edges. The initial configure fills the usable area without gaps or borders, so the window does not open at its normal size first. Layer-shell exclusive zones stay visible. Takes precedence over `default_maximize`; when combined with `default_fullscreen` the window opens fullscreen and returns to maximized to edges once fullscreen is cleared. |
 | `default_maximize` | bool | Explicitly open maximized. Parented transient dialogs keep their natural size. The initial configure uses the layout's final full-width target, so the window does not open at its normal size first. Umbriel ignores client maximization requested before the first buffer maps unless `general.honor_restored_maximize` is enabled, but always honors requests sent after mapping. Tiled windows expand their column to full width without changing the layout; floating windows fill the usable area. |
@@ -80,6 +82,29 @@ configured workspace, `default_workspace = 4` opens there even when the window
 was launched from another output. If several fixed outputs contain that
 position, Umbriel keeps the launch output. An explicit `default_output` always
 scopes the workspace lookup to that output.
+
+#### Named columns
+
+Assign the same `default_column` to applications that should share a scrolling
+column. The first matching window opens a column. Later matches on the same
+workspace join it.
+
+```toml
+[[window_rule]]
+match.app_id = "^firefox$"
+default_column = "browsers"
+default_column_order = 10
+
+[[window_rule]]
+match.app_id = "^chromium$"
+default_column = "browsers"
+default_column_order = 20
+```
+
+The name is local to a workspace. If a named column has been split manually,
+new windows join the first column containing that name. The first window also
+sets the column width. `default_column_order` has no effect without
+`default_column`.
 
 #### Floating position
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -422,8 +422,8 @@ default_size = [800, 600]
 # appear higher in horizontal scrolling and farther left in vertical scrolling.
 # [[window_rule]]
 # match.app_id = "^firefox$"
-# default_column = "browsers"
-# default_column_order = 10
+# default_scrolling_column = "browsers"
+# default_scrolling_column_order = 10
 
 # [[window_rule]]
 # match.title = "^notificationtoasts_.+_desktop"

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -418,6 +418,13 @@ default_size = [800, 600]
 # tearing = true                 # force a tearing request; false vetoes the client hint
 # hdr = "fullscreen"            # override the output HDR policy while focused
 
+# Keep tiled windows from several rules in one scrolling column. Lower orders
+# appear higher in horizontal scrolling and farther left in vertical scrolling.
+# [[window_rule]]
+# match.app_id = "^firefox$"
+# default_column = "browsers"
+# default_column_order = 10
+
 # [[window_rule]]
 # match.title = "^notificationtoasts_.+_desktop"
 # default_position = { x = 0, y = 0, anchor = "bottom_right" }

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1700,17 +1700,17 @@ namespace umbriel {
           }
         }
 
-        if (const toml::node* n = keys.take("default_column")) {
+        if (const toml::node* n = keys.take("default_scrolling_column")) {
           const auto value = n->value<std::string>();
           if (!value || value->empty()) {
-            warnAt(n->source(), "ignoring window_rule.default_column (expected non-empty string)");
+            warnAt(n->source(), "ignoring window_rule.default_scrolling_column (expected non-empty string)");
           } else {
-            rule.defaultColumn = *value;
+            rule.defaultScrollingColumn = *value;
           }
         }
         keys.integer(
-            "default_column_order", std::numeric_limits<int>::min(), std::numeric_limits<int>::max(),
-            rule.defaultColumnOrder
+            "default_scrolling_column_order", std::numeric_limits<int>::min(), std::numeric_limits<int>::max(),
+            rule.defaultScrollingColumnOrder
         );
 
         if (valid) {

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -26,6 +26,7 @@
 #include <format>
 #include <initializer_list>
 #include <iterator>
+#include <limits>
 #include <string_view>
 #include <utility>
 
@@ -1698,6 +1699,19 @@ namespace umbriel {
             rule.defaultWorkspace = static_cast<int>(*value);
           }
         }
+
+        if (const toml::node* n = keys.take("default_column")) {
+          const auto value = n->value<std::string>();
+          if (!value || value->empty()) {
+            warnAt(n->source(), "ignoring window_rule.default_column (expected non-empty string)");
+          } else {
+            rule.defaultColumn = *value;
+          }
+        }
+        keys.integer(
+            "default_column_order", std::numeric_limits<int>::min(), std::numeric_limits<int>::max(),
+            rule.defaultColumnOrder
+        );
 
         if (valid) {
           loaded.windowRules.push_back(std::move(rule));

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -243,8 +243,8 @@ namespace umbriel {
     std::optional<double> defaultWidth;  // column width fraction override
     std::optional<double> defaultHeight; // floating height fraction of the usable area
     std::optional<int> defaultWorkspace; // 1-64
-    std::optional<std::string> defaultColumn;
-    std::optional<int> defaultColumnOrder;
+    std::optional<std::string> defaultScrollingColumn;
+    std::optional<int> defaultScrollingColumnOrder;
     std::optional<bool> defaultFullscreen;
     std::optional<bool> defaultMaximizeToEdges;
     std::optional<bool> defaultMaximize;
@@ -277,8 +277,8 @@ namespace umbriel {
           && defaultWidth == other.defaultWidth
           && defaultHeight == other.defaultHeight
           && defaultWorkspace == other.defaultWorkspace
-          && defaultColumn == other.defaultColumn
-          && defaultColumnOrder == other.defaultColumnOrder
+          && defaultScrollingColumn == other.defaultScrollingColumn
+          && defaultScrollingColumnOrder == other.defaultScrollingColumnOrder
           && defaultFullscreen == other.defaultFullscreen
           && defaultMaximizeToEdges == other.defaultMaximizeToEdges
           && defaultMaximize == other.defaultMaximize
@@ -305,8 +305,8 @@ namespace umbriel {
     std::optional<double> defaultWidth;
     std::optional<double> defaultHeight;
     std::optional<int> defaultWorkspace;
-    std::optional<std::string> defaultColumn;
-    std::optional<int> defaultColumnOrder;
+    std::optional<std::string> defaultScrollingColumn;
+    std::optional<int> defaultScrollingColumnOrder;
     std::optional<bool> defaultFullscreen;
     std::optional<bool> defaultMaximizeToEdges;
     std::optional<bool> defaultMaximize;

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -243,6 +243,8 @@ namespace umbriel {
     std::optional<double> defaultWidth;  // column width fraction override
     std::optional<double> defaultHeight; // floating height fraction of the usable area
     std::optional<int> defaultWorkspace; // 1-64
+    std::optional<std::string> defaultColumn;
+    std::optional<int> defaultColumnOrder;
     std::optional<bool> defaultFullscreen;
     std::optional<bool> defaultMaximizeToEdges;
     std::optional<bool> defaultMaximize;
@@ -275,6 +277,8 @@ namespace umbriel {
           && defaultWidth == other.defaultWidth
           && defaultHeight == other.defaultHeight
           && defaultWorkspace == other.defaultWorkspace
+          && defaultColumn == other.defaultColumn
+          && defaultColumnOrder == other.defaultColumnOrder
           && defaultFullscreen == other.defaultFullscreen
           && defaultMaximizeToEdges == other.defaultMaximizeToEdges
           && defaultMaximize == other.defaultMaximize
@@ -301,6 +305,8 @@ namespace umbriel {
     std::optional<double> defaultWidth;
     std::optional<double> defaultHeight;
     std::optional<int> defaultWorkspace;
+    std::optional<std::string> defaultColumn;
+    std::optional<int> defaultColumnOrder;
     std::optional<bool> defaultFullscreen;
     std::optional<bool> defaultMaximizeToEdges;
     std::optional<bool> defaultMaximize;

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -175,11 +175,11 @@ namespace umbriel {
       if (rule.defaultWorkspace) {
         resolved.defaultWorkspace = rule.defaultWorkspace;
       }
-      if (rule.defaultColumn) {
-        resolved.defaultColumn = rule.defaultColumn;
+      if (rule.defaultScrollingColumn) {
+        resolved.defaultScrollingColumn = rule.defaultScrollingColumn;
       }
-      if (rule.defaultColumnOrder) {
-        resolved.defaultColumnOrder = rule.defaultColumnOrder;
+      if (rule.defaultScrollingColumnOrder) {
+        resolved.defaultScrollingColumnOrder = rule.defaultScrollingColumnOrder;
       }
       if (rule.defaultFullscreen) {
         resolved.defaultFullscreen = rule.defaultFullscreen;

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -175,6 +175,12 @@ namespace umbriel {
       if (rule.defaultWorkspace) {
         resolved.defaultWorkspace = rule.defaultWorkspace;
       }
+      if (rule.defaultColumn) {
+        resolved.defaultColumn = rule.defaultColumn;
+      }
+      if (rule.defaultColumnOrder) {
+        resolved.defaultColumnOrder = rule.defaultColumnOrder;
+      }
       if (rule.defaultFullscreen) {
         resolved.defaultFullscreen = rule.defaultFullscreen;
       }

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -1582,7 +1582,8 @@ namespace umbriel {
             .workspaceName = workspace->name(),
             .layoutSnapshot = nullptr,
             .layoutMember = 0,
-            .ownsNamedColumnWidth = view->m_ownsNamedColumnWidth,
+            .ownsNamedScrollingColumnWidth = view->m_ownsNamedScrollingColumnWidth,
+            .pendingNamedScrollingColumnWidth = std::nullopt,
             .layoutModeOverride = workspace->layoutModeOverride(),
             .floatingOutputPosition = std::nullopt,
             .configGeneration = configStore().generation(),
@@ -1770,6 +1771,17 @@ namespace umbriel {
         first = last;
         continue;
       }
+      const auto applyPendingNamedScrollingColumnWidth = [workspace](View* view, const View::DisplacedHome& home) {
+        if (!home.pendingNamedScrollingColumnWidth || !view->namedScrollingColumnName()) {
+          return;
+        }
+        ScrollingLayout* scrolling = workspace->scrollingLayout();
+        const int column = scrolling != nullptr ? scrolling->columnOf(view) : -1;
+        if (column >= 0) {
+          scrolling->setWidthFraction(column, *home.pendingNamedScrollingColumnWidth);
+          workspace->markArrange(false);
+        }
+      };
 
       struct SnapshotCandidate {
         std::shared_ptr<const LayoutSnapshot> snapshot;
@@ -1830,9 +1842,9 @@ namespace umbriel {
       std::vector<View*> exactViews;
       if (exact != nullptr) {
         for (View* view : exact->views) {
-          const bool ownsNamedColumnWidth = view->displacedHome()->ownsNamedColumnWidth;
+          const bool ownsNamedScrollingColumnWidth = view->displacedHome()->ownsNamedScrollingColumnWidth;
           view->setWorkspace(workspace, false);
-          view->m_ownsNamedColumnWidth = ownsNamedColumnWidth;
+          view->m_ownsNamedScrollingColumnWidth = ownsNamedScrollingColumnWidth;
           if (view->workspace() == workspace && view->mapped() && view->tiled()) {
             exactViews.push_back(view);
           }
@@ -1882,6 +1894,9 @@ namespace umbriel {
           }
           workspace->markArrange(false);
         }
+        for (View* view : exactViews) {
+          applyPendingNamedScrollingColumnWidth(view, *view->displacedHome());
+        }
         restored += exactViews.size();
       }
 
@@ -1923,6 +1938,7 @@ namespace umbriel {
         if (moved) {
           view->setWorkspace(workspace);
         }
+        applyPendingNamedScrollingColumnWidth(view, home);
         if (floating && home.floatingOutputPosition && target != nullptr) {
           const wlr_box outputBox = target->layoutBox();
           if (outputBox.width > 0 && outputBox.height > 0) {

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -1582,6 +1582,7 @@ namespace umbriel {
             .workspaceName = workspace->name(),
             .layoutSnapshot = nullptr,
             .layoutMember = 0,
+            .ownsNamedColumnWidth = view->m_ownsNamedColumnWidth,
             .layoutModeOverride = workspace->layoutModeOverride(),
             .floatingOutputPosition = std::nullopt,
             .configGeneration = configStore().generation(),
@@ -1829,7 +1830,9 @@ namespace umbriel {
       std::vector<View*> exactViews;
       if (exact != nullptr) {
         for (View* view : exact->views) {
+          const bool ownsNamedColumnWidth = view->displacedHome()->ownsNamedColumnWidth;
           view->setWorkspace(workspace, false);
+          view->m_ownsNamedColumnWidth = ownsNamedColumnWidth;
           if (view->workspace() == workspace && view->mapped() && view->tiled()) {
             exactViews.push_back(view);
           }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1683,8 +1683,8 @@ namespace umbriel {
     m_initialRules = rule;
     m_initialRulesXdgTag = m_xdgTag;
     m_initialRulesContentType = m_contentType;
-    m_namedColumnName = rule.defaultColumn;
-    m_namedColumnOrder = rule.defaultColumnOrder;
+    m_namedScrollingColumnName = rule.defaultScrollingColumn;
+    m_namedScrollingColumnOrder = rule.defaultScrollingColumnOrder;
     if (rule.defaultFloating) {
       m_tiled = !*rule.defaultFloating;
     }
@@ -1880,9 +1880,9 @@ namespace umbriel {
     m_initialRules = {};
     m_initialRulesXdgTag.clear();
     m_initialRulesContentType = ContentType::None;
-    m_namedColumnName.reset();
-    m_namedColumnOrder.reset();
-    m_ownsNamedColumnWidth = false;
+    m_namedScrollingColumnName.reset();
+    m_namedScrollingColumnOrder.reset();
+    m_ownsNamedScrollingColumnWidth = false;
     m_ruleOpacity = 1.0F;
     m_hasMaximizeRestoreBox = false;
     m_floating.clearSizeRequest();
@@ -2014,13 +2014,16 @@ namespace umbriel {
         const Layout& layout = target != nullptr ? target->layout() : *fallbackLayout;
 
         Layout::InitialSize initial;
-        const std::optional<Layout::InitialSize> namedColumnInitial = target != nullptr && rule.defaultColumn
-            ? target->initialNamedColumnSize(this, usable, *rule.defaultColumn, rule.defaultColumnOrder, wantMaximized)
+        const std::optional<Layout::InitialSize> namedScrollingColumnInitial =
+            target != nullptr && rule.defaultScrollingColumn
+            ? target->initialNamedScrollingColumnSize(
+                  this, usable, *rule.defaultScrollingColumn, rule.defaultScrollingColumnOrder, wantMaximized
+              )
             : std::nullopt;
         if (wantMaximizeToEdges) {
           initial = {.width = usable.width, .height = usable.height};
-        } else if (namedColumnInitial) {
-          initial = *namedColumnInitial;
+        } else if (namedScrollingColumnInitial) {
+          initial = *namedScrollingColumnInitial;
         } else if (wantMaximized && target != nullptr) {
           initial = target->initialMaximizedSize(this, usable);
         } else {
@@ -2028,8 +2031,9 @@ namespace umbriel {
           initial = layout.initialSize(usable, widthFraction, target != nullptr ? target->focusedView() : nullptr);
         }
         const XdgSizeHints hints = xdgSizeHints(m_toplevel);
-        const int requestedWidth =
-            (rule.defaultSize && !wantMaximized && !namedColumnInitial) ? (*rule.defaultSize)[0] : initial.width;
+        const int requestedWidth = (rule.defaultSize && !wantMaximized && !namedScrollingColumnInitial)
+            ? (*rule.defaultSize)[0]
+            : initial.width;
         const int width =
             (requestedWidth > 0 && !wantMaximizeToEdges) ? clampXdgWidth(requestedWidth, hints) : requestedWidth;
         const int height =
@@ -2754,19 +2758,19 @@ namespace umbriel {
         m_borderFocusedState
     );
 
-    const bool namedColumnNameChanged =
-        rule.defaultColumn.has_value() && rule.defaultColumn != initiallyApplied.defaultColumn;
-    const bool namedColumnOrderChanged =
-        rule.defaultColumn.has_value() && rule.defaultColumnOrder != initiallyApplied.defaultColumnOrder;
-    std::optional<Workspace::NamedColumnChange> namedColumnChange;
-    if (namedColumnNameChanged) {
-      namedColumnChange = Workspace::NamedColumnChange::Name;
-    } else if (namedColumnOrderChanged) {
-      namedColumnChange = Workspace::NamedColumnChange::Order;
+    const bool namedScrollingColumnNameChanged = rule.defaultScrollingColumn.has_value()
+        && rule.defaultScrollingColumn != initiallyApplied.defaultScrollingColumn;
+    const bool namedScrollingColumnOrderChanged = rule.defaultScrollingColumn.has_value()
+        && rule.defaultScrollingColumnOrder != initiallyApplied.defaultScrollingColumnOrder;
+    std::optional<Workspace::NamedScrollingColumnChange> namedScrollingColumnChange;
+    if (namedScrollingColumnNameChanged) {
+      namedScrollingColumnChange = Workspace::NamedScrollingColumnChange::Name;
+    } else if (namedScrollingColumnOrderChanged) {
+      namedScrollingColumnChange = Workspace::NamedScrollingColumnChange::Order;
     }
-    if (namedColumnChange) {
-      m_namedColumnName = rule.defaultColumn;
-      m_namedColumnOrder = rule.defaultColumnOrder;
+    if (namedScrollingColumnChange) {
+      m_namedScrollingColumnName = rule.defaultScrollingColumn;
+      m_namedScrollingColumnOrder = rule.defaultScrollingColumnOrder;
     }
 
     // Identity can arrive after map. Apply a newly selected one-shot value, but
@@ -2799,8 +2803,8 @@ namespace umbriel {
       }
     }
 
-    if (namedColumnChange && m_workspace != nullptr) {
-      m_workspace->applyNamedColumnRule(this, rule.defaultWidth, *namedColumnChange);
+    if (namedScrollingColumnChange && m_workspace != nullptr) {
+      m_workspace->applyNamedScrollingColumnRule(this, rule.defaultWidth, *namedScrollingColumnChange);
     }
 
     if (changedInitialRule(rule.defaultPinned, initiallyApplied.defaultPinned)) {
@@ -2808,10 +2812,22 @@ namespace umbriel {
     }
 
     ScrollingLayout* scrolling = m_workspace != nullptr ? m_workspace->scrollingLayout() : nullptr;
-    if (changedInitialRule(rule.defaultWidth, initiallyApplied.defaultWidth)
+    const bool defaultWidthChanged = changedInitialRule(rule.defaultWidth, initiallyApplied.defaultWidth);
+    const bool ownsNamedScrollingColumnWidth =
+        m_displacedHome ? m_displacedHome->ownsNamedScrollingColumnWidth : m_ownsNamedScrollingColumnWidth;
+    if (defaultWidthChanged
+        && m_tiled
+        && m_namedScrollingColumnName
+        && m_displacedHome
+        && ownsNamedScrollingColumnWidth) {
+      m_displacedHome->pendingNamedScrollingColumnWidth = rule.defaultWidth;
+    }
+    const bool canResizeCurrentNamedScrollingColumn =
+        ownsNamedScrollingColumnWidth && (!m_displacedHome || m_ownsNamedScrollingColumnWidth);
+    if (defaultWidthChanged
         && m_tiled
         && scrolling != nullptr
-        && (!m_namedColumnName || m_ownsNamedColumnWidth)) {
+        && (!m_namedScrollingColumnName || canResizeCurrentNamedScrollingColumn)) {
       const int column = scrolling->columnOf(this);
       if (column >= 0) {
         scrolling->setWidthFraction(column, *rule.defaultWidth);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1683,6 +1683,8 @@ namespace umbriel {
     m_initialRules = rule;
     m_initialRulesXdgTag = m_xdgTag;
     m_initialRulesContentType = m_contentType;
+    m_namedColumnName = rule.defaultColumn;
+    m_namedColumnOrder = rule.defaultColumnOrder;
     if (rule.defaultFloating) {
       m_tiled = !*rule.defaultFloating;
     }
@@ -1878,6 +1880,9 @@ namespace umbriel {
     m_initialRules = {};
     m_initialRulesXdgTag.clear();
     m_initialRulesContentType = ContentType::None;
+    m_namedColumnName.reset();
+    m_namedColumnOrder.reset();
+    m_ownsNamedColumnWidth = false;
     m_ruleOpacity = 1.0F;
     m_hasMaximizeRestoreBox = false;
     m_floating.clearSizeRequest();
@@ -2009,8 +2014,13 @@ namespace umbriel {
         const Layout& layout = target != nullptr ? target->layout() : *fallbackLayout;
 
         Layout::InitialSize initial;
+        const std::optional<Layout::InitialSize> namedColumnInitial = target != nullptr && rule.defaultColumn
+            ? target->initialNamedColumnSize(this, usable, *rule.defaultColumn, rule.defaultColumnOrder, wantMaximized)
+            : std::nullopt;
         if (wantMaximizeToEdges) {
           initial = {.width = usable.width, .height = usable.height};
+        } else if (namedColumnInitial) {
+          initial = *namedColumnInitial;
         } else if (wantMaximized && target != nullptr) {
           initial = target->initialMaximizedSize(this, usable);
         } else {
@@ -2018,7 +2028,8 @@ namespace umbriel {
           initial = layout.initialSize(usable, widthFraction, target != nullptr ? target->focusedView() : nullptr);
         }
         const XdgSizeHints hints = xdgSizeHints(m_toplevel);
-        const int requestedWidth = (rule.defaultSize && !wantMaximized) ? (*rule.defaultSize)[0] : initial.width;
+        const int requestedWidth =
+            (rule.defaultSize && !wantMaximized && !namedColumnInitial) ? (*rule.defaultSize)[0] : initial.width;
         const int width =
             (requestedWidth > 0 && !wantMaximizeToEdges) ? clampXdgWidth(requestedWidth, hints) : requestedWidth;
         const int height =
@@ -2743,6 +2754,21 @@ namespace umbriel {
         m_borderFocusedState
     );
 
+    const bool namedColumnNameChanged =
+        rule.defaultColumn.has_value() && rule.defaultColumn != initiallyApplied.defaultColumn;
+    const bool namedColumnOrderChanged =
+        rule.defaultColumn.has_value() && rule.defaultColumnOrder != initiallyApplied.defaultColumnOrder;
+    std::optional<Workspace::NamedColumnChange> namedColumnChange;
+    if (namedColumnNameChanged) {
+      namedColumnChange = Workspace::NamedColumnChange::Name;
+    } else if (namedColumnOrderChanged) {
+      namedColumnChange = Workspace::NamedColumnChange::Order;
+    }
+    if (namedColumnChange) {
+      m_namedColumnName = rule.defaultColumn;
+      m_namedColumnOrder = rule.defaultColumnOrder;
+    }
+
     // Identity can arrive after map. Apply a newly selected one-shot value, but
     // never replay a value already applied at map over the user's later state.
     if (changedInitialRule(rule.defaultFloating, initiallyApplied.defaultFloating)) {
@@ -2756,11 +2782,25 @@ namespace umbriel {
         && (rule.defaultOutput != initiallyApplied.defaultOutput
             || rule.defaultWorkspace != initiallyApplied.defaultWorkspace);
     if (placementChanged && m_workspace != nullptr) {
+      const bool wasActivated = m_activated;
       WorkspaceGroup* targetGroup = windowRuleWorkspaceGroup(*m_server, rule, m_workspace->group());
       Workspace* target = windowRuleWorkspace(targetGroup, rule);
       if (target != nullptr && target != m_workspace) {
-        setWorkspace(target);
+        setWorkspace(target, false);
+        if (m_workspace == target) {
+          target->layoutAttach(this, rule.defaultWidth);
+          if (m_tiled && m_toplevel->scheduled.maximized && !m_maximizedToEdges) {
+            setMaximized(true);
+          }
+          if (wasActivated) {
+            m_server->focusView(this);
+          }
+        }
       }
+    }
+
+    if (namedColumnChange && m_workspace != nullptr) {
+      m_workspace->applyNamedColumnRule(this, rule.defaultWidth, *namedColumnChange);
     }
 
     if (changedInitialRule(rule.defaultPinned, initiallyApplied.defaultPinned)) {
@@ -2768,7 +2808,10 @@ namespace umbriel {
     }
 
     ScrollingLayout* scrolling = m_workspace != nullptr ? m_workspace->scrollingLayout() : nullptr;
-    if (changedInitialRule(rule.defaultWidth, initiallyApplied.defaultWidth) && m_tiled && scrolling != nullptr) {
+    if (changedInitialRule(rule.defaultWidth, initiallyApplied.defaultWidth)
+        && m_tiled
+        && scrolling != nullptr
+        && (!m_namedColumnName || m_ownsNamedColumnWidth)) {
       const int column = scrolling->columnOf(this);
       if (column >= 0) {
         scrolling->setWidthFraction(column, *rule.defaultWidth);

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -64,8 +64,10 @@ namespace umbriel {
     [[nodiscard]] bool onActiveWorkspace() const { return m_onActiveWorkspace; }
     [[nodiscard]] bool tiled() const { return m_tiled; }
     [[nodiscard]] bool floating() const { return !m_tiled; }
-    [[nodiscard]] const std::optional<std::string>& namedColumnName() const { return m_namedColumnName; }
-    [[nodiscard]] std::optional<int> namedColumnOrder() const { return m_namedColumnOrder; }
+    [[nodiscard]] const std::optional<std::string>& namedScrollingColumnName() const {
+      return m_namedScrollingColumnName;
+    }
+    [[nodiscard]] std::optional<int> namedScrollingColumnOrder() const { return m_namedScrollingColumnOrder; }
     [[nodiscard]] bool pinned() const { return m_pinned; }
     // True while an unfullscreen configure with size 0x0 is unacknowledged;
     // Workspace::arrange must not impose the column size yet.
@@ -120,7 +122,10 @@ namespace umbriel {
       std::string workspaceName;
       std::shared_ptr<const LayoutSnapshot> layoutSnapshot;
       LayoutMemberId layoutMember = 0;
-      bool ownsNamedColumnWidth = false;
+      bool ownsNamedScrollingColumnWidth = false;
+      // A late owner width can settle while this window is temporarily attached
+      // to another output. Replay it after restoring the captured home layout.
+      std::optional<double> pendingNamedScrollingColumnWidth;
       std::optional<LayoutMode> layoutModeOverride;
       // Position relative to the full logical output. Unlike the ordinary
       // usable-area memory, this stays stable while a returning panel has not
@@ -377,11 +382,11 @@ namespace umbriel {
     ResolvedWindowRule m_initialRules;
     std::string m_initialRulesXdgTag;
     ContentType m_initialRulesContentType = ContentType::None;
-    std::optional<std::string> m_namedColumnName;
-    std::optional<int> m_namedColumnOrder;
+    std::optional<std::string> m_namedScrollingColumnName;
+    std::optional<int> m_namedScrollingColumnOrder;
     // True for the member that created its current named scrolling column.
     // Its own late width rule still applies after peers have joined.
-    bool m_ownsNamedColumnWidth = false;
+    bool m_ownsNamedScrollingColumnWidth = false;
 
     Server* m_server = nullptr;
     wlr_xdg_toplevel* m_toplevel = nullptr;

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -64,6 +64,8 @@ namespace umbriel {
     [[nodiscard]] bool onActiveWorkspace() const { return m_onActiveWorkspace; }
     [[nodiscard]] bool tiled() const { return m_tiled; }
     [[nodiscard]] bool floating() const { return !m_tiled; }
+    [[nodiscard]] const std::optional<std::string>& namedColumnName() const { return m_namedColumnName; }
+    [[nodiscard]] std::optional<int> namedColumnOrder() const { return m_namedColumnOrder; }
     [[nodiscard]] bool pinned() const { return m_pinned; }
     // True while an unfullscreen configure with size 0x0 is unacknowledged;
     // Workspace::arrange must not impose the column size yet.
@@ -118,6 +120,7 @@ namespace umbriel {
       std::string workspaceName;
       std::shared_ptr<const LayoutSnapshot> layoutSnapshot;
       LayoutMemberId layoutMember = 0;
+      bool ownsNamedColumnWidth = false;
       std::optional<LayoutMode> layoutModeOverride;
       // Position relative to the full logical output. Unlike the ordinary
       // usable-area memory, this stays stable while a returning panel has not
@@ -220,6 +223,7 @@ namespace umbriel {
     friend class Server;
     friend class Popup;
     friend class Overview;
+    friend class Workspace;
 
     struct ViewSurfaceWatch {
       View* view = nullptr;
@@ -373,6 +377,11 @@ namespace umbriel {
     ResolvedWindowRule m_initialRules;
     std::string m_initialRulesXdgTag;
     ContentType m_initialRulesContentType = ContentType::None;
+    std::optional<std::string> m_namedColumnName;
+    std::optional<int> m_namedColumnOrder;
+    // True for the member that created its current named scrolling column.
+    // Its own late width rule still applies after peers have joined.
+    bool m_ownsNamedColumnWidth = false;
 
     Server* m_server = nullptr;
     wlr_xdg_toplevel* m_toplevel = nullptr;

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -50,12 +50,12 @@ namespace umbriel {
       };
     }
 
-    struct NamedColumnPlacement {
+    struct NamedScrollingColumnPlacement {
       size_t column = 0;
       int row = 0;
     };
 
-    std::optional<NamedColumnPlacement> namedColumnPlacement(
+    std::optional<NamedScrollingColumnPlacement> namedScrollingColumnPlacement(
         const ScrollingLayout& layout, const View* joining, std::string_view name, std::optional<int> order
     ) {
       if (name.empty()) {
@@ -65,24 +65,27 @@ namespace umbriel {
       for (size_t columnIndex = 0; columnIndex < columns.size(); ++columnIndex) {
         const Column& column = columns[columnIndex];
         const auto anchor = std::ranges::find_if(column.views, [&](const View* existing) {
-          return existing != joining && existing->namedColumnName() && *existing->namedColumnName() == name;
+          return existing != joining
+              && existing->namedScrollingColumnName()
+              && *existing->namedScrollingColumnName() == name;
         });
         if (anchor == column.views.end()) {
           continue;
         }
 
-        const auto before = order ? std::ranges::find_if(
-                                        column.views,
-                                        [&](const View* existing) {
-                                          const std::optional<int> existingOrder = existing->namedColumnOrder();
-                                          return existing != joining
-                                              && existing->namedColumnName()
-                                              && *existing->namedColumnName() == name
-                                              && (!existingOrder || *existingOrder > *order);
-                                        }
-                                    )
-                                  : column.views.end();
-        return NamedColumnPlacement{
+        const auto before = order
+            ? std::ranges::find_if(
+                  column.views,
+                  [&](const View* existing) {
+                    const std::optional<int> existingOrder = existing->namedScrollingColumnOrder();
+                    return existing != joining
+                        && existing->namedScrollingColumnName()
+                        && *existing->namedScrollingColumnName() == name
+                        && (!existingOrder || *existingOrder > *order);
+                  }
+              )
+            : column.views.end();
+        return NamedScrollingColumnPlacement{
             .column = columnIndex,
             .row = static_cast<int>(std::distance(column.views.begin(), before)),
         };
@@ -290,11 +293,11 @@ namespace umbriel {
       return;
     }
     ScrollingLayout* scrolling = scrollingLayout();
-    const std::optional<std::string>& name = view->namedColumnName();
-    const std::optional<NamedColumnPlacement> placement = scrolling != nullptr && name
-        ? namedColumnPlacement(*scrolling, view, *name, view->namedColumnOrder())
+    const std::optional<std::string>& name = view->namedScrollingColumnName();
+    const std::optional<NamedScrollingColumnPlacement> placement = scrolling != nullptr && name
+        ? namedScrollingColumnPlacement(*scrolling, view, *name, view->namedScrollingColumnOrder())
         : std::nullopt;
-    view->m_ownsNamedColumnWidth = scrolling != nullptr && name.has_value() && !placement;
+    view->m_ownsNamedScrollingColumnWidth = scrolling != nullptr && name.has_value() && !placement;
     if (placement) {
       scrolling->insertViewIntoColumn(view, static_cast<int>(placement->column), placement->row);
     } else {
@@ -346,14 +349,15 @@ namespace umbriel {
     return {.width = target.width, .height = target.height};
   }
 
-  std::optional<Layout::InitialSize> Workspace::initialNamedColumnSize(
+  std::optional<Layout::InitialSize> Workspace::initialNamedScrollingColumnSize(
       View* view, const wlr_box& usable, std::string_view group, std::optional<int> order, bool maximized
   ) const {
     const ScrollingLayout* scrolling = scrollingLayout();
     if (view == nullptr || scrolling == nullptr) {
       return std::nullopt;
     }
-    const std::optional<NamedColumnPlacement> placement = namedColumnPlacement(*scrolling, view, group, order);
+    const std::optional<NamedScrollingColumnPlacement> placement =
+        namedScrollingColumnPlacement(*scrolling, view, group, order);
     if (!placement) {
       return std::nullopt;
     }
@@ -376,12 +380,18 @@ namespace umbriel {
     return Layout::InitialSize{.width = target.width, .height = target.height};
   }
 
-  void Workspace::applyNamedColumnRule(View* view, std::optional<double> initialWidth, NamedColumnChange change) {
+  void Workspace::applyNamedScrollingColumnRule(
+      View* view, std::optional<double> initialWidth, NamedScrollingColumnChange change
+  ) {
     ScrollingLayout* scrolling = scrollingLayout();
-    if (view == nullptr || !view->mapped() || !view->tiled() || scrolling == nullptr || !view->namedColumnName()) {
+    if (view == nullptr
+        || !view->mapped()
+        || !view->tiled()
+        || scrolling == nullptr
+        || !view->namedScrollingColumnName()) {
       return;
     }
-    const std::string& name = *view->namedColumnName();
+    const std::string& name = *view->namedScrollingColumnName();
     const auto restoreMaximizedColumn = [&] {
       const int column = scrolling->columnOf(view);
       if (column >= 0
@@ -391,20 +401,20 @@ namespace umbriel {
         scrolling->toggleFullWidth(column);
       }
     };
-    std::optional<NamedColumnPlacement> placement =
-        namedColumnPlacement(*scrolling, view, name, view->namedColumnOrder());
+    std::optional<NamedScrollingColumnPlacement> placement =
+        namedScrollingColumnPlacement(*scrolling, view, name, view->namedScrollingColumnOrder());
     switch (change) {
-    case NamedColumnChange::Name:
-      view->m_ownsNamedColumnWidth = !placement;
+    case NamedScrollingColumnChange::Name:
+      view->m_ownsNamedScrollingColumnWidth = !placement;
       break;
-    case NamedColumnChange::Order:
+    case NamedScrollingColumnChange::Order:
       if (placement && static_cast<int>(placement->column) != scrolling->columnOf(view)) {
         return;
       }
       break;
     }
     if (!placement) {
-      if (change == NamedColumnChange::Order) {
+      if (change == NamedScrollingColumnChange::Order) {
         return;
       }
       const int previousColumn = scrolling->columnOf(view);
@@ -428,12 +438,12 @@ namespace umbriel {
 
     const int previousColumn = scrolling->columnOf(view);
     detachFromLayout(view);
-    placement = namedColumnPlacement(*scrolling, view, name, view->namedColumnOrder());
+    placement = namedScrollingColumnPlacement(*scrolling, view, name, view->namedScrollingColumnOrder());
     if (!placement) {
       // The earlier lookup found another member. Preserve a valid layout if a
       // future detach path ever removes more than the joining view.
       scrolling->insertView(view, std::clamp(previousColumn, 0, static_cast<int>(scrolling->columns().size())));
-      kLog.error("named column '{}' disappeared while moving a view", name);
+      kLog.error("named scrolling column '{}' disappeared while moving a view", name);
     } else {
       scrolling->insertViewIntoColumn(view, static_cast<int>(placement->column), placement->row);
     }

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
+#include <iterator>
 #include <utility>
 #include "wlr.h"
 // clang-format on
@@ -47,6 +48,46 @@ namespace umbriel {
           .fullscreen = view != nullptr && view->layoutFullscreen(),
           .maximizedToEdges = view != nullptr && view->maximizedToEdges(),
       };
+    }
+
+    struct NamedColumnPlacement {
+      size_t column = 0;
+      int row = 0;
+    };
+
+    std::optional<NamedColumnPlacement> namedColumnPlacement(
+        const ScrollingLayout& layout, const View* joining, std::string_view name, std::optional<int> order
+    ) {
+      if (name.empty()) {
+        return std::nullopt;
+      }
+      const auto& columns = layout.columns();
+      for (size_t columnIndex = 0; columnIndex < columns.size(); ++columnIndex) {
+        const Column& column = columns[columnIndex];
+        const auto anchor = std::ranges::find_if(column.views, [&](const View* existing) {
+          return existing != joining && existing->namedColumnName() && *existing->namedColumnName() == name;
+        });
+        if (anchor == column.views.end()) {
+          continue;
+        }
+
+        const auto before = order ? std::ranges::find_if(
+                                        column.views,
+                                        [&](const View* existing) {
+                                          const std::optional<int> existingOrder = existing->namedColumnOrder();
+                                          return existing != joining
+                                              && existing->namedColumnName()
+                                              && *existing->namedColumnName() == name
+                                              && (!existingOrder || *existingOrder > *order);
+                                        }
+                                    )
+                                  : column.views.end();
+        return NamedColumnPlacement{
+            .column = columnIndex,
+            .row = static_cast<int>(std::distance(column.views.begin(), before)),
+        };
+      }
+      return std::nullopt;
     }
   } // namespace
 
@@ -248,9 +289,19 @@ namespace umbriel {
     if (view == nullptr || !view->mapped() || !view->tiled() || m_layout->columnOf(view) >= 0) {
       return;
     }
-    const int index = layoutAttachIndex(view);
-    m_layout->insertView(view, index);
-    if (ScrollingLayout* scrolling = scrollingLayout(); scrolling != nullptr) {
+    ScrollingLayout* scrolling = scrollingLayout();
+    const std::optional<std::string>& name = view->namedColumnName();
+    const std::optional<NamedColumnPlacement> placement = scrolling != nullptr && name
+        ? namedColumnPlacement(*scrolling, view, *name, view->namedColumnOrder())
+        : std::nullopt;
+    view->m_ownsNamedColumnWidth = scrolling != nullptr && name.has_value() && !placement;
+    if (placement) {
+      scrolling->insertViewIntoColumn(view, static_cast<int>(placement->column), placement->row);
+    } else {
+      m_layout->insertView(view, layoutAttachIndex(view));
+    }
+
+    if (scrolling != nullptr && !placement) {
       const int column = scrolling->columnOf(view);
       const std::optional<double> configuredWidth =
           initialWidth ? initialWidth : m_layoutConfig.scrolling.defaultWidthFraction;
@@ -267,16 +318,24 @@ namespace umbriel {
     }
     markArrange(true);
   }
-  Layout::InitialSize Workspace::initialMaximizedSize(View* view, const wlr_box& usable) const {
+
+  std::unique_ptr<Layout> Workspace::previewLayout() const {
     LayoutCapture capture = m_layout->captureState();
     std::unique_ptr<Layout> preview = createLayout(m_layout->mode());
     preview->setConfig(&m_layoutConfig);
     preview->setConstraints(&viewLayoutConstraints);
     if (capture.snapshot == nullptr || !preview->restoreState(*capture.snapshot, capture.members)) {
-      kLog.error("failed to restore layout while resolving initial maximized size");
+      kLog.error("failed to restore layout preview");
+      return nullptr;
+    }
+    return preview;
+  }
+
+  Layout::InitialSize Workspace::initialMaximizedSize(View* view, const wlr_box& usable) const {
+    std::unique_ptr<Layout> preview = previewLayout();
+    if (preview == nullptr) {
       return m_layout->initialSize(usable, 1.0, m_focusedView);
     }
-
     preview->insertView(view, layoutAttachIndex(view));
     const int column = preview->columnOf(view);
     if (column >= 0 && !preview->isFullWidth(column)) {
@@ -285,6 +344,103 @@ namespace umbriel {
     preview->arrange(usable);
     const wlr_box target = preview->targetBox(view);
     return {.width = target.width, .height = target.height};
+  }
+
+  std::optional<Layout::InitialSize> Workspace::initialNamedColumnSize(
+      View* view, const wlr_box& usable, std::string_view group, std::optional<int> order, bool maximized
+  ) const {
+    const ScrollingLayout* scrolling = scrollingLayout();
+    if (view == nullptr || scrolling == nullptr) {
+      return std::nullopt;
+    }
+    const std::optional<NamedColumnPlacement> placement = namedColumnPlacement(*scrolling, view, group, order);
+    if (!placement) {
+      return std::nullopt;
+    }
+
+    std::unique_ptr<Layout> basePreview = previewLayout();
+    auto* preview = dynamic_cast<ScrollingLayout*>(basePreview.get());
+    if (preview == nullptr) {
+      return std::nullopt;
+    }
+    if (placement->column >= preview->columns().size()) {
+      return std::nullopt;
+    }
+    const int column = static_cast<int>(placement->column);
+    preview->insertViewIntoColumn(view, column, placement->row);
+    if (maximized && !preview->isFullWidth(column)) {
+      preview->toggleFullWidth(column);
+    }
+    preview->arrange(usable);
+    const wlr_box target = preview->targetBox(view);
+    return Layout::InitialSize{.width = target.width, .height = target.height};
+  }
+
+  void Workspace::applyNamedColumnRule(View* view, std::optional<double> initialWidth, NamedColumnChange change) {
+    ScrollingLayout* scrolling = scrollingLayout();
+    if (view == nullptr || !view->mapped() || !view->tiled() || scrolling == nullptr || !view->namedColumnName()) {
+      return;
+    }
+    const std::string& name = *view->namedColumnName();
+    const auto restoreMaximizedColumn = [&] {
+      const int column = scrolling->columnOf(view);
+      if (column >= 0
+          && view->toplevel()->scheduled.maximized
+          && !view->maximizedToEdges()
+          && !scrolling->isFullWidth(column)) {
+        scrolling->toggleFullWidth(column);
+      }
+    };
+    std::optional<NamedColumnPlacement> placement =
+        namedColumnPlacement(*scrolling, view, name, view->namedColumnOrder());
+    switch (change) {
+    case NamedColumnChange::Name:
+      view->m_ownsNamedColumnWidth = !placement;
+      break;
+    case NamedColumnChange::Order:
+      if (placement && static_cast<int>(placement->column) != scrolling->columnOf(view)) {
+        return;
+      }
+      break;
+    }
+    if (!placement) {
+      if (change == NamedColumnChange::Order) {
+        return;
+      }
+      const int previousColumn = scrolling->columnOf(view);
+      if (previousColumn < 0 || scrolling->columns()[static_cast<size_t>(previousColumn)].views.size() == 1) {
+        return;
+      }
+
+      // A late identity change can move a member from an established group to
+      // a new one. Start that group in its own adjacent column.
+      detachFromLayout(view);
+      scrolling->insertView(view, previousColumn + 1);
+      if (initialWidth) {
+        scrolling->setWidthFraction(scrolling->columnOf(view), *initialWidth);
+      }
+      restoreMaximizedColumn();
+      clampScrollToRange();
+      ensureFocusedVisible();
+      markArrange(true);
+      return;
+    }
+
+    const int previousColumn = scrolling->columnOf(view);
+    detachFromLayout(view);
+    placement = namedColumnPlacement(*scrolling, view, name, view->namedColumnOrder());
+    if (!placement) {
+      // The earlier lookup found another member. Preserve a valid layout if a
+      // future detach path ever removes more than the joining view.
+      scrolling->insertView(view, std::clamp(previousColumn, 0, static_cast<int>(scrolling->columns().size())));
+      kLog.error("named column '{}' disappeared while moving a view", name);
+    } else {
+      scrolling->insertViewIntoColumn(view, static_cast<int>(placement->column), placement->row);
+    }
+    restoreMaximizedColumn();
+    clampScrollToRange();
+    ensureFocusedVisible();
+    markArrange(true);
   }
 
   void Workspace::layoutDetach(View* view, bool animate) {

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -26,6 +26,11 @@ namespace umbriel {
 
   class Workspace {
   public:
+    enum class NamedColumnChange {
+      Name,
+      Order,
+    };
+
     Workspace(
         WorkspaceGroup& group, wlr_ext_workspace_handle_v1* handle, std::string id, std::string name, size_t index,
         ResolvedLayoutConfig layoutConfig
@@ -82,6 +87,14 @@ namespace umbriel {
     // Predict the first configure by applying the same insertion and full-width
     // transition that the mapped path will use on the authoritative layout.
     [[nodiscard]] Layout::InitialSize initialMaximizedSize(View* view, const wlr_box& usable) const;
+    // Predict the first configure for a view joining an existing named column.
+    [[nodiscard]] std::optional<Layout::InitialSize> initialNamedColumnSize(
+        View* view, const wlr_box& usable, std::string_view group, std::optional<int> order, bool maximized
+    ) const;
+    // Reposition a tiled view after a late title selects its named-column rule.
+    // initialWidth seeds a new column when its name has no existing member.
+    // A name change permits a split; an order-only change preserves manual placement.
+    void applyNamedColumnRule(View* view, std::optional<double> initialWidth, NamedColumnChange change);
     void layoutDetach(View* view, bool animate = false);
     void arrange(bool animate = true);
     // Record that the layout is stale instead of rebuilding it now. The work runs once, before the next frame, however
@@ -138,6 +151,7 @@ namespace umbriel {
   private:
     void applyPositions(bool animate);
     [[nodiscard]] wlr_box tiledTargetBox(const View* view, const wlr_box& usable) const;
+    [[nodiscard]] std::unique_ptr<Layout> previewLayout() const;
     [[nodiscard]] int layoutAttachIndex(const View* view) const;
     // Resize the focused floating window by usable-area fractions; an axis
     // without a fraction keeps its current basis size. False when no float is

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -26,7 +26,7 @@ namespace umbriel {
 
   class Workspace {
   public:
-    enum class NamedColumnChange {
+    enum class NamedScrollingColumnChange {
       Name,
       Order,
     };
@@ -87,14 +87,15 @@ namespace umbriel {
     // Predict the first configure by applying the same insertion and full-width
     // transition that the mapped path will use on the authoritative layout.
     [[nodiscard]] Layout::InitialSize initialMaximizedSize(View* view, const wlr_box& usable) const;
-    // Predict the first configure for a view joining an existing named column.
-    [[nodiscard]] std::optional<Layout::InitialSize> initialNamedColumnSize(
+    // Predict the first configure for a view joining an existing named scrolling column.
+    [[nodiscard]] std::optional<Layout::InitialSize> initialNamedScrollingColumnSize(
         View* view, const wlr_box& usable, std::string_view group, std::optional<int> order, bool maximized
     ) const;
-    // Reposition a tiled view after a late title selects its named-column rule.
+    // Reposition a tiled view after a late title selects its named scrolling-column rule.
     // initialWidth seeds a new column when its name has no existing member.
     // A name change permits a split; an order-only change preserves manual placement.
-    void applyNamedColumnRule(View* view, std::optional<double> initialWidth, NamedColumnChange change);
+    void
+    applyNamedScrollingColumnRule(View* view, std::optional<double> initialWidth, NamedScrollingColumnChange change);
     void layoutDetach(View* view, bool animate = false);
     void arrange(bool animate = true);
     // Record that the layout is stale instead of rebuilding it now. The work runs once, before the next frame, however

--- a/tests/harness/checks/115_named_columns.sh
+++ b/tests/harness/checks/115_named_columns.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Named-column rules stack real clients in configured order, not launch order.
+# Named scrolling-column rules stack real clients in configured order, not launch order.
 set -euo pipefail
 
 failed=0
@@ -30,31 +30,31 @@ default_width_fraction = 0.5
 
 [[window_rule]]
 match.title = "^named-later$"
-default_column = "browser-stack"
-default_column_order = 20
+default_scrolling_column = "browser-stack"
+default_scrolling_column_order = 20
 default_width = 0.6
 
 [[window_rule]]
 match.title = "^named-first$"
-default_column = "browser-stack"
+default_scrolling_column = "browser-stack"
 default_size = [300, 300]
-default_column_order = 10
+default_scrolling_column_order = 10
 default_width = 0.25
 
 [[window_rule]]
 match.title = "^named-delayed$"
-default_column = "browser-stack"
-default_column_order = 15
+default_scrolling_column = "browser-stack"
+default_scrolling_column_order = 15
 default_width = 0.4
 
 [[window_rule]]
 match.title = "^named-max-order$"
-default_column = "browser-stack"
-default_column_order = 2147483647
+default_scrolling_column = "browser-stack"
+default_scrolling_column_order = 2147483647
 
 [[window_rule]]
 match.title = "^named-unordered$"
-default_column = "browser-stack"
+default_scrolling_column = "browser-stack"
 EOF
 "$UMBRIEL" msg config-reload > /dev/null
 
@@ -131,7 +131,7 @@ if [[ $first_x != "$delayed_x" || $delayed_x != "$later_x" || $unrelated_x == "$
   failed=1
 fi
 if ((first_y >= delayed_y || delayed_y >= later_y)); then
-  echo "default_column_order did not place named clients in configured order: $windows"
+  echo "default_scrolling_column_order did not place named clients in configured order: $windows"
   failed=1
 fi
 if ((later_y >= max_order_y || max_order_y >= unordered_y)); then

--- a/tests/harness/checks/115_named_columns.sh
+++ b/tests/harness/checks/115_named_columns.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Named-column rules stack real clients in configured order, not launch order.
+set -euo pipefail
+
+failed=0
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
+readonly DELAYED_LOG="$UMBRIEL_RUNTIME_DIR/named-delayed.log"
+readonly FIRST_LOG="$UMBRIEL_RUNTIME_DIR/named-first.log"
+readonly CONTROL_FIFO="$UMBRIEL_RUNTIME_DIR/named-column-control"
+
+spawn_client() {
+  "$CLIENT" "$1" 800 600 > "$UMBRIEL_RUNTIME_DIR/$1.log" 2>&1 &
+}
+
+wait_for_windows() {
+  local count=$1
+  for _ in $(seq 60); do
+    [[ $("$UMBRIEL" windows --json | jq 'length') -eq $count ]] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for $count named-column clients: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[layout.scrolling]
+default_width_fraction = 0.5
+
+[[window_rule]]
+match.title = "^named-later$"
+default_column = "browser-stack"
+default_column_order = 20
+default_width = 0.6
+
+[[window_rule]]
+match.title = "^named-first$"
+default_column = "browser-stack"
+default_size = [300, 300]
+default_column_order = 10
+default_width = 0.25
+
+[[window_rule]]
+match.title = "^named-delayed$"
+default_column = "browser-stack"
+default_column_order = 15
+default_width = 0.4
+
+[[window_rule]]
+match.title = "^named-max-order$"
+default_column = "browser-stack"
+default_column_order = 2147483647
+
+[[window_rule]]
+match.title = "^named-unordered$"
+default_column = "browser-stack"
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+# Start the lower window first. The rule order must correct the final stack.
+spawn_client named-later
+wait_for_windows 1
+spawn_client unrelated
+wait_for_windows 2
+LOG_CONFIGURES=1 "$CLIENT" named-first 800 600 > "$FIRST_LOG" 2>&1 &
+wait_for_windows 3
+
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  later_x=$(jq -r '.[] | select(.title == "named-later") | .x' <<< "$windows")
+  first_x=$(jq -r '.[] | select(.title == "named-first") | .x' <<< "$windows")
+  [[ -n $first_x && $first_x == "$later_x" ]] && break
+  sleep 0.1
+done
+
+sleep 0.2
+first_configure=$(awk -F= '/^configured-size=/{print $2; exit}' "$FIRST_LOG")
+first_arranged=$(awk -F= '/^configured-size=/{size=$2} END {print size}' "$FIRST_LOG")
+if [[ $first_configure != "$first_arranged" ]]; then
+  echo "named client first configure $first_configure did not match joined size $first_arranged"
+  failed=1
+fi
+
+# INT_MAX is still an explicit order and must sort before an unordered member.
+spawn_client named-unordered
+wait_for_windows 4
+spawn_client named-max-order
+wait_for_windows 5
+
+# Fill the strip and focus its end. The placeholder will initially open there,
+# then its real title must move focus back to the visible named column.
+spawn_client filler-a
+wait_for_windows 6
+spawn_client filler-b
+wait_for_windows 7
+spawn_client filler-c
+wait_for_windows 8
+
+# Some clients publish their useful title after mapping. The late rule must
+# move the window into the named column without changing that column's width.
+mkfifo "$CONTROL_FIFO"
+exec {control_fd}<>"$CONTROL_FIFO"
+TITLE_AFTER_MAP=named-delayed "$CLIENT" named-placeholder 800 600 <&"$control_fd" > "$DELAYED_LOG" 2>&1 &
+wait_for_windows 9
+printf 'u' >&"$control_fd"
+
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  later_x=$(jq -r '.[] | select(.title == "named-later") | .x' <<< "$windows")
+  later_y=$(jq -r '.[] | select(.title == "named-later") | .y' <<< "$windows")
+  first_x=$(jq -r '.[] | select(.title == "named-first") | .x' <<< "$windows")
+  first_y=$(jq -r '.[] | select(.title == "named-first") | .y' <<< "$windows")
+  delayed_x=$(jq -r '.[] | select(.title == "named-delayed") | .x' <<< "$windows")
+  delayed_y=$(jq -r '.[] | select(.title == "named-delayed") | .y' <<< "$windows")
+  max_order_y=$(jq -r '.[] | select(.title == "named-max-order") | .y' <<< "$windows")
+  unordered_y=$(jq -r '.[] | select(.title == "named-unordered") | .y' <<< "$windows")
+  unrelated_x=$(jq -r '.[] | select(.title == "unrelated") | .x' <<< "$windows")
+  if [[ -n $delayed_x && $first_x == "$delayed_x" && $delayed_x == "$later_x" && $unrelated_x != "$first_x" ]] \
+      && ((first_y < delayed_y && delayed_y < later_y)) \
+      && ((later_y < max_order_y && max_order_y < unordered_y)) \
+      && ((delayed_x >= 0)) \
+      && ((unrelated_x - first_x > 640)); then
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ $first_x != "$delayed_x" || $delayed_x != "$later_x" || $unrelated_x == "$first_x" ]]; then
+  echo "named clients did not share one column separate from the unrelated client: $windows"
+  failed=1
+fi
+if ((first_y >= delayed_y || delayed_y >= later_y)); then
+  echo "default_column_order did not place named clients in configured order: $windows"
+  failed=1
+fi
+if ((later_y >= max_order_y || max_order_y >= unordered_y)); then
+  echo "explicit maximum order did not precede the unordered client: $windows"
+  failed=1
+fi
+if ((delayed_x < 0)); then
+  echo "late named-column relocation left the focused client outside the viewport: $windows"
+  failed=1
+fi
+if ((unrelated_x - first_x <= 640)); then
+  echo "a joining client changed the named column width: $windows"
+  failed=1
+fi
+
+((failed == 0)) || exit 1
+echo "named clients shared the first window's column in configured order"

--- a/tests/harness/checks/116_named_column_contract.sh
+++ b/tests/harness/checks/116_named_column_contract.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Named columns honor scrolling orientation and workspace scope without changing floats or other layouts.
+# Named scrolling columns honor orientation and workspace scope without changing other layouts.
 set -euo pipefail
 
 readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
@@ -57,45 +57,45 @@ layout.mode = "master"
 
 [[window_rule]]
 match.title = "^named-vertical-later$"
-default_column = "vertical-stack"
-default_column_order = 20
+default_scrolling_column = "vertical-stack"
+default_scrolling_column_order = 20
 default_width = 0.25
 
 [[window_rule]]
 match.title = "^named-vertical-first$"
-default_column = "vertical-stack"
-default_column_order = 10
+default_scrolling_column = "vertical-stack"
+default_scrolling_column_order = 10
 default_width = 0.75
 
 [[window_rule]]
 match.title = "^named-vertical-max$"
-default_column = "vertical-stack"
-default_column_order = 15
+default_scrolling_column = "vertical-stack"
+default_scrolling_column_order = 15
 default_maximize = true
 
 [[window_rule]]
 match.title = "^named-split-(a|b|c|local)$"
-default_column = "split-stack"
+default_scrolling_column = "split-stack"
 
 [[window_rule]]
 match.title = "^named-split-a$"
-default_column_order = 10
+default_scrolling_column_order = 10
 
 [[window_rule]]
 match.title = "^named-split-b$"
-default_column_order = 20
+default_scrolling_column_order = 20
 
 [[window_rule]]
 match.title = "^named-split-c$"
-default_column_order = 15
+default_scrolling_column_order = 15
 
 [[window_rule]]
 match.title = "^named-master-"
-default_column = "ignored-master-stack"
+default_scrolling_column = "ignored-master-stack"
 
 [[window_rule]]
 match.title = "^named-float-"
-default_column = "ignored-floating-stack"
+default_scrolling_column = "ignored-floating-stack"
 default_floating = true
 EOF
 "$UMBRIEL" msg config-reload > /dev/null

--- a/tests/harness/checks/116_named_column_contract.sh
+++ b/tests/harness/checks/116_named_column_contract.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Named columns honor scrolling orientation and workspace scope without changing floats or other layouts.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
+readonly VERTICAL_CLIENT="${UMBRIEL_SUBSURFACE_CLIENT:-./build-debug/subsurface-client}"
+readonly MAX_LOG="$UMBRIEL_RUNTIME_DIR/named-vertical-max.log"
+
+spawn_client() {
+  "$CLIENT" "$1" 800 600 > "$UMBRIEL_RUNTIME_DIR/$1.log" 2>&1 &
+}
+
+wait_for_windows() {
+  local expected=$1
+  for _ in $(seq 60); do
+    [[ $("$UMBRIEL" windows --json | jq 'length') -eq $expected ]] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for $expected clients: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+wait_for_query() {
+  local query=$1 message=$2
+  for _ in $(seq 60); do
+    if "$UMBRIEL" windows --json | jq -e "$query" > /dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "$message: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+workspace_of() {
+  "$UMBRIEL" windows --json | jq -r --arg title "$1" '.[] | select(.title == $title) | .workspace'
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[animation]
+duration_ms = 1
+
+[layout.scrolling]
+default_width_fraction = 0.5
+
+[output."HEADLESS-1"]
+workspaces = 4
+
+[[workspace]]
+index = 1
+layout.scrolling.direction = "vertical"
+
+[[workspace]]
+index = 3
+layout.mode = "master"
+
+[[window_rule]]
+match.title = "^named-vertical-later$"
+default_column = "vertical-stack"
+default_column_order = 20
+default_width = 0.25
+
+[[window_rule]]
+match.title = "^named-vertical-first$"
+default_column = "vertical-stack"
+default_column_order = 10
+default_width = 0.75
+
+[[window_rule]]
+match.title = "^named-vertical-max$"
+default_column = "vertical-stack"
+default_column_order = 15
+default_maximize = true
+
+[[window_rule]]
+match.title = "^named-split-(a|b|c|local)$"
+default_column = "split-stack"
+
+[[window_rule]]
+match.title = "^named-split-a$"
+default_column_order = 10
+
+[[window_rule]]
+match.title = "^named-split-b$"
+default_column_order = 20
+
+[[window_rule]]
+match.title = "^named-split-c$"
+default_column_order = 15
+
+[[window_rule]]
+match.title = "^named-master-"
+default_column = "ignored-master-stack"
+
+[[window_rule]]
+match.title = "^named-float-"
+default_column = "ignored-floating-stack"
+default_floating = true
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+# A vertical named lane uses the first launched member's primary-axis extent,
+# while configured order controls the cross-axis row positions.
+"$VERTICAL_CLIENT" named-vertical-later 800 600 > "$UMBRIEL_RUNTIME_DIR/named-vertical-later.log" 2>&1 &
+wait_for_windows 1
+"$VERTICAL_CLIENT" named-vertical-first 800 600 > "$UMBRIEL_RUNTIME_DIR/named-vertical-first.log" 2>&1 &
+wait_for_windows 2
+wait_for_query \
+  'all(.[]; .w == 624 and .h == 166 and .y == 277) and any(.[]; .title == "named-vertical-first" and .x == 10) and any(.[]; .title == "named-vertical-later" and .x == 646)' \
+  "vertical named lane did not retain the first launched member's width or configured order"
+
+# Maximizing a joining member expands the established lane. Its first configure
+# must already match the final arranged size.
+"$VERTICAL_CLIENT" named-vertical-max 800 600 > "$MAX_LOG" 2>&1 &
+wait_for_windows 3
+wait_for_query \
+  'all(.[]; .w == 412 and .h == 700 and .y == 10) and any(.[]; .title == "named-vertical-first" and .x == 10) and any(.[]; .title == "named-vertical-max" and .x == 434) and any(.[]; .title == "named-vertical-later" and .x == 858)' \
+  "maximized member did not join and expand the vertical named lane"
+first_configure=$(awk '/^first-configure /{print $2 "x" $3; exit}' "$MAX_LOG")
+final_size=$("$UMBRIEL" windows --json | jq -r '.[] | select(.title == "named-vertical-max") | "\(.w)x\(.h)"')
+if [[ $first_configure != "$final_size" ]]; then
+  echo "vertical named maximize first configure $first_configure did not match final size $final_size"
+  exit 1
+fi
+vertical_workspace=$(workspace_of named-vertical-first)
+
+# Once users split a named column manually, new members join the first named
+# column in strip order, not whichever column happens to be focused.
+"$UMBRIEL" msg workspace-switch:2 > /dev/null
+spawn_client named-split-a
+wait_for_windows 4
+spawn_client named-split-b
+wait_for_windows 5
+wait_for_query \
+  '[.[] | select(.title == "named-split-a" or .title == "named-split-b") | .x] | unique | length == 1' \
+  "horizontal named members did not initially share a column"
+"$UMBRIEL" msg window-consume-or-expel-right > /dev/null
+wait_for_query \
+  'any(.[]; .title == "named-split-a" and .x == 10) and any(.[]; .title == "named-split-b" and .x > 600)' \
+  "manual expel did not split the named column"
+spawn_client named-split-c
+wait_for_windows 6
+wait_for_query \
+  'any(.[]; .title == "named-split-a" and .x == 10 and .y == 10) and any(.[]; .title == "named-split-c" and .x == 10 and .y > 10) and any(.[]; .title == "named-split-b" and .x > 600)' \
+  "new member did not join the first named column after a manual split"
+split_workspace=$(workspace_of named-split-a)
+
+# The same name on another workspace starts a local column instead of reaching
+# into the existing workspace's layout.
+"$UMBRIEL" msg workspace-switch:4 > /dev/null
+spawn_client named-split-local
+wait_for_windows 7
+local_workspace=$(workspace_of named-split-local)
+if [[ -z $vertical_workspace || -z $split_workspace || -z $local_workspace \
+      || $vertical_workspace == "$split_workspace" || $split_workspace == "$local_workspace" ]]; then
+  echo "named columns were not scoped to distinct workspaces: $("$UMBRIEL" windows --json)"
+  exit 1
+fi
+
+# Floating views retain floating placement even when they share a name.
+spawn_client named-float-a
+wait_for_windows 8
+spawn_client named-float-b
+wait_for_windows 9
+wait_for_query \
+  '[.[] | select(.title == "named-float-a" or .title == "named-float-b")] | length == 2 and all(.[]; .floating == true)' \
+  "named-column rules changed floating placement"
+
+# Master layout keeps its own insertion policy rather than treating the name as
+# a scrolling column.
+"$UMBRIEL" msg workspace-switch:3 > /dev/null
+spawn_client named-master-a
+wait_for_windows 10
+spawn_client named-master-b
+wait_for_windows 11
+wait_for_query \
+  '[.[] | select(.title == "named-master-a" or .title == "named-master-b") | .x] | unique | length == 2' \
+  "named-column rules changed master layout insertion"
+
+echo "named columns honor vertical sizing, manual splits, workspace scope, and layout applicability"

--- a/tests/harness/checks/117_named_column_late_width.sh
+++ b/tests/harness/checks/117_named_column_late_width.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Late title rules preserve established width ownership and may reclassify a member into a new named column.
+# Late title rules preserve named scrolling-column width ownership and may reclassify a member.
 set -euo pipefail
 
 readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
@@ -37,14 +37,14 @@ default_width_fraction = 0.5
 
 [[window_rule]]
 match.title = "^named-width-owner$"
-default_column = "width-stack"
-default_column_order = 10
+default_scrolling_column = "width-stack"
+default_scrolling_column_order = 10
 default_width = 0.25
 
 [[window_rule]]
 match.app_id = "^named-width-joiner$"
-default_column = "width-stack"
-default_column_order = 20
+default_scrolling_column = "width-stack"
+default_scrolling_column_order = 20
 
 [[window_rule]]
 match.title = "^named-width-late$"
@@ -52,34 +52,34 @@ default_width = 0.9
 
 [[window_rule]]
 match.title = "^named-reclass-owner$"
-default_column = "old-stack"
+default_scrolling_column = "old-stack"
 
 [[window_rule]]
 match.app_id = "^named-reclass-joiner$"
-default_column = "old-stack"
+default_scrolling_column = "old-stack"
 default_width = 0.4
 
 [[window_rule]]
 match.title = "^named-reclass-late$"
-default_column = "new-stack"
+default_scrolling_column = "new-stack"
 
 [[window_rule]]
 match.title = "^named-reclass-follower$"
-default_column = "new-stack"
+default_scrolling_column = "new-stack"
 
 [[window_rule]]
 match.app_id = "^named-order-joiner$"
-default_column = "order-stable"
+default_scrolling_column = "order-stable"
 default_workspace = 2
 
 [[window_rule]]
 match.title = "^named-order-late$"
-default_column_order = 10
+default_scrolling_column_order = 10
 default_width = 0.9
 
 [[window_rule]]
 match.title = "^named-order-owner$"
-default_column = "order-stable"
+default_scrolling_column = "order-stable"
 default_workspace = 2
 
 [[window_rule]]

--- a/tests/harness/checks/117_named_column_late_width.sh
+++ b/tests/harness/checks/117_named_column_late_width.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Late title rules preserve established width ownership and may reclassify a member into a new named column.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
+readonly CONTROL_FIFO="$UMBRIEL_RUNTIME_DIR/named-width-control"
+readonly RECLASSIFY_FIFO="$UMBRIEL_RUNTIME_DIR/named-reclassify-control"
+readonly ORDER_FIFO="$UMBRIEL_RUNTIME_DIR/named-order-control"
+
+spawn_client() {
+  "$CLIENT" "$1" 800 600 > "$UMBRIEL_RUNTIME_DIR/$1.log" 2>&1 &
+}
+
+wait_for_windows() {
+  local expected=$1
+  for _ in $(seq 60); do
+    [[ $("$UMBRIEL" windows --json | jq 'length') -eq $expected ]] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for $expected clients: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+column_delta() {
+  "$UMBRIEL" windows --json | jq \
+    '([.[] | select(.title == "named-width-unrelated") | .x][0])
+      - ([.[] | select(.title == "named-width-owner") | .x][0])'
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[animation]
+duration_ms = 1
+
+[layout.scrolling]
+default_width_fraction = 0.5
+
+[[window_rule]]
+match.title = "^named-width-owner$"
+default_column = "width-stack"
+default_column_order = 10
+default_width = 0.25
+
+[[window_rule]]
+match.app_id = "^named-width-joiner$"
+default_column = "width-stack"
+default_column_order = 20
+
+[[window_rule]]
+match.title = "^named-width-late$"
+default_width = 0.9
+
+[[window_rule]]
+match.title = "^named-reclass-owner$"
+default_column = "old-stack"
+
+[[window_rule]]
+match.app_id = "^named-reclass-joiner$"
+default_column = "old-stack"
+default_width = 0.4
+
+[[window_rule]]
+match.title = "^named-reclass-late$"
+default_column = "new-stack"
+
+[[window_rule]]
+match.title = "^named-reclass-follower$"
+default_column = "new-stack"
+
+[[window_rule]]
+match.app_id = "^named-order-joiner$"
+default_column = "order-stable"
+default_workspace = 2
+
+[[window_rule]]
+match.title = "^named-order-late$"
+default_column_order = 10
+default_width = 0.9
+
+[[window_rule]]
+match.title = "^named-order-owner$"
+default_column = "order-stable"
+default_workspace = 2
+
+[[window_rule]]
+match.title = "^named-order-after$"
+default_workspace = 2
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+spawn_client named-width-owner
+wait_for_windows 1
+spawn_client named-width-unrelated
+wait_for_windows 2
+
+mkfifo "$CONTROL_FIFO"
+exec {control_fd}<>"$CONTROL_FIFO"
+APP_ID=named-width-joiner TITLE_AFTER_MAP=named-width-late \
+  "$CLIENT" named-width-placeholder 800 600 <&"$control_fd" > "$UMBRIEL_RUNTIME_DIR/named-width-joiner.log" 2>&1 &
+wait_for_windows 3
+
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  owner_x=$(jq -r '.[] | select(.title == "named-width-owner") | .x' <<< "$windows")
+  joiner_x=$(jq -r '.[] | select(.title == "named-width-placeholder") | .x' <<< "$windows")
+  [[ -n $owner_x && $owner_x == "$joiner_x" && $(column_delta) -eq 318 ]] && break
+  sleep 0.1
+done
+before=$(column_delta)
+if [[ $owner_x != "$joiner_x" || $before -ne 318 ]]; then
+  echo "preselected client did not join the owner's 0.25 column: $windows"
+  exit 1
+fi
+
+printf 'u' >&"$control_fd"
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  title=$(jq -r '.[] | select(.title == "named-width-late") | .title' <<< "$windows")
+  [[ $title == named-width-late ]] && break
+  sleep 0.1
+done
+after=$(column_delta)
+if [[ $after -ne $before ]]; then
+  echo "late member width resized its established named column: before=$before after=$after windows=$windows"
+  exit 1
+fi
+
+# Reclassifying a member from one named group to a new group must split it out
+# of the old stack. Later members of the new group then join its new column.
+spawn_client named-reclass-owner
+wait_for_windows 4
+mkfifo "$RECLASSIFY_FIFO"
+exec {reclassify_fd}<>"$RECLASSIFY_FIFO"
+APP_ID=named-reclass-joiner TITLE_AFTER_MAP=named-reclass-late \
+  "$CLIENT" named-reclass-placeholder 800 600 <&"$reclassify_fd" \
+  > "$UMBRIEL_RUNTIME_DIR/named-reclass-joiner.log" 2>&1 &
+wait_for_windows 5
+printf 'u' >&"$reclassify_fd"
+
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  old_x=$(jq -r '.[] | select(.title == "named-reclass-owner") | .x' <<< "$windows")
+  new_x=$(jq -r '.[] | select(.title == "named-reclass-late") | .x' <<< "$windows")
+  [[ -n $old_x && -n $new_x && $old_x != "$new_x" ]] && break
+  sleep 0.1
+done
+if [[ -z $old_x || -z $new_x || $old_x == "$new_x" ]]; then
+  echo "late group change left the member in its old named column: $windows"
+  exit 1
+fi
+
+spawn_client named-reclass-follower
+wait_for_windows 6
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  old_x=$(jq -r '.[] | select(.title == "named-reclass-owner") | .x' <<< "$windows")
+  new_x=$(jq -r '.[] | select(.title == "named-reclass-late") | .x' <<< "$windows")
+  follower_x=$(jq -r '.[] | select(.title == "named-reclass-follower") | .x' <<< "$windows")
+  [[ -n $follower_x && $new_x == "$follower_x" && $old_x != "$new_x" ]] && break
+  sleep 0.1
+done
+if [[ -z $follower_x || $new_x != "$follower_x" || $old_x == "$new_x" ]]; then
+  echo "new named-group member did not join the reclassified column: $windows"
+  exit 1
+fi
+
+spawn_client named-reclass-after
+wait_for_windows 7
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  new_x=$(jq -r '.[] | select(.title == "named-reclass-late") | .x' <<< "$windows")
+  after_x=$(jq -r '.[] | select(.title == "named-reclass-after") | .x' <<< "$windows")
+  [[ -n $new_x && -n $after_x ]] && ((after_x - new_x == 509)) && break
+  sleep 0.1
+done
+if ((after_x - new_x != 509)); then
+  echo "reclassified first member did not retain its 0.4 width rule: $windows"
+  exit 1
+fi
+
+# A late order-only rule must not undo a manual split from an existing named
+# column or let the later-joining member apply its own width.
+spawn_client named-order-owner
+wait_for_windows 8
+mkfifo "$ORDER_FIFO"
+exec {order_fd}<>"$ORDER_FIFO"
+APP_ID=named-order-joiner TITLE_AFTER_MAP=named-order-late \
+  "$CLIENT" named-order-placeholder 800 600 <&"$order_fd" > "$UMBRIEL_RUNTIME_DIR/named-order-joiner.log" 2>&1 &
+wait_for_windows 9
+order_id=$("$UMBRIEL" windows --json | jq -r '.[] | select(.title == "named-order-placeholder") | .id')
+"$UMBRIEL" msg "window-focus:$order_id" > /dev/null
+"$UMBRIEL" msg window-consume-or-expel-right > /dev/null
+spawn_client named-order-after
+wait_for_windows 10
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  owner_x=$(jq -r '.[] | select(.title == "named-order-owner") | .x' <<< "$windows")
+  order_x=$(jq -r '.[] | select(.title == "named-order-placeholder") | .x' <<< "$windows")
+  after_x=$(jq -r '.[] | select(.title == "named-order-after") | .x' <<< "$windows")
+  [[ -n $owner_x && -n $order_x && -n $after_x && $owner_x != "$order_x" ]] \
+    && ((after_x - order_x == 636)) && break
+  sleep 0.1
+done
+if [[ -z $owner_x || -z $order_x || -z $after_x || $owner_x == "$order_x" ]] \
+    || ((after_x - order_x != 636)); then
+  echo "could not prepare the manual named-column split: $windows"
+  exit 1
+fi
+
+printf 'u' >&"$order_fd"
+for _ in $(seq 60); do
+  windows=$("$UMBRIEL" windows --json)
+  owner_x=$(jq -r '.[] | select(.title == "named-order-owner") | .x' <<< "$windows")
+  order_x=$(jq -r '.[] | select(.title == "named-order-late") | .x' <<< "$windows")
+  after_x=$(jq -r '.[] | select(.title == "named-order-after") | .x' <<< "$windows")
+  [[ -n $order_x && $owner_x != "$order_x" ]] && ((after_x - order_x == 636)) && break
+  sleep 0.1
+done
+if [[ -z $order_x || $owner_x == "$order_x" ]] || ((after_x - order_x != 636)); then
+  echo "late order-only rule undid a manual split or applied the joiner's width: $windows"
+  exit 1
+fi
+
+echo "late named-column rules preserved width, grouping, and manual placement"

--- a/tests/harness/checks/118_named_column_lifecycle.sh
+++ b/tests/harness/checks/118_named_column_lifecycle.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Late named-column rules preserve ownership, focus, width, and maximize state across relocation.
+# Late named scrolling-column rules preserve ownership, focus, width, and maximize state across relocation.
 set -euo pipefail
 
 readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
@@ -60,12 +60,12 @@ workspaces = 4
 
 [[window_rule]]
 match.app_id = "^named-move-owner$"
-default_column = "move-source"
+default_scrolling_column = "move-source"
 default_width = 0.4
 
 [[window_rule]]
 match.title = "^named-move-late$"
-default_column = "move-target"
+default_scrolling_column = "move-target"
 default_workspace = 2
 
 [[window_rule]]
@@ -74,12 +74,12 @@ default_workspace = 2
 
 [[window_rule]]
 match.app_id = "^named-max-move-owner$"
-default_column = "max-move-source"
+default_scrolling_column = "max-move-source"
 default_maximize = true
 
 [[window_rule]]
 match.title = "^named-max-move-late$"
-default_column = "max-move-target"
+default_scrolling_column = "max-move-target"
 default_workspace = 3
 
 [[window_rule]]
@@ -88,18 +88,18 @@ default_workspace = 3
 
 [[window_rule]]
 match.title = "^named-max-reclass-owner$"
-default_column = "max-reclass-source"
+default_scrolling_column = "max-reclass-source"
 default_workspace = 4
 
 [[window_rule]]
 match.app_id = "^named-max-reclass-joiner$"
-default_column = "max-reclass-source"
+default_scrolling_column = "max-reclass-source"
 default_workspace = 4
 default_maximize = true
 
 [[window_rule]]
 match.title = "^named-max-reclass-late$"
-default_column = "max-reclass-target"
+default_scrolling_column = "max-reclass-target"
 
 [[window_rule]]
 match.title = "^named-max-reclass-after$"
@@ -107,15 +107,15 @@ default_workspace = 4
 
 [[window_rule]]
 match.app_id = "^named-owner-width-owner$"
-default_column = "owner-width-stack"
+default_scrolling_column = "owner-width-stack"
 
 [[window_rule]]
 match.title = "^named-owner-width-peer$"
-default_column = "owner-width-stack"
+default_scrolling_column = "owner-width-stack"
 
 [[window_rule]]
 match.title = "^named-owner-width-late$"
-default_column_order = 10
+default_scrolling_column_order = 10
 default_width = 0.7
 EOF
 "$UMBRIEL" msg config-reload > /dev/null

--- a/tests/harness/checks/118_named_column_lifecycle.sh
+++ b/tests/harness/checks/118_named_column_lifecycle.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Late named-column rules preserve ownership, focus, width, and maximize state across relocation.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
+readonly MOVE_FIFO="$UMBRIEL_RUNTIME_DIR/named-move-control"
+readonly MAX_MOVE_FIFO="$UMBRIEL_RUNTIME_DIR/named-max-move-control"
+readonly MAX_RECLASSIFY_FIFO="$UMBRIEL_RUNTIME_DIR/named-max-reclassify-control"
+readonly OWNER_WIDTH_FIFO="$UMBRIEL_RUNTIME_DIR/named-owner-width-control"
+
+spawn_client() {
+  "$CLIENT" "$1" 800 600 > "$UMBRIEL_RUNTIME_DIR/$1.log" 2>&1 &
+}
+
+wait_for_windows() {
+  local expected=$1
+  for _ in $(seq 60); do
+    [[ $("$UMBRIEL" windows --json | jq 'length') -eq $expected ]] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for $expected clients: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+wait_for_query() {
+  local query=$1 message=$2
+  for _ in $(seq 60); do
+    if "$UMBRIEL" windows --json | jq -e "$query" > /dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "$message: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+wait_for_delta() {
+  local first=$1 second=$2 expected=$3 message=$4 windows first_x second_x
+  for _ in $(seq 60); do
+    windows=$("$UMBRIEL" windows --json)
+    first_x=$(jq -r --arg title "$first" '.[] | select(.title == $title) | .x' <<< "$windows")
+    second_x=$(jq -r --arg title "$second" '.[] | select(.title == $title) | .x' <<< "$windows")
+    [[ -n $first_x && -n $second_x ]] && ((second_x - first_x == expected)) && return 0
+    sleep 0.1
+  done
+  echo "$message: $windows"
+  return 1
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[animation]
+duration_ms = 1
+
+[layout.scrolling]
+default_width_fraction = 0.5
+
+[output."HEADLESS-1"]
+workspaces = 4
+
+[[window_rule]]
+match.app_id = "^named-move-owner$"
+default_column = "move-source"
+default_width = 0.4
+
+[[window_rule]]
+match.title = "^named-move-late$"
+default_column = "move-target"
+default_workspace = 2
+
+[[window_rule]]
+match.title = "^named-move-after$"
+default_workspace = 2
+
+[[window_rule]]
+match.app_id = "^named-max-move-owner$"
+default_column = "max-move-source"
+default_maximize = true
+
+[[window_rule]]
+match.title = "^named-max-move-late$"
+default_column = "max-move-target"
+default_workspace = 3
+
+[[window_rule]]
+match.title = "^named-max-move-after$"
+default_workspace = 3
+
+[[window_rule]]
+match.title = "^named-max-reclass-owner$"
+default_column = "max-reclass-source"
+default_workspace = 4
+
+[[window_rule]]
+match.app_id = "^named-max-reclass-joiner$"
+default_column = "max-reclass-source"
+default_workspace = 4
+default_maximize = true
+
+[[window_rule]]
+match.title = "^named-max-reclass-late$"
+default_column = "max-reclass-target"
+
+[[window_rule]]
+match.title = "^named-max-reclass-after$"
+default_workspace = 4
+
+[[window_rule]]
+match.app_id = "^named-owner-width-owner$"
+default_column = "owner-width-stack"
+
+[[window_rule]]
+match.title = "^named-owner-width-peer$"
+default_column = "owner-width-stack"
+
+[[window_rule]]
+match.title = "^named-owner-width-late$"
+default_column_order = 10
+default_width = 0.7
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+# A focused late move keeps focus and seeds the target column with the width
+# already resolved from the app ID.
+mkfifo "$MOVE_FIFO"
+exec {move_fd}<>"$MOVE_FIFO"
+APP_ID=named-move-owner TITLE_AFTER_MAP=named-move-late \
+  "$CLIENT" named-move-placeholder 800 600 <&"$move_fd" > "$UMBRIEL_RUNTIME_DIR/named-move-owner.log" 2>&1 &
+wait_for_windows 1
+printf 'u' >&"$move_fd"
+wait_for_query \
+  'any(.[]; .title == "named-move-late" and (.workspace | endswith(":2")) and .active and .focused)' \
+  "late named member did not retain focus on workspace 2"
+spawn_client named-move-after
+wait_for_windows 2
+wait_for_delta named-move-late named-move-after 509 \
+  "late workspace placement lost the first member's 0.4 width rule"
+
+# Standard maximize is column state, so it must be restored after a late move.
+mkfifo "$MAX_MOVE_FIFO"
+exec {max_move_fd}<>"$MAX_MOVE_FIFO"
+APP_ID=named-max-move-owner TITLE_AFTER_MAP=named-max-move-late \
+  "$CLIENT" named-max-move-placeholder 800 600 <&"$max_move_fd" \
+  > "$UMBRIEL_RUNTIME_DIR/named-max-move-owner.log" 2>&1 &
+wait_for_windows 3
+printf 'u' >&"$max_move_fd"
+wait_for_query 'any(.[]; .title == "named-max-move-late" and (.workspace | endswith(":3")))' \
+  "late maximized member did not move to workspace 3"
+spawn_client named-max-move-after
+wait_for_windows 4
+wait_for_delta named-max-move-late named-max-move-after 1272 \
+  "late workspace placement lost the first member's maximized column state"
+
+# Reclassification within one workspace must carry that same full-width state
+# into the new named column.
+spawn_client named-max-reclass-owner
+wait_for_windows 5
+mkfifo "$MAX_RECLASSIFY_FIFO"
+exec {max_reclassify_fd}<>"$MAX_RECLASSIFY_FIFO"
+APP_ID=named-max-reclass-joiner TITLE_AFTER_MAP=named-max-reclass-late \
+  "$CLIENT" named-max-reclass-placeholder 800 600 <&"$max_reclassify_fd" \
+  > "$UMBRIEL_RUNTIME_DIR/named-max-reclassify-joiner.log" 2>&1 &
+wait_for_windows 6
+printf 'u' >&"$max_reclassify_fd"
+wait_for_query 'any(.[]; .title == "named-max-reclass-late" and (.workspace | endswith(":4")))' \
+  "maximized reclassified member did not remain on workspace 4"
+spawn_client named-max-reclass-after
+wait_for_windows 7
+wait_for_delta named-max-reclass-late named-max-reclass-after 1272 \
+  "late group reclassification lost the member's maximized column state"
+
+# A joiner's late width is ignored, but the member that created a column still
+# owns it if its title settles after another member joined.
+mkfifo "$OWNER_WIDTH_FIFO"
+exec {owner_width_fd}<>"$OWNER_WIDTH_FIFO"
+APP_ID=named-owner-width-owner TITLE_AFTER_MAP=named-owner-width-late \
+  "$CLIENT" named-owner-width-placeholder 800 600 <&"$owner_width_fd" \
+  > "$UMBRIEL_RUNTIME_DIR/named-owner-width-owner.log" 2>&1 &
+wait_for_windows 8
+spawn_client named-owner-width-peer
+wait_for_windows 9
+spawn_client named-owner-width-after
+wait_for_windows 10
+printf 'u' >&"$owner_width_fd"
+wait_for_delta named-owner-width-late named-owner-width-after 890 \
+  "late width rule from the column owner did not resize its named column"
+
+echo "late named-column lifecycle preserved ownership, focus, width, and maximize state"

--- a/tests/harness/checks/119_named_column_output_restore.sh
+++ b/tests/harness/checks/119_named_column_output_restore.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # harness: outputs=2
-# A named-column creator keeps width ownership after its output disappears and returns.
+# A named scrolling-column creator keeps width ownership after its output disappears and returns.
 set -euo pipefail
 
 readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
@@ -58,7 +58,7 @@ position = [1280, 0]
 
 [[window_rule]]
 match.app_id = "^named-output-owner$"
-default_column = "shared-refuge"
+default_scrolling_column = "shared-refuge"
 default_output = "HEADLESS-1"
 
 [[window_rule]]
@@ -67,12 +67,12 @@ default_width = 0.7
 
 [[window_rule]]
 match.title = "^named-output-peer$"
-default_column = "shared-refuge"
+default_scrolling_column = "shared-refuge"
 default_output = "HEADLESS-1"
 
 [[window_rule]]
 match.title = "^named-output-refuge$"
-default_column = "shared-refuge"
+default_scrolling_column = "shared-refuge"
 default_output = "HEADLESS-2"
 
 [[window_rule]]
@@ -93,16 +93,18 @@ spawn_client named-output-peer
 wait_for_windows 3
 
 # The home column temporarily joins a populated, identically named refuge.
-# Recreating the output restores its exact layout and creator ownership.
+# Settle its late width there, then verify exact restoration retains both the
+# creator's ownership and the newly resolved width.
 "$UMBRIEL" output-destroy HEADLESS-1 > /dev/null
 wait_for_output named-output-owner-placeholder HEADLESS-2
+printf 'u' >&"$owner_fd"
+wait_for_output named-output-owner-late HEADLESS-2
 created=$("$UMBRIEL" output-create HEADLESS-1)
 [[ $created == HEADLESS-1 ]] || { echo "expected HEADLESS-1, got '$created'"; exit 1; }
-wait_for_output named-output-owner-placeholder HEADLESS-1
+wait_for_output named-output-owner-late HEADLESS-1
 
 spawn_client named-output-after
 wait_for_windows 4
-printf 'u' >&"$owner_fd"
 wait_for_delta named-output-owner-late named-output-after 890
 
 echo "named-column width ownership survived output loss and exact layout restoration"

--- a/tests/harness/checks/119_named_column_output_restore.sh
+++ b/tests/harness/checks/119_named_column_output_restore.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# harness: outputs=2
+# A named-column creator keeps width ownership after its output disappears and returns.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/unmap-client}"
+readonly OWNER_FIFO="$UMBRIEL_RUNTIME_DIR/named-output-owner-control"
+
+spawn_client() {
+  "$CLIENT" "$1" 800 600 > "$UMBRIEL_RUNTIME_DIR/$1.log" 2>&1 &
+}
+
+wait_for_windows() {
+  local expected=$1
+  for _ in $(seq 80); do
+    [[ $("$UMBRIEL" windows --json | jq 'length') -eq $expected ]] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for $expected clients: $("$UMBRIEL" windows --json)"
+  return 1
+}
+
+wait_for_output() {
+  local title=$1 expected=$2 output=
+  for _ in $(seq 80); do
+    output=$("$UMBRIEL" windows --json | jq -r --arg title "$title" \
+      '.[] | select(.title == $title) | .workspace | split(":")[0]')
+    [[ $output == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  echo "expected '$title' on '$expected', got '$output'"
+  return 1
+}
+
+wait_for_delta() {
+  local first=$1 second=$2 expected=$3 windows first_x second_x
+  for _ in $(seq 80); do
+    windows=$("$UMBRIEL" windows --json)
+    first_x=$(jq -r --arg title "$first" '.[] | select(.title == $title) | .x' <<< "$windows")
+    second_x=$(jq -r --arg title "$second" '.[] | select(.title == $title) | .x' <<< "$windows")
+    [[ -n $first_x && -n $second_x ]] && ((second_x - first_x == expected)) && return 0
+    sleep 0.1
+  done
+  echo "restored column owner did not apply its late width: $windows"
+  return 1
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[animation]
+duration_ms = 1
+
+[output.HEADLESS-1]
+position = [0, 0]
+
+[output.HEADLESS-2]
+position = [1280, 0]
+
+[[window_rule]]
+match.app_id = "^named-output-owner$"
+default_column = "shared-refuge"
+default_output = "HEADLESS-1"
+
+[[window_rule]]
+match.title = "^named-output-owner-late$"
+default_width = 0.7
+
+[[window_rule]]
+match.title = "^named-output-peer$"
+default_column = "shared-refuge"
+default_output = "HEADLESS-1"
+
+[[window_rule]]
+match.title = "^named-output-refuge$"
+default_column = "shared-refuge"
+default_output = "HEADLESS-2"
+
+[[window_rule]]
+match.title = "^named-output-after$"
+default_output = "HEADLESS-1"
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+spawn_client named-output-refuge
+wait_for_windows 1
+mkfifo "$OWNER_FIFO"
+exec {owner_fd}<>"$OWNER_FIFO"
+APP_ID=named-output-owner TITLE_AFTER_MAP=named-output-owner-late \
+  "$CLIENT" named-output-owner-placeholder 800 600 <&"$owner_fd" \
+  > "$UMBRIEL_RUNTIME_DIR/named-output-owner.log" 2>&1 &
+wait_for_windows 2
+spawn_client named-output-peer
+wait_for_windows 3
+
+# The home column temporarily joins a populated, identically named refuge.
+# Recreating the output restores its exact layout and creator ownership.
+"$UMBRIEL" output-destroy HEADLESS-1 > /dev/null
+wait_for_output named-output-owner-placeholder HEADLESS-2
+created=$("$UMBRIEL" output-create HEADLESS-1)
+[[ $created == HEADLESS-1 ]] || { echo "expected HEADLESS-1, got '$created'"; exit 1; }
+wait_for_output named-output-owner-placeholder HEADLESS-1
+
+spawn_client named-output-after
+wait_for_windows 4
+printf 'u' >&"$owner_fd"
+wait_for_delta named-output-owner-late named-output-after 890
+
+echo "named-column width ownership survived output loss and exact layout restoration"

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -880,8 +880,8 @@ focus_on_activate = true
 match.app_id = "^game$"
 default_focused = false
 default_pinned = true
-default_column = "browser-stack"
-default_column_order = 20
+default_scrolling_column = "browser-stack"
+default_scrolling_column_order = 20
 focus_on_activate = false
 default_position = { x = 32, y = 48, anchor = "bottom_left" }
 
@@ -901,8 +901,8 @@ default_position = { x = 0, y = 0 }
   CHECK(!*store.config().windowRules[0].defaultFocused);
   CHECK(store.config().windowRules[0].defaultPinned.has_value());
   CHECK(*store.config().windowRules[0].defaultPinned);
-  CHECK(store.config().windowRules[0].defaultColumn == "browser-stack");
-  CHECK(store.config().windowRules[0].defaultColumnOrder == 20);
+  CHECK(store.config().windowRules[0].defaultScrollingColumn == "browser-stack");
+  CHECK(store.config().windowRules[0].defaultScrollingColumnOrder == 20);
   CHECK(store.config().windowRules[0].focusOnActivate.has_value());
   CHECK(!*store.config().windowRules[0].focusOnActivate);
   CHECK(store.config().windowRules[0].defaultPosition.has_value());

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -880,6 +880,8 @@ focus_on_activate = true
 match.app_id = "^game$"
 default_focused = false
 default_pinned = true
+default_column = "browser-stack"
+default_column_order = 20
 focus_on_activate = false
 default_position = { x = 32, y = 48, anchor = "bottom_left" }
 
@@ -899,6 +901,8 @@ default_position = { x = 0, y = 0 }
   CHECK(!*store.config().windowRules[0].defaultFocused);
   CHECK(store.config().windowRules[0].defaultPinned.has_value());
   CHECK(*store.config().windowRules[0].defaultPinned);
+  CHECK(store.config().windowRules[0].defaultColumn == "browser-stack");
+  CHECK(store.config().windowRules[0].defaultColumnOrder == 20);
   CHECK(store.config().windowRules[0].focusOnActivate.has_value());
   CHECK(!*store.config().windowRules[0].focusOnActivate);
   CHECK(store.config().windowRules[0].defaultPosition.has_value());

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -184,8 +184,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   app.blur = true;
   app.defaultFocused = false;
   app.defaultPinned = true;
-  app.defaultColumn = "browser-stack";
-  app.defaultColumnOrder = 20;
+  app.defaultScrollingColumn = "browser-stack";
+  app.defaultScrollingColumnOrder = 20;
   app.focusOnActivate = false;
   app.vrr = VrrMode::Disabled;
   app.allowTearing = false;
@@ -206,8 +206,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   title.allowTearing = true;
   title.hdr = umbriel::HdrMode::On;
   title.defaultPinned = false;
-  title.defaultColumn = "terminals";
-  title.defaultColumnOrder = 10;
+  title.defaultScrollingColumn = "terminals";
+  title.defaultScrollingColumnOrder = 10;
   config.windowRules.push_back(std::move(title));
 
   WindowRule unfocused;
@@ -225,8 +225,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   CHECK(resolved.defaultPosition->anchor == umbriel::WindowPositionAnchor::TopRight);
   CHECK(resolved.defaultFocused && !*resolved.defaultFocused);
   CHECK(resolved.defaultPinned && !*resolved.defaultPinned);
-  CHECK(resolved.defaultColumn && *resolved.defaultColumn == "terminals");
-  CHECK(resolved.defaultColumnOrder && *resolved.defaultColumnOrder == 10);
+  CHECK(resolved.defaultScrollingColumn && *resolved.defaultScrollingColumn == "terminals");
+  CHECK(resolved.defaultScrollingColumnOrder && *resolved.defaultScrollingColumnOrder == 10);
   CHECK(resolved.focusOnActivate && *resolved.focusOnActivate);
   CHECK(resolved.vrr == VrrMode::Always);
   CHECK(resolved.allowTearing && *resolved.allowTearing);
@@ -234,8 +234,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
 
   const auto appOnly = umbriel::resolveWindowRules(config, "foot", "editor", "", ContentType::None, false);
   CHECK(appOnly.defaultPinned && *appOnly.defaultPinned);
-  CHECK(appOnly.defaultColumn && *appOnly.defaultColumn == "browser-stack");
-  CHECK(appOnly.defaultColumnOrder && *appOnly.defaultColumnOrder == 20);
+  CHECK(appOnly.defaultScrollingColumn && *appOnly.defaultScrollingColumn == "browser-stack");
+  CHECK(appOnly.defaultScrollingColumnOrder && *appOnly.defaultScrollingColumnOrder == 20);
   CHECK(appOnly.vrr == VrrMode::Disabled);
   CHECK(appOnly.allowTearing && !*appOnly.allowTearing);
   CHECK(appOnly.hdr == umbriel::HdrMode::Off);

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -184,6 +184,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   app.blur = true;
   app.defaultFocused = false;
   app.defaultPinned = true;
+  app.defaultColumn = "browser-stack";
+  app.defaultColumnOrder = 20;
   app.focusOnActivate = false;
   app.vrr = VrrMode::Disabled;
   app.allowTearing = false;
@@ -204,6 +206,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   title.allowTearing = true;
   title.hdr = umbriel::HdrMode::On;
   title.defaultPinned = false;
+  title.defaultColumn = "terminals";
+  title.defaultColumnOrder = 10;
   config.windowRules.push_back(std::move(title));
 
   WindowRule unfocused;
@@ -221,6 +225,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   CHECK(resolved.defaultPosition->anchor == umbriel::WindowPositionAnchor::TopRight);
   CHECK(resolved.defaultFocused && !*resolved.defaultFocused);
   CHECK(resolved.defaultPinned && !*resolved.defaultPinned);
+  CHECK(resolved.defaultColumn && *resolved.defaultColumn == "terminals");
+  CHECK(resolved.defaultColumnOrder && *resolved.defaultColumnOrder == 10);
   CHECK(resolved.focusOnActivate && *resolved.focusOnActivate);
   CHECK(resolved.vrr == VrrMode::Always);
   CHECK(resolved.allowTearing && *resolved.allowTearing);
@@ -228,6 +234,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
 
   const auto appOnly = umbriel::resolveWindowRules(config, "foot", "editor", "", ContentType::None, false);
   CHECK(appOnly.defaultPinned && *appOnly.defaultPinned);
+  CHECK(appOnly.defaultColumn && *appOnly.defaultColumn == "browser-stack");
+  CHECK(appOnly.defaultColumnOrder && *appOnly.defaultColumnOrder == 20);
   CHECK(appOnly.vrr == VrrMode::Disabled);
   CHECK(appOnly.allowTearing && !*appOnly.allowTearing);
   CHECK(appOnly.hdr == umbriel::HdrMode::Off);


### PR DESCRIPTION
## Summary

Add `default_column` and `default_column_order` window rules for opening related applications in one scrolling column. Lower order values are placed first regardless of launch timing.

The first matching window owns the column width. Later matches join that column without applying their own `default_width`. Named columns are local to a workspace and ignored for floating windows and other layout modes.

Late rule settlement preserves established width ownership, manual placement, focus, maximize state, and target-workspace sizing. Exact layout restoration after output loss also preserves the original column owner.

## Motivation

Related applications currently open as separate scrolling columns. Named columns let users declare a predictable stack for applications launched together.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

None. Repository issues are disabled.

## Testing

- `just format`
- Unit suite: 29/29 passed
- `just lint debug`: warning-free build and clang-tidy on 109 files
- `just verify debug`: 100/100 compositor checks passed
- Clang ASan and UBSan unit suite: 29/29 passed
- Clang ASan and UBSan scrolling and named-column coverage: 6/6 passed
- ShellCheck on all five named-column harness checks
- Native Umbriel session using the scrolling layout

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

Not applicable. This changes window placement without adding visual UI.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.