### PR TITLE
feat: add switch events for laptop lid close and open

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -105,6 +105,16 @@ reload does not update environments already captured by running processes.
 Restart Umbriel after changing it, then fully quit and relaunch long-running
 applications such as Steam if they survived the session restart.
 
+## Events
+
+```toml
+[events]
+lid-close = "notify-send 'The laptop lid is closed !'"
+lid-open = "notify-send 'The laptop lid is open !'"
+```
+
+Defines commands that are executed when the laptop lid is closed or opened.
+
 ## Idle inhibition
 
 Umbriel supports application idle inhibitors and idle notifications. An

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -109,8 +109,8 @@ applications such as Steam if they survived the session restart.
 
 ```toml
 [events]
-lid-close = "notify-send 'The laptop lid is closed !'"
-lid-open = "notify-send 'The laptop lid is open !'"
+lid_close = "notify-send 'The laptop lid is closed!'"
+lid_open = "notify-send 'The laptop lid is open!'"
 ```
 
 Defines commands that are executed when the laptop lid is closed or opened.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -28,6 +28,11 @@ honor_restored_maximize = false # let apps restore their saved maximized state
 # GTK_THEME = "Adwaita:dark"
 # QT_QPA_PLATFORMTHEME = "qt5ct"
 
+# Defines commands that are executed when the laptop lid is closed or opened.
+# [events]
+# lid-close = "notify-send 'The laptop lid is closed !'"
+# lid-open = "notify-send 'The laptop lid is open !'"
+
 [workspaces]
 back_and_forth = false
 empty_above = false

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -30,8 +30,8 @@ honor_restored_maximize = false # let apps restore their saved maximized state
 
 # Defines commands that are executed when the laptop lid is closed or opened.
 # [events]
-# lid-close = "notify-send 'The laptop lid is closed !'"
-# lid-open = "notify-send 'The laptop lid is open !'"
+# lid_close = "notify-send 'The laptop lid is closed!'"
+# lid_open = "notify-send 'The laptop lid is open!'"
 
 [workspaces]
 back_and_forth = false

--- a/src/config/change.cpp
+++ b/src/config/change.cpp
@@ -148,6 +148,7 @@ namespace umbriel {
         .workspaces = true,
         .general = true,
         .environment = true,
+        .events = true,
         .input = true,
         .keybinds = true,
         .outputs = true,
@@ -168,6 +169,7 @@ namespace umbriel {
         .workspaces = before.workspaces != after.workspaces,
         .general = before.general != after.general,
         .environment = before.environment != after.environment,
+        .events = before.events != after.events,
         .input = before.input != after.input,
         .keybinds = before.keybinds != after.keybinds,
         .outputs = before.outputs != after.outputs,
@@ -197,6 +199,7 @@ namespace umbriel {
     add(workspaces, "workspaces");
     add(general, "general");
     add(environment, "environment");
+    add(events, "events");
     add(input, "input");
     add(keybinds, "keybinds");
     add(outputs, "outputs");

--- a/src/config/change.h
+++ b/src/config/change.h
@@ -18,6 +18,7 @@ namespace umbriel {
     bool workspaces = false;
     bool general = false;
     bool environment = false;
+    bool events = false;
     bool input = false;
     bool keybinds = false;
     bool outputs = false;
@@ -35,6 +36,7 @@ namespace umbriel {
           || workspaces
           || general
           || environment
+          || events
           || input
           || keybinds
           || outputs

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1015,6 +1015,12 @@ namespace umbriel {
       });
     }
 
+    void readEvents(Section& root, Config& loaded) {
+      root.sub("events", [&](Section& s) {
+        s.text("lid-close", loaded.events.lidClose).text("lid-open", loaded.events.lidOpen);
+      });
+    }
+
     bool validateKeyboardInput(
         const Config::Input::Keyboard& keyboard, const toml::source_region& source, std::string_view context
     ) {
@@ -1803,6 +1809,7 @@ namespace umbriel {
           readLayout(root, loaded);
           readGeneral(root, loaded);
           readEnvironment(root, loaded);
+          readEvents(root, loaded);
           readWorkspaceSettings(root, loaded);
           readInput(root, loaded);
           readOutputs(root, loaded);

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1017,7 +1017,7 @@ namespace umbriel {
 
     void readEvents(Section& root, Config& loaded) {
       root.sub("events", [&](Section& s) {
-        s.text("lid-close", loaded.events.lidClose).text("lid-open", loaded.events.lidOpen);
+        s.text("lid_close", loaded.events.lidClose).text("lid_open", loaded.events.lidOpen);
       });
     }
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -573,6 +573,12 @@ namespace umbriel {
       bool operator==(const Environment&) const = default;
     } environment;
 
+    struct Events {
+      std::string lidClose;
+      std::string lidOpen;
+      bool operator==(const Events&) const = default;
+    } events;
+
     struct Input {
       // Advertise and accept the primary-selection clipboard used for
       // middle-click paste.

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -369,6 +369,8 @@ namespace umbriel {
     static void onTabletPadRing(wl_listener* listener, void* data);
     static void onTabletPadStrip(wl_listener* listener, void* data);
     static void onPadKeyboardFocusChange(wl_listener* listener, void* data);
+    static void onSwitchDestroy(wl_listener* listener, void* data);
+    static void onSwitchToggle(wl_listener* listener, void* data);
     static void onOutputManagerApply(wl_listener* listener, void* data);
     static void onOutputManagerTest(wl_listener* listener, void* data);
     static void onOutputLayoutChange(wl_listener* listener, void* data);
@@ -409,6 +411,13 @@ namespace umbriel {
     };
     void addTablet(wlr_input_device* device);
     void addTabletPad(wlr_input_device* device);
+    struct SwitchDevice {
+      Server* server = nullptr;
+      wlr_input_device* device = nullptr;
+      wl_listener destroy{};
+      wl_listener toggle{};
+    };
+    void addSwitch(wlr_input_device* device);
     void applyTabletConfig(TabletDevice& tablet);
     void applyTabletPadConfig(TabletPadDevice& pad);
     void pairTabletPads();
@@ -616,6 +625,7 @@ namespace umbriel {
     std::vector<std::unique_ptr<TouchDevice>> m_touchDevices;
     std::vector<std::unique_ptr<TabletDevice>> m_tabletDevices;
     std::vector<std::unique_ptr<TabletPadDevice>> m_tabletPads;
+    std::vector<std::unique_ptr<SwitchDevice>> m_switchDevices;
     std::vector<std::unique_ptr<VirtualPointerDevice>> m_virtualPointers;
     Dirty m_dirty = Dirty::None;
     ViewRegistry m_registry;

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -1258,12 +1258,12 @@ namespace umbriel {
     if (event->switch_state == WLR_SWITCH_STATE_ON) {
       kLog.info("lid closed");
       if (!config().events.lidClose.empty()) {
-        server->spawn(config().events.lidClose.c_str(), "events.lid-close");
+        server->spawn(config().events.lidClose.c_str(), "events.lid_close");
       }
     } else {
       kLog.info("lid opened");
       if (!config().events.lidOpen.empty()) {
-        server->spawn(config().events.lidOpen.c_str(), "events.lid-open");
+        server->spawn(config().events.lidOpen.c_str(), "events.lid_open");
       }
     }
   }

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -596,6 +596,9 @@ namespace umbriel {
     case WLR_INPUT_DEVICE_TABLET_PAD:
       self->addTabletPad(device);
       break;
+    case WLR_INPUT_DEVICE_SWITCH:
+      self->addSwitch(device);
+      break;
     default:
       break;
     }
@@ -1219,6 +1222,50 @@ namespace umbriel {
       return entry.get() == watch;
     });
     server->updateSeatCapabilities();
+  }
+
+  void Server::addSwitch(wlr_input_device* device) {
+    auto entry = std::make_unique<SwitchDevice>();
+    entry->server = this;
+    entry->device = device;
+    entry->destroy.notify = onSwitchDestroy;
+    wl_signal_add(&device->events.destroy, &entry->destroy);
+    entry->toggle.notify = onSwitchToggle;
+    wl_signal_add(&wlr_switch_from_input_device(device)->events.toggle, &entry->toggle);
+    m_switchDevices.push_back(std::move(entry));
+    kLog.info("input: added switch device '{}'", deviceName(device));
+  }
+
+  void Server::onSwitchDestroy(wl_listener* listener, void* /*data*/) {
+    SwitchDevice* watch;
+    watch = wl_container_of(listener, watch, destroy);
+    Server* server = watch->server;
+    wl_list_remove(&watch->destroy.link);
+    wl_list_remove(&watch->toggle.link);
+    std::erase_if(server->m_switchDevices, [watch](const std::unique_ptr<SwitchDevice>& entry) {
+      return entry.get() == watch;
+    });
+  }
+
+  void Server::onSwitchToggle(wl_listener* listener, void* data) {
+    SwitchDevice* watch;
+    watch = wl_container_of(listener, watch, toggle);
+    const auto* event = static_cast<wlr_switch_toggle_event*>(data);
+    if (event->switch_type != WLR_SWITCH_TYPE_LID) {
+      return;
+    }
+    Server* server = watch->server;
+    if (event->switch_state == WLR_SWITCH_STATE_ON) {
+      kLog.info("lid closed");
+      if (!config().events.lidClose.empty()) {
+        server->spawn(config().events.lidClose.c_str(), "events.lid-close");
+      }
+    } else {
+      kLog.info("lid opened");
+      if (!config().events.lidOpen.empty()) {
+        server->spawn(config().events.lidOpen.c_str(), "events.lid-open");
+      }
+    }
   }
 
   void Server::addTablet(wlr_input_device* device) {

--- a/src/wlr.h
+++ b/src/wlr.h
@@ -54,6 +54,7 @@ extern "C" {
 #include <wlr/types/wlr_server_decoration.h>
 #include <wlr/types/wlr_session_lock_v1.h>
 #include <wlr/types/wlr_subcompositor.h>
+#include <wlr/types/wlr_switch.h>
 #include <wlr/types/wlr_tablet_pad.h>
 #include <wlr/types/wlr_tablet_tool.h>
 #include <wlr/types/wlr_tablet_v2.h>

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -27,6 +27,7 @@ UMBRIEL_TEST(aFirstLoadReportsEverything) {
   CHECK(change.appearance);
   CHECK(change.animation);
   CHECK(change.colors);
+  CHECK(change.events);
   CHECK(change.input);
   CHECK(change.outputs);
 }
@@ -112,6 +113,15 @@ UMBRIEL_TEST(eachSectionIsReportedOnItsOwn) {
     const ConfigChange change = ConfigChange::between(before, after);
     CHECK(change.general);
     CHECK(!change.input);
+  }
+  {
+    Config after;
+    after.events.lidClose = "systemctl suspend";
+    const ConfigChange change = ConfigChange::between(before, after);
+    CHECK(change.events);
+    CHECK(!change.general);
+    CHECK(!change.input);
+    CHECK_EQ(change.summary(), std::string("events"));
   }
   {
     Config after;

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -1344,6 +1344,24 @@ WAYLAND_DISPLAY = "wrong"
   CHECK(!containsDiagnostic(store, "unknown key environment._PRIVATE"));
 }
 
+UMBRIEL_TEST(eventsLoadCanonicalLidCommands) {
+  const TempConfig file;
+  file.write(R"(
+[events]
+lid_close = "systemctl suspend"
+lid_open = "notify-send awake"
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+  const umbriel::ConfigReloadResult result = store.reload();
+
+  CHECK(result.success);
+  CHECK_EQ(store.config().events.lidClose, std::string{"systemctl suspend"});
+  CHECK_EQ(store.config().events.lidOpen, std::string{"notify-send awake"});
+  CHECK(store.diagnostics().empty());
+}
+
 UMBRIEL_TEST(packagedAnimationDefaultsMatchCompiledDefaults) {
   std::filesystem::path root = std::filesystem::current_path();
   while (!std::filesystem::exists(root / "examples/config.toml")) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add switch events for laptop lid close and open

## Motivation

<!-- What problem does this solve? -->
Useful to suspend the laptop when the lid is closed, this is also a feature in niri.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Discord

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just format`
`just test`
`just lint`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
