### PR TITLE
Apply natural_scroll setting to other touchpad gestures

### DIFF
--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -79,6 +79,12 @@ touchpad active while typing. Removing either optional setting on reload
 restores the device default. Options are applied only when supported by the
 device; an explicitly configured unsupported option is reported in the log.
 
+The effective `natural_scroll` value also controls Umbriel's three-finger
+gestures: horizontal strip scrolling, vertical workspace switching, and
+workspace selection while the overview is open. A per-device override or
+preserved libinput default applies to gestures from that device. The
+four-finger overview open and close gesture keeps its fixed direction.
+
 `accel_profile` and `sensitivity` work like their `[input.mouse]` counterparts,
 including custom curves. Both remain unset by default, which uses each
 touchpad's libinput default profile and speed. Removing either setting on reload

--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -1,6 +1,5 @@
 #include "input/gestures.h"
 
-#include "config/config.h"
 #include "input/cursor.h"
 #include "input/seat.h"
 #include "layout/scrolling.h"
@@ -33,6 +32,17 @@ namespace umbriel {
     constexpr double kOverviewStepPx = kSwitchDistancePx * kCommitProgress;
     // Finger travel that scrolls the strip by one viewport width.
     constexpr double kViewGestureMovementPx = 1200.0;
+
+    int touchpadGestureDirection(wlr_pointer* pointer) {
+      if (pointer == nullptr || !wlr_input_device_is_libinput(&pointer->base)) {
+        return 1;
+      }
+      libinput_device* device = wlr_libinput_get_device_handle(&pointer->base);
+      if (device == nullptr || libinput_device_config_scroll_has_natural_scroll(device) == 0) {
+        return 1;
+      }
+      return libinput_device_config_scroll_get_natural_scroll_enabled(device) != 0 ? 1 : -1;
+    }
   } // namespace
 
   // trampolines (same pattern as Cursor)
@@ -194,6 +204,7 @@ namespace umbriel {
       return;
     }
     if (event->fingers == 3) {
+      m_naturalScrollDirection = touchpadGestureDirection(event->pointer);
       // Which of the three-finger gestures this is (scroll, switch, or an
       // overview row step) is decided once the axis locks, not here.
       m_state = State::Pending;
@@ -306,10 +317,7 @@ namespace umbriel {
       // Natural: fingers left → content moves left → scroll increases. The strip follows the
       // fingers unclamped, past the strip edges included; the release resolves the overscroll.
       m_scrollTracker.push(event->dx, event->time_msec);
-      const double target = m_scrollStart
-          - m_scrollTracker.pos()
-              * scrollNormFactor()
-              * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
+      const double target = m_scrollStart - m_scrollTracker.pos() * scrollNormFactor() * m_naturalScrollDirection;
       scrolling->setScroll(target);
       m_scrollWorkspace->markArrange(false);
       return;
@@ -326,7 +334,7 @@ namespace umbriel {
       }
       m_accumY += event->dy;
       // Natural: swipe up (negative dy) → next workspace (positive progress).
-      double p = -m_accumY / kSwitchDistancePx * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
+      double p = -m_accumY / kSwitchDistancePx * m_naturalScrollDirection;
       const double lo = m_hasPrev ? -1.0 : 0.0;
       const double hi = m_hasNext ? 1.0 : 0.0;
       if (p < lo) {
@@ -336,7 +344,7 @@ namespace umbriel {
         p = std::min(hi + (p - hi) * kOverscrollCompress, hi + kOverscrollMaxWs);
       }
       const uint32_t dt = std::max(1U, event->time_msec - m_lastTimeMsec);
-      m_velocity = 0.75 * m_velocity + 0.25 * (-event->dy / static_cast<double>(dt));
+      m_velocity = 0.75 * m_velocity + 0.25 * (-event->dy / static_cast<double>(dt) * m_naturalScrollDirection);
       m_lastTimeMsec = event->time_msec;
       m_progress = p;
       m_switchGroup->slideApply(p);
@@ -354,15 +362,11 @@ namespace umbriel {
       // workspace. The leftover travel stays in m_accumY so one long swipe crosses several rows.
       while (m_accumY <= -kOverviewStepPx) {
         m_accumY += kOverviewStepPx;
-        overview->selectRelativeWorkspace(
-            1 * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0), m_output
-        );
+        overview->selectRelativeWorkspace(m_naturalScrollDirection, m_output);
       }
       while (m_accumY >= kOverviewStepPx) {
         m_accumY -= kOverviewStepPx;
-        overview->selectRelativeWorkspace(
-            -1 * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0), m_output
-        );
+        overview->selectRelativeWorkspace(-m_naturalScrollDirection, m_output);
       }
       return;
     }
@@ -480,10 +484,7 @@ namespace umbriel {
     const double factor = scrollNormFactor();
     const double currentScroll = scrolling->scroll();
     // Where the swipe would coast to a stop under deceleration.
-    const double projected = m_scrollStart
-        - m_scrollTracker.projectedEndPos()
-            * factor
-            * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
+    const double projected = m_scrollStart - m_scrollTracker.projectedEndPos() * factor * m_naturalScrollDirection;
 
     const auto maxScroll = static_cast<double>(scrolling->maxScroll(m_viewportPrimary));
     const auto columnCount = static_cast<int>(scrolling->columns().size());

--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -306,7 +306,8 @@ namespace umbriel {
       // Natural: fingers left → content moves left → scroll increases. The strip follows the
       // fingers unclamped, past the strip edges included; the release resolves the overscroll.
       m_scrollTracker.push(event->dx, event->time_msec);
-      const double target = m_scrollStart - m_scrollTracker.pos() * scrollNormFactor();
+      const double target = m_scrollStart - m_scrollTracker.pos() * scrollNormFactor()
+        * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
       scrolling->setScroll(target);
       m_scrollWorkspace->markArrange(false);
       return;
@@ -323,7 +324,8 @@ namespace umbriel {
       }
       m_accumY += event->dy;
       // Natural: swipe up (negative dy) → next workspace (positive progress).
-      double p = -m_accumY / kSwitchDistancePx;
+      double p = -m_accumY / kSwitchDistancePx
+        * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
       const double lo = m_hasPrev ? -1.0 : 0.0;
       const double hi = m_hasNext ? 1.0 : 0.0;
       if (p < lo) {
@@ -351,11 +353,11 @@ namespace umbriel {
       // workspace. The leftover travel stays in m_accumY so one long swipe crosses several rows.
       while (m_accumY <= -kOverviewStepPx) {
         m_accumY += kOverviewStepPx;
-        overview->selectRelativeWorkspace(1, m_output);
+        overview->selectRelativeWorkspace(1 * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0), m_output);
       }
       while (m_accumY >= kOverviewStepPx) {
         m_accumY -= kOverviewStepPx;
-        overview->selectRelativeWorkspace(-1, m_output);
+        overview->selectRelativeWorkspace(-1 * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0), m_output);
       }
       return;
     }
@@ -473,7 +475,8 @@ namespace umbriel {
     const double factor = scrollNormFactor();
     const double currentScroll = scrolling->scroll();
     // Where the swipe would coast to a stop under deceleration.
-    const double projected = m_scrollStart - m_scrollTracker.projectedEndPos() * factor;
+    const double projected = m_scrollStart - m_scrollTracker.projectedEndPos() * factor
+       * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
 
     const auto maxScroll = static_cast<double>(scrolling->maxScroll(m_viewportPrimary));
     const auto columnCount = static_cast<int>(scrolling->columns().size());

--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -306,8 +306,10 @@ namespace umbriel {
       // Natural: fingers left → content moves left → scroll increases. The strip follows the
       // fingers unclamped, past the strip edges included; the release resolves the overscroll.
       m_scrollTracker.push(event->dx, event->time_msec);
-      const double target = m_scrollStart - m_scrollTracker.pos() * scrollNormFactor()
-        * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
+      const double target = m_scrollStart
+          - m_scrollTracker.pos()
+              * scrollNormFactor()
+              * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
       scrolling->setScroll(target);
       m_scrollWorkspace->markArrange(false);
       return;
@@ -324,8 +326,7 @@ namespace umbriel {
       }
       m_accumY += event->dy;
       // Natural: swipe up (negative dy) → next workspace (positive progress).
-      double p = -m_accumY / kSwitchDistancePx
-        * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
+      double p = -m_accumY / kSwitchDistancePx * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
       const double lo = m_hasPrev ? -1.0 : 0.0;
       const double hi = m_hasNext ? 1.0 : 0.0;
       if (p < lo) {
@@ -353,11 +354,15 @@ namespace umbriel {
       // workspace. The leftover travel stays in m_accumY so one long swipe crosses several rows.
       while (m_accumY <= -kOverviewStepPx) {
         m_accumY += kOverviewStepPx;
-        overview->selectRelativeWorkspace(1 * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0), m_output);
+        overview->selectRelativeWorkspace(
+            1 * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0), m_output
+        );
       }
       while (m_accumY >= kOverviewStepPx) {
         m_accumY -= kOverviewStepPx;
-        overview->selectRelativeWorkspace(-1 * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0), m_output);
+        overview->selectRelativeWorkspace(
+            -1 * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0), m_output
+        );
       }
       return;
     }
@@ -475,8 +480,10 @@ namespace umbriel {
     const double factor = scrollNormFactor();
     const double currentScroll = scrolling->scroll();
     // Where the swipe would coast to a stop under deceleration.
-    const double projected = m_scrollStart - m_scrollTracker.projectedEndPos() * factor
-       * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
+    const double projected = m_scrollStart
+        - m_scrollTracker.projectedEndPos()
+            * factor
+            * (config().input.touchpad.naturalScroll.value_or(true) ? 1.0 : -1.0);
 
     const auto maxScroll = static_cast<double>(scrolling->maxScroll(m_viewportPrimary));
     const auto columnCount = static_cast<int>(scrolling->columns().size());

--- a/src/input/gestures.h
+++ b/src/input/gestures.h
@@ -57,6 +57,7 @@ namespace umbriel {
     double m_accumX = 0;
     double m_accumY = 0;
     Output* m_output = nullptr;
+    int m_naturalScrollDirection = 1;
 
     // Scroll state (horizontal 3-finger).
     Workspace* m_scrollWorkspace = nullptr;


### PR DESCRIPTION
## Summary

Natural scroll setting previously only applied to two-finger scroll; natural scroll was assumed by other gestures. This reverses those gestures when natural_scroll = false. 

## Motivation

It's quite disorienting to have reverse scrolling only some of the time. 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.