### PR TITLE
feat(rules): default_width/default_height fractions for floating windows

### DIFF
--- a/docs/user/rules.md
+++ b/docs/user/rules.md
@@ -41,9 +41,10 @@ opening settings do not overwrite user changes made in the meantime.
 |-----|------|-------------|
 | `default_output` | string | Open on a specific output (e.g. `"DP-1"`). |
 | `default_floating` | bool | Force floating (`true`) or force tiling (`false`). |
-| `default_size` | `[w, h]` | Initial size in pixels, clamped to the client's min/max hints. Floats use both, then own their size and honor client resizes; tiled windows ignore height. |
+| `default_size` | `[w, h]` | Initial size in pixels, clamped to the client's min/max hints. Floats use both, then own their size and honor client resizes; tiled windows ignore height. Takes precedence over `default_width`/`default_height` when set. |
 | `default_position` | table | Initial position for floating windows: `{ x = int, y = int, anchor = string }`. Ignored for tiled windows. |
-| `default_width` | float | Scrolling only. Lane scroll-axis extent fraction (0.1-1.0), which is height on a vertical workspace. Gap-aware: fractions that sum to 1 tile exactly. Overrides `layout.scrolling.default_width_fraction`. Dragging the lane within or between scrolling workspaces retains its current fraction. Ignored in dwindle and master. |
+| `default_width` | float | For floating windows, the initial width as a fraction (0.1-1.0) of the usable area. For tiled windows, scrolling only: lane scroll-axis extent fraction (0.1-1.0), which is height on a vertical workspace. Gap-aware: fractions that sum to 1 tile exactly. Overrides `layout.scrolling.default_width_fraction`. Dragging the lane within or between scrolling workspaces retains its current fraction. Ignored in dwindle and master. |
+| `default_height` | float | Floating windows only. Initial height as a fraction (0.1-1.0) of the usable area. Ignored for tiled windows. |
 | `default_workspace` | int | Place on workspace N from 1 to 64. On dynamic outputs, values beyond the current count clamp to the last workspace. |
 | `default_fullscreen` | bool | Open in fullscreen. |
 | `default_maximize_to_edges` | bool | Explicitly open maximized to edges. The initial configure fills the usable area without gaps or borders, so the window does not open at its normal size first. Layer-shell exclusive zones stay visible. Takes precedence over `default_maximize`; when combined with `default_fullscreen` the window opens fullscreen and returns to maximized to edges once fullscreen is cleared. |
@@ -77,6 +78,17 @@ match.app_id = "^org[.]example[.]Utility$"
 default_floating = true
 default_size = [800, 600]
 default_position = { x = 32, y = 24, anchor = "bottom_left" }
+```
+
+Floating windows can instead be sized as fractions of the usable area, per
+axis. `default_size` (pixels) wins when both are set:
+
+```toml
+[[window_rule]]
+match.app_id = "^org[.]example[.]Utility$"
+default_floating = true
+default_width = 0.5
+default_height = 0.6
 ```
 
 `anchor` defaults to `"center"`, so this centers a floating window exactly:

--- a/docs/user/rules.md
+++ b/docs/user/rules.md
@@ -61,8 +61,8 @@ opening settings do not overwrite user changes made in the meantime.
 | `default_floating` | bool | Force floating (`true`) or force tiling (`false`). |
 | `default_size` | `[w, h]` | Initial size in pixels, clamped to the client's min/max hints. Floats use both, then own their size and honor client resizes; tiled windows ignore height. Takes precedence over `default_width`/`default_height` when set. |
 | `default_position` | table | Initial position for floating windows: `{ x = int, y = int, anchor = string }`. Ignored for tiled windows. |
-| `default_width` | float | For floating windows, the initial width as a fraction (0.1-1.0) of the usable area. For tiled windows, scrolling only: lane scroll-axis extent fraction (0.1-1.0), which is height on a vertical workspace. Gap-aware: fractions that sum to 1 tile exactly. Overrides `layout.scrolling.default_width_fraction`. Dragging the lane within or between scrolling workspaces retains its current fraction. Ignored in dwindle and master. |
-| `default_height` | float | Floating windows only. Initial height as a fraction (0.1-1.0) of the usable area. Ignored for tiled windows. |
+| `default_width` | float | For floating windows, the initial width as a fraction (0.1-1.0) of the usable area. This includes windows that float without `default_floating`, such as dialogs that declare a parent. For tiled windows, scrolling only: lane scroll-axis extent fraction (0.1-1.0), which is height on a vertical workspace. Gap-aware: fractions that sum to 1 tile exactly. Overrides `layout.scrolling.default_width_fraction`. Dragging the lane within or between scrolling workspaces retains its current fraction. Ignored in dwindle and master. |
+| `default_height` | float | Floating windows only, on the same terms as `default_width`. Initial height as a fraction (0.1-1.0) of the usable area. Ignored for tiled windows. |
 | `default_workspace` | int | Place on workspace N from 1 to 64. On dynamic outputs, values beyond the current count clamp to the last workspace. |
 | `default_fullscreen` | bool | Open in fullscreen. |
 | `default_maximize_to_edges` | bool | Explicitly open maximized to edges. The initial configure fills the usable area without gaps or borders, so the window does not open at its normal size first. Layer-shell exclusive zones stay visible. Takes precedence over `default_maximize`; when combined with `default_fullscreen` the window opens fullscreen and returns to maximized to edges once fullscreen is cleared. |
@@ -98,17 +98,6 @@ default_size = [800, 600]
 default_position = { x = 32, y = 24, anchor = "bottom_left" }
 ```
 
-Floating windows can instead be sized as fractions of the usable area, per
-axis. `default_size` (pixels) wins when both are set:
-
-```toml
-[[window_rule]]
-match.app_id = "^org[.]example[.]Utility$"
-default_floating = true
-default_width = 0.5
-default_height = 0.6
-```
-
 `anchor` defaults to `"center"`, so this centers a floating window exactly:
 
 ```toml
@@ -121,6 +110,30 @@ Available anchors are `"center"`, `"top_left"`, `"top_right"`,
 anchors measure `y` upward from the bottom edge. The single-edge anchors center
 the window on the other axis. Umbriel keeps part of the window visible if an
 offset would otherwise place it completely off-screen.
+
+#### Floating size
+
+`default_size` sizes a float in pixels. `default_width` and `default_height`
+size it as fractions of the output's usable area instead, so one rule suits any
+monitor. The axes are independent: an axis without a fraction keeps the size the
+client asked for. Both are clamped to the client's min/max hints.
+
+```toml
+[[window_rule]]
+match.app_id = "^org[.]example[.]Utility$"
+default_floating = true
+default_width = 0.5
+default_height = 0.6
+```
+
+`default_size` wins on both axes when it is set as well.
+
+Fractions reach every floating window the rule matches, not only windows the
+rule floats with `default_floating`. A window that floats because it declares a
+parent, such as a dialog, or because it fixes its size through min/max hints,
+takes the fraction too. Dialogs usually share their application's `app_id`, so a
+`default_width` written for scrolling lane widths also sizes that application's
+dialogs. Match on `title` or `xdg_tag` to keep a rule off them.
 
 ### Settings updated while a window is open
 
@@ -144,7 +157,8 @@ offset would otherwise place it completely off-screen.
 blur = true
 blur_optimized = true
 
-# Narrow columns for terminals and file managers
+# Narrow columns for terminals and file managers. These fractions also size any
+# floating window these applications open, including their dialogs.
 [[window_rule]]
 match.app_id = "^(Alacritty|kitty|org\\.gnome\\.Nautilus)$"
 default_width = 0.33

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -378,6 +378,12 @@ default_floating = true
 default_size = [800, 600]
 
 # [[window_rule]]
+# match.app_id = "^org[.]example[.]Utility$"
+# default_floating = true
+# default_width = 0.5             # initial width as a fraction of the usable area
+# default_height = 0.6            # initial height as a fraction of the usable area
+
+# [[window_rule]]
 # match.app_id = "firefox"
 # match.title = "^Library$"
 # default_floating = true

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -387,6 +387,8 @@ match.app_id = "^dev.noctalia.UmbrielSharePicker$"
 default_floating = true
 default_size = [800, 600]
 
+# Size a float as fractions of the usable area instead of pixels, so the rule
+# suits any monitor. default_size wins on both axes when it is also set.
 # [[window_rule]]
 # match.app_id = "^org[.]example[.]Utility$"
 # default_floating = true

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1608,6 +1608,19 @@ namespace umbriel {
           }
         }
 
+        if (const toml::node* n = keys.take("default_height")) {
+          const auto value = n->value<double>();
+          if (!value || std::isnan(*value)) {
+            warnAt(n->source(), "ignoring window_rule.default_height (expected number 0.1-1.0)");
+          } else {
+            const double used = std::clamp(*value, 0.1, 1.0);
+            if (used != *value) {
+              warnAt(n->source(), "window_rule.default_height = {} out of range, clamped to {}", *value, used);
+            }
+            rule.defaultHeight = used;
+          }
+        }
+
         if (const toml::node* n = keys.take("default_workspace")) {
           const auto value = n->value<std::int64_t>();
           if (!value || *value < 1 || *value > static_cast<std::int64_t>(kMaxWorkspaces)) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -206,6 +206,7 @@ namespace umbriel {
     std::optional<std::array<int, 2>> defaultSize; // [width, height]
     std::optional<WindowPosition> defaultPosition;
     std::optional<double> defaultWidth;  // column width fraction override
+    std::optional<double> defaultHeight; // floating height fraction of the usable area
     std::optional<int> defaultWorkspace; // 1-64
     std::optional<bool> defaultFullscreen;
     std::optional<bool> defaultMaximizeToEdges;
@@ -235,6 +236,7 @@ namespace umbriel {
           && defaultSize == other.defaultSize
           && defaultPosition == other.defaultPosition
           && defaultWidth == other.defaultWidth
+          && defaultHeight == other.defaultHeight
           && defaultWorkspace == other.defaultWorkspace
           && defaultFullscreen == other.defaultFullscreen
           && defaultMaximizeToEdges == other.defaultMaximizeToEdges
@@ -260,6 +262,7 @@ namespace umbriel {
     std::optional<std::array<int, 2>> defaultSize;
     std::optional<WindowPosition> defaultPosition;
     std::optional<double> defaultWidth;
+    std::optional<double> defaultHeight;
     std::optional<int> defaultWorkspace;
     std::optional<bool> defaultFullscreen;
     std::optional<bool> defaultMaximizeToEdges;

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -152,6 +152,9 @@ namespace umbriel {
       if (rule.defaultWidth) {
         resolved.defaultWidth = rule.defaultWidth;
       }
+      if (rule.defaultHeight) {
+        resolved.defaultHeight = rule.defaultHeight;
+      }
       if (rule.defaultWorkspace) {
         resolved.defaultWorkspace = rule.defaultWorkspace;
       }

--- a/src/view/floating.h
+++ b/src/view/floating.h
@@ -8,6 +8,7 @@ extern "C" {
 #include <array>
 #include <cstdint>
 #include <optional>
+#include <vector>
 
 namespace umbriel {
 
@@ -69,6 +70,45 @@ namespace umbriel {
         .x = usable.x + (usable.width - width) / 2,
         .y = usable.y + (usable.height - height) / 2,
     };
+  }
+
+  // Pixel length of `fraction` of the usable area on one axis. A degenerate axis
+  // yields 0, which callers pass through unclamped so xdg-shell keeps the client's
+  // own preference for that axis.
+  [[nodiscard]] constexpr int floatingFractionSize(double fraction, int usable) {
+    if (usable <= 0) {
+      return 0;
+    }
+    const int pixels = static_cast<int>(fraction * static_cast<double>(usable));
+    return pixels < 1 ? 1 : (pixels > usable ? usable : pixels);
+  }
+
+  // `size` as a fraction of a usable-axis length. The caller guarantees usable > 0.
+  [[nodiscard]] constexpr double floatingSizeFraction(int size, int usable) {
+    return static_cast<double>(size) / static_cast<double>(usable);
+  }
+
+  // The next preset fraction from `current` in `direction` (negative shrinks),
+  // wrapping to the opposite end. Mirrors ScrollingLayout::cycleWidth's walk over
+  // layout.width_presets, shared by tiling and floating window cycling.
+  [[nodiscard]] inline double nextFractionPreset(const std::vector<double>& presets, double current, int direction) {
+    if (presets.empty()) {
+      return current;
+    }
+    if (direction < 0) {
+      for (auto it = presets.rbegin(); it != presets.rend(); ++it) {
+        if (*it < current - 0.0001) {
+          return *it;
+        }
+      }
+      return presets.back();
+    }
+    for (const double preset : presets) {
+      if (preset > current + 0.0001) {
+        return preset;
+      }
+    }
+    return presets.front();
   }
 
   // The remembered state of a window's floating identity, kept across tiled round trips so that floating a window twice

--- a/src/view/floating.h
+++ b/src/view/floating.h
@@ -8,6 +8,7 @@ extern "C" {
 #include <array>
 #include <cstdint>
 #include <optional>
+#include <ranges>
 #include <vector>
 
 namespace umbriel {
@@ -96,9 +97,9 @@ namespace umbriel {
       return current;
     }
     if (direction < 0) {
-      for (auto it = presets.rbegin(); it != presets.rend(); ++it) {
-        if (*it < current - 0.0001) {
-          return *it;
+      for (const double preset : std::views::reverse(presets)) {
+        if (preset < current - 0.0001) {
+          return preset;
         }
       }
       return presets.back();

--- a/src/view/floating.h
+++ b/src/view/floating.h
@@ -6,6 +6,7 @@ extern "C" {
 }
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <optional>
 #include <ranges>
@@ -73,14 +74,16 @@ namespace umbriel {
     };
   }
 
-  // Pixel length of `fraction` of the usable area on one axis. A degenerate axis
-  // yields 0, which callers pass through unclamped so xdg-shell keeps the client's
-  // own preference for that axis.
+  // Pixel length of `fraction` of the usable area on one axis. Rounds like
+  // Layout::fractionalWidth so a float and a tiled lane at the same fraction do
+  // not disagree by a pixel on an odd axis. A degenerate axis yields 0, which
+  // callers pass through unclamped so xdg-shell keeps the client's own
+  // preference for that axis.
   [[nodiscard]] constexpr int floatingFractionSize(double fraction, int usable) {
     if (usable <= 0) {
       return 0;
     }
-    const int pixels = static_cast<int>(fraction * static_cast<double>(usable));
+    const int pixels = static_cast<int>(std::lround(fraction * static_cast<double>(usable)));
     return pixels < 1 ? 1 : (pixels > usable ? usable : pixels);
   }
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1903,6 +1903,25 @@ namespace umbriel {
           requestFloatingSize(
               clampXdgWidth((*rule.defaultSize)[0], hints), clampXdgHeight((*rule.defaultSize)[1], hints)
           );
+        } else if (rule.defaultWidth || rule.defaultHeight) {
+          // Fractions of usable area per axis; default_size (pixels) outranks
+          // them. An axis without a fraction stays 0 so the client keeps its own
+          // preference there.
+          wlr_box usable = targetOutput != nullptr
+              ? targetOutput->usableArea()
+              : m_server->usableAreaAt(m_server->cursor()->wlr()->x, m_server->cursor()->wlr()->y);
+          if (targetOutput != nullptr && (usable.width <= 0 || usable.height <= 0)) {
+            wlr_output_layout_get_box(m_server->outputLayout(), targetOutput->wlr(), &usable);
+          }
+          if (usable.width <= 0 || usable.height <= 0) {
+            usable = m_server->usableAreaAt(m_server->cursor()->wlr()->x, m_server->cursor()->wlr()->y);
+          }
+          const int requestedWidth = rule.defaultWidth ? floatingFractionSize(*rule.defaultWidth, usable.width) : 0;
+          const int requestedHeight = rule.defaultHeight ? floatingFractionSize(*rule.defaultHeight, usable.height) : 0;
+          requestFloatingSize(
+              requestedWidth > 0 ? clampXdgWidth(requestedWidth, hints) : 0,
+              requestedHeight > 0 ? clampXdgHeight(requestedHeight, hints) : 0
+          );
         } else {
           requestFloatingSize(0, 0);
         }
@@ -2599,9 +2618,33 @@ namespace umbriel {
       }
     }
 
-    if (changedInitialRule(rule.defaultSize, initiallyApplied.defaultSize) && !m_tiled) {
+    if (!m_tiled
+        && (changedInitialRule(rule.defaultSize, initiallyApplied.defaultSize)
+            || changedInitialRule(rule.defaultWidth, initiallyApplied.defaultWidth)
+            || changedInitialRule(rule.defaultHeight, initiallyApplied.defaultHeight))) {
       const XdgSizeHints hints = xdgSizeHints(m_toplevel);
-      requestFloatingSize(clampXdgWidth((*rule.defaultSize)[0], hints), clampXdgHeight((*rule.defaultSize)[1], hints));
+      if (rule.defaultSize) {
+        requestFloatingSize(
+            clampXdgWidth((*rule.defaultSize)[0], hints), clampXdgHeight((*rule.defaultSize)[1], hints)
+        );
+      } else if (rule.defaultWidth || rule.defaultHeight) {
+        // Pixel rules outrank fractions, an axis without either keeps the last
+        // acked (then scheduled) size instead of reverting to client preference.
+        const wlr_box usable = floatingUsableArea();
+        int width =
+            rule.defaultWidth ? floatingFractionSize(*rule.defaultWidth, usable.width) : m_toplevel->current.width;
+        int height =
+            rule.defaultHeight ? floatingFractionSize(*rule.defaultHeight, usable.height) : m_toplevel->current.height;
+        if (width <= 0) {
+          width = m_toplevel->scheduled.width;
+        }
+        if (height <= 0) {
+          height = m_toplevel->scheduled.height;
+        }
+        requestFloatingSize(
+            width > 0 ? clampXdgWidth(width, hints) : 0, height > 0 ? clampXdgHeight(height, hints) : 0
+        );
+      }
       placeInUsableArea();
     }
 

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -661,6 +661,35 @@ UMBRIEL_TEST(windowTearingOverrideLoadsAsAnOptionalBoolean) {
   CHECK(containsDiagnostic(store, "ignoring window_rule.tearing (expected boolean)"));
 }
 
+UMBRIEL_TEST(windowRuleFractionSizingLoadsAndClamps) {
+  const TempConfig file;
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  file.write(
+      "[[window_rule]]\nmatch.app_id = \"^utility$\"\ndefault_floating = true\ndefault_width = 0.5\ndefault_height = "
+      "0.6\n"
+  );
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().windowRules.size(), size_t{1});
+  CHECK(store.config().windowRules[0].defaultWidth && *store.config().windowRules[0].defaultWidth == 0.5);
+  CHECK(store.config().windowRules[0].defaultHeight && *store.config().windowRules[0].defaultHeight == 0.6);
+
+  // Out-of-range fractions clamp into [0.1, 1.0] with a diagnostic, like default_width.
+  file.write("[[window_rule]]\ndefault_width = 3.0\ndefault_height = 0.01\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().windowRules[0].defaultWidth && *store.config().windowRules[0].defaultWidth == 1.0);
+  CHECK(store.config().windowRules[0].defaultHeight && *store.config().windowRules[0].defaultHeight == 0.1);
+  CHECK(containsDiagnostic(store, "window_rule.default_width = 3 out of range, clamped to 1"));
+  CHECK(containsDiagnostic(store, "window_rule.default_height = 0.01 out of range, clamped to 0.1"));
+
+  // Non-numeric values are ignored with a diagnostic.
+  file.write("[[window_rule]]\ndefault_height = \"half\"\n");
+  CHECK(store.reload().success);
+  CHECK(!store.config().windowRules[0].defaultHeight);
+  CHECK(containsDiagnostic(store, "ignoring window_rule.default_height (expected number 0.1-1.0)"));
+}
+
 UMBRIEL_TEST(outputEnabledFlagParsesAndDefaultsTrue) {
   const TempConfig file;
   ConfigStore& store = umbriel::configStore();

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -231,6 +231,30 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   CHECK(umbriel::anyWindowRuleHasTitlePattern(config));
 }
 
+UMBRIEL_TEST(windowRulesMergeFractionSizingLastWriterWins) {
+  Config config;
+
+  WindowRule first;
+  first.appIdPattern = "^utility$";
+  first.appIdRegex = std::regex(first.appIdPattern);
+  first.defaultFloating = true;
+  first.defaultWidth = 0.5;
+  first.defaultHeight = 0.6;
+  config.windowRules.push_back(std::move(first));
+
+  WindowRule second;
+  second.appIdPattern = "^utility$";
+  second.appIdRegex = std::regex(second.appIdPattern);
+  second.defaultWidth = 0.75;
+  config.windowRules.push_back(std::move(second));
+
+  const auto resolved = umbriel::resolveWindowRules(config, "utility", "", false);
+  CHECK(resolved.defaultFloating && *resolved.defaultFloating);
+  // Later rules overwrite only the fields they set.
+  CHECK(resolved.defaultWidth && *resolved.defaultWidth == 0.75);
+  CHECK(resolved.defaultHeight && *resolved.defaultHeight == 0.6);
+}
+
 UMBRIEL_TEST(windowVrrRuleOverridesTheOutputPolicy) {
   CHECK(umbriel::effectiveVrrEnabled(VrrMode::Disabled, false, VrrMode::Always, false));
   CHECK(!umbriel::effectiveVrrEnabled(VrrMode::Always, false, VrrMode::Disabled, false));

--- a/tests/unit/floating.cpp
+++ b/tests/unit/floating.cpp
@@ -267,6 +267,15 @@ UMBRIEL_TEST(aDegenerateUsableAxisLeavesTheChoiceToTheClient) {
   CHECK_EQ(floatingFractionSize(0.5, -1), 0);
 }
 
+UMBRIEL_TEST(aFractionRoundsRatherThanTruncates) {
+  // Layout::fractionalWidth rounds, so a float and a tiled lane at the same
+  // fraction must not disagree by a pixel when the usable axis is odd, which a
+  // layer-shell exclusive zone readily produces.
+  CHECK_EQ(floatingFractionSize(0.5, 1281), 641);
+  CHECK_EQ(floatingFractionSize(0.5, 719), 360);
+  CHECK_EQ(floatingFractionSize(0.75, 1366), 1025);
+}
+
 UMBRIEL_TEST(fractionPixelsStayWithinTheAxis) {
   // Defensive: parse clamps fractions to [0.1, 1.0], but the arithmetic result
   // never leaves the usable axis and never collapses to 0.

--- a/tests/unit/floating.cpp
+++ b/tests/unit/floating.cpp
@@ -5,9 +5,12 @@
 using umbriel::anchoredContentOrigin;
 using umbriel::centeredOrigin;
 using umbriel::clampFloatingOrigin;
+using umbriel::floatingFractionSize;
 using umbriel::FloatingGeometry;
 using umbriel::floatingKeepVisible;
 using umbriel::FloatingPoint;
+using umbriel::floatingSizeFraction;
+using umbriel::nextFractionPreset;
 using umbriel::serialSettled;
 
 namespace {
@@ -249,6 +252,67 @@ UMBRIEL_TEST(centeringHonoursAnOffsetUsableArea) {
   const FloatingPoint origin = centeredOrigin(usable, 800, 600);
   CHECK_EQ(origin.x, 1920 + 560);
   CHECK_EQ(origin.y, 40 + 220);
+}
+
+// Fraction sizing (window_rule.default_width / default_height on floats)
+UMBRIEL_TEST(aFractionOfTheUsableAxisBecomesPixels) {
+  CHECK_EQ(floatingFractionSize(0.5, 1920), 960);
+  CHECK_EQ(floatingFractionSize(0.5, 1080), 540);
+  CHECK_EQ(floatingFractionSize(0.1, 1920), 192);
+  CHECK_EQ(floatingFractionSize(1.0, 1920), 1920);
+}
+
+UMBRIEL_TEST(aDegenerateUsableAxisLeavesTheChoiceToTheClient) {
+  CHECK_EQ(floatingFractionSize(0.5, 0), 0);
+  CHECK_EQ(floatingFractionSize(0.5, -1), 0);
+}
+
+UMBRIEL_TEST(fractionPixelsStayWithinTheAxis) {
+  // Defensive: parse clamps fractions to [0.1, 1.0], but the arithmetic result
+  // never leaves the usable axis and never collapses to 0.
+  CHECK_EQ(floatingFractionSize(0.0001, 100), 1);
+  CHECK_EQ(floatingFractionSize(1.5, 800), 800);
+}
+
+UMBRIEL_TEST(aSizeReadsBackAsTheFractionItCameFrom) {
+  CHECK(floatingSizeFraction(960, 1920) == 0.5);
+  CHECK(floatingSizeFraction(192, 1920) == 0.1);
+}
+
+// Preset cycling (window-cycle-width/-height on floats)
+UMBRIEL_TEST(cyclingForwardPicksTheNextLargerPreset) {
+  const std::vector<double> presets{1.0 / 3, 0.5, 2.0 / 3};
+  CHECK(nextFractionPreset(presets, 0.4, 1) == 0.5);
+  CHECK(nextFractionPreset(presets, 0.5, 1) == 2.0 / 3);
+}
+
+UMBRIEL_TEST(cyclingForwardWrapsToTheSmallestPreset) {
+  const std::vector<double> presets{1.0 / 3, 0.5, 2.0 / 3};
+  CHECK(nextFractionPreset(presets, 0.9, 1) == 1.0 / 3);
+}
+
+UMBRIEL_TEST(cyclingBackwardPicksTheNextSmallerPreset) {
+  const std::vector<double> presets{1.0 / 3, 0.5, 2.0 / 3};
+  CHECK(nextFractionPreset(presets, 0.6, -1) == 0.5);
+  CHECK(nextFractionPreset(presets, 0.4, -1) == 1.0 / 3);
+}
+
+UMBRIEL_TEST(cyclingBackwardWrapsToTheLargestPreset) {
+  const std::vector<double> presets{1.0 / 3, 0.5, 2.0 / 3};
+  CHECK(nextFractionPreset(presets, 0.2, -1) == 2.0 / 3);
+}
+
+UMBRIEL_TEST(anExactPresetCyclesPastItself) {
+  // The epsilon guard: a window sitting exactly on a preset moves to the next
+  // one instead of re-selecting its own size.
+  const std::vector<double> presets{1.0 / 3, 0.5, 2.0 / 3};
+  CHECK(nextFractionPreset(presets, 0.5, -1) == 1.0 / 3);
+  CHECK(nextFractionPreset(presets, 0.5, 1) == 2.0 / 3);
+}
+
+UMBRIEL_TEST(cyclingWithoutPresetsKeepsTheCurrentFraction) {
+  CHECK(nextFractionPreset({}, 0.42, 1) == 0.42);
+  CHECK(nextFractionPreset({}, 0.42, -1) == 0.42);
 }
 
 int main() { return RUN_TESTS(); }


### PR DESCRIPTION
## Summary

This PR add fraction based `default_height` for floating windows which works with `default_width` (0.1-1.0)
These two axes are independent, an axis without a fraction keeps the client's preferred size. If user have `default_size` (pixels) set then client uses size ignoring `default_width` and `default_height`. Tiled-window behavior is unchanged (`default_width` remains the scrolling lane fraction, tiled windows ignore `default_height`).

## Motivation

Before we could could only be sized floating windows with fixed pixels using `default_size`, which is output-size dependent. Fraction-based sizing is good for any size of monitor for floating windows.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

Feature request from discord

## Testing

- `just format`, `just test`, `just lint`,`just debug` everything clean 
- Installed the branch to test it natively

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos


https://github.com/user-attachments/assets/8258d955-8165-43f7-8018-283738a90f08



## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`.
- [x] I ran the relevant build, test, lint, or verification commands.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

#60 is build on top of this PR, after merge check #60.