### PR TITLE
feat: add workspace-focus-last bind

### DIFF
--- a/docs/user/actions.md
+++ b/docs/user/actions.md
@@ -72,9 +72,9 @@ restriction.
 - **Previously focused window:** `window-focus-last`. Focus the previous entry in
   the global focus history, including windows on another workspace or output.
   Repeated use toggles between the two most recently focused windows.
-- **Previously focused workspace:** `workspace-focus-last`. Focus the previous
-  entry in the global workspace focus history. Repeated use toggles between
-  the two most recently focused workspaces.
+- **Previously focused workspace:** `workspace-focus-last`. Focus the previously
+  active workspace on the focused output. Repeated use toggles between the two
+  most recently active workspaces on that output.
 
 With `input.cursor.follows_focus` enabled, these navigation actions warp the
 cursor to the visible center of the selected window. This also applies to

--- a/docs/user/actions.md
+++ b/docs/user/actions.md
@@ -72,6 +72,9 @@ restriction.
 - **Previously focused window:** `window-focus-last`. Focus the previous entry in
   the global focus history, including windows on another workspace or output.
   Repeated use toggles between the two most recently focused windows.
+- **Previously focused workspace:** `workspace-focus-last`. Focus the previous
+  entry in the global workspace focus history. Repeated use toggles between
+  the two most recently focused workspaces.
 
 With `input.cursor.follows_focus` enabled, these navigation actions warp the
 cursor to the visible center of the selected window. This also applies to

--- a/src/config/keybind_parse.cpp
+++ b/src/config/keybind_parse.cpp
@@ -245,6 +245,7 @@ namespace umbriel {
         {"window-toggle-pinned", "", KeybindAction::TogglePinned},
         {"window-toggle-scratchpad", "[<output>]", KeybindAction::WindowToggleScratchpad,
          ActionArgKind::OptionalOutput},
+        {"workspace-focus-last", "", KeybindAction::WorkspaceFocusLast},
         {"workspace-move-down", "", KeybindAction::WorkspaceMoveDown},
         {"workspace-move-to-output-down", "", KeybindAction::WorkspaceMoveToOutputDown},
         {"workspace-move-to-output-left", "", KeybindAction::WorkspaceMoveToOutputLeft},

--- a/src/config/keybind_parse.h
+++ b/src/config/keybind_parse.h
@@ -127,6 +127,7 @@ namespace umbriel {
     WindowSetHeight,
     WindowModifyHeight,
     WindowFocusLast,
+    WorkspaceFocusLast,
     Count,
   };
 

--- a/src/scene/cheatsheet_rows.cpp
+++ b/src/scene/cheatsheet_rows.cpp
@@ -295,6 +295,7 @@ namespace {
     case A::WindowFocusWarpId:
     case A::WindowFocusSwitchFloating:
     case A::WindowFocusLast:
+    case A::WorkspaceFocusLast:
       return Group::Focus;
     case A::ColumnMoveLeft:
     case A::ColumnMoveRight:

--- a/src/server/actions.cpp
+++ b/src/server/actions.cpp
@@ -885,6 +885,23 @@ namespace umbriel {
       return true;
     }
 
+    bool actionWorkspaceFocusLast(Server& server, const Keybind& /*bind*/, std::string* /*error*/) {
+      Workspace* workspace = activeWorkspace(server);
+      if (workspace == nullptr) {
+        return true;
+      }
+      WorkspaceGroup* group = workspace->group();
+      if (group == nullptr) {
+        return true;
+      }
+      Workspace* target = group->previous();
+      if (target == nullptr || target == group->active()) {
+        return true;
+      }
+      group->select(target);
+      return true;
+    }
+
     bool actionFocusSwitchFloating(Server& server, const Keybind& /*bind*/, std::string* /*error*/) {
       Workspace* workspace = activeWorkspace(server);
       if (workspace == nullptr) {
@@ -1377,6 +1394,7 @@ namespace umbriel {
         &actionSetHeight,
         &actionModifyHeight,
         &actionWindowFocusLast,
+        &actionWorkspaceFocusLast,
     };
 
     consteval bool everyActionHasHandler() {

--- a/src/server/actions.cpp
+++ b/src/server/actions.cpp
@@ -899,6 +899,8 @@ namespace umbriel {
         return true;
       }
       group->select(target);
+      Workspace* selected = group->active();
+      maybeWarpCursorToWindow(server, selected != nullptr ? selected->focusedView() : nullptr);
       return true;
     }
 

--- a/tests/harness/checks/510_pointer_focus.sh
+++ b/tests/harness/checks/510_pointer_focus.sh
@@ -34,8 +34,11 @@ wait_for_count() {
   return 1
 }
 
-# x of the focused window, or "none".
-focused_x() { "$UMBRIEL" windows --json | jq -r '[.[] | select(.focused) | .x] | if length == 1 then .[0] else "none" end'; }
+# x of the focused window on the active workspace, or "none".
+focused_x() {
+  "$UMBRIEL" windows --json | jq -r \
+    '[.[] | select(.focused and .active) | .x] | if length == 1 then .[0] else "none" end'
+}
 
 wait_for_focus_at() {
   local want=$1
@@ -44,7 +47,7 @@ wait_for_focus_at() {
     sleep 0.25
   done
   echo "expected the window at x=$want to be focused, focus is at $(focused_x)"
-  echo "  windows: $("$UMBRIEL" windows --json | jq -c '[.[] | {x, focused}]')"
+  echo "  windows: $("$UMBRIEL" windows --json | jq -c '[.[] | {x, focused, active}]')"
   return 1
 }
 
@@ -114,4 +117,20 @@ wait_for_focus_at 10
 pointer click "$BTN_LEFT"
 wait_for_focus_at 646
 
-echo "click focus, hover behavior, and configured focus-navigation cursor warps are correct"
+# Workspace focus history is local to the focused output. Returning to that
+# output's previous workspace is still focus navigation, so follows_focus must
+# move the cursor to its restored focused window. Leave a second window under
+# the old pointer position, then click without motion after the transition.
+"$UMBRIEL" msg window-focus-left > /dev/null
+wait_for_focus_at 10
+"$UMBRIEL" msg workspace-switch:2 > /dev/null
+spawn_client
+wait_for_count 3
+pointer move "$RIGHT_X" "$MID_Y"
+"$UMBRIEL" msg workspace-focus-last > /dev/null
+wait_for_focus_at 10
+sleep 1
+pointer click "$BTN_LEFT"
+wait_for_focus_at 10
+
+echo "click focus and configured window and workspace focus-navigation cursor warps are correct"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add workspace-focus-last bind to focus the last active workspace.
Similar to `back_and_forth` but a bind.

## Motivation

<!-- What problem does this solve? -->
Feature request on discord.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
