### PR TITLE
feat(input): add disable_on_external_mouse for touchpad

### DIFF
--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -102,6 +102,7 @@ natural_scroll = true
 # sensitivity = 0.5           # -1.0 to 1.0
 # scroll_factor = 1.5         # touchpad scroll speed, 0.1 to 10.0
 # disable_while_typing = true
+# disable_on_external_mouse = true
 ```
 
 Tap-to-click is enabled by default. Set `tap = false` to disable it globally,
@@ -130,6 +131,15 @@ remains unset by default (identity, `1.0`) and takes the next scroll event on
 reload. It applies only to the continuous scroll delta: discrete notches,
 overview wheel stepping, and three-finger-swipe strip travel keep their own
 counting semantics.
+
+Set `disable_on_external_mouse = true` to disable the touchpad while an
+external mouse is connected, libinput re-enables it automatically once the
+mouse is unplugged. Detection is handled by libinput itself, so this only
+works in a native session — a nested session has no libinput devices to
+configure. Unlike `tap` and `disable_while_typing`, this option has no
+`[[input.device]]` per-device override. If a device doesn't support the mode,
+an explicitly configured value is ignored and a warning is logged; removing
+the key on reload restores the device's default.
 
 ### Mouse
 

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -133,9 +133,9 @@ overview wheel stepping, and three-finger-swipe strip travel keep their own
 counting semantics.
 
 Set `disable_on_external_mouse = true` to disable the touchpad while an
-external mouse is connected, libinput re-enables it automatically once the
+external mouse is connected. Libinput re-enables it automatically once the
 mouse is unplugged. Detection is handled by libinput itself, so this only
-works in a native session — a nested session has no libinput devices to
+works in a native session because a nested session has no libinput devices to
 configure. Unlike `tap` and `disable_while_typing`, this option has no
 `[[input.device]]` per-device override. If a device doesn't support the mode,
 an explicitly configured value is ignored and a warning is logged; removing

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -241,6 +241,7 @@ tap = true                      # enabled by default; false disables tap-to-clic
 # sensitivity = 0.5             # pointer speed, -1.0 to 1.0
 # scroll_factor = 1.5           # touchpad scroll speed, 0.1 to 10.0
 # disable_while_typing = true   # omitted preserves the device's libinput default
+# disable_on_external_mouse = true  # disable the touchpad while an external mouse is connected
 
 [input.mouse]
 # natural_scroll = false

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1167,7 +1167,8 @@ namespace umbriel {
               .boolean("natural_scroll", in.touchpad.naturalScroll)
               .real("sensitivity", -1.0, 1.0, in.touchpad.sensitivity)
               .real("scroll_factor", 0.1, 10.0, in.touchpad.scrollFactor)
-              .boolean("disable_while_typing", in.touchpad.disableWhileTyping);
+              .boolean("disable_while_typing", in.touchpad.disableWhileTyping)
+              .boolean("disable_on_external_mouse", in.touchpad.disableOnExternalMouse);
           in.touchpad.accelProfile = readAccelProfile(t, "accel_profile", "input.touchpad");
         });
         s.sub("mouse", [&](Section& m) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -601,6 +601,7 @@ namespace umbriel {
         std::optional<double> sensitivity;
         std::optional<double> scrollFactor;
         std::optional<bool> disableWhileTyping;
+        std::optional<bool> disableOnExternalMouse;
         bool operator==(const Touchpad&) const = default;
       } touchpad;
 

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -278,7 +278,26 @@ namespace umbriel {
               override != nullptr && override->tap ? "input.device.tap" : "input.touchpad.tap", deviceName(device)
           );
         }
-
+        if ((libinput_device_config_send_events_get_modes(libinputDevice)
+             & LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE)
+            != 0) {
+          const auto sendEventsMode = input.touchpad.disableOnExternalMouse.value_or(
+                                          libinput_device_config_send_events_get_default_mode(libinputDevice)
+                                          == LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE
+                                      )
+              ? LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE
+              : LIBINPUT_CONFIG_SEND_EVENTS_ENABLED;
+          if (libinput_device_config_send_events_set_mode(libinputDevice, sendEventsMode)
+              != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+            kLog.warn("input: failed to apply input.touchpad.disable_on_external_mouse to '{}'", deviceName(device));
+          }
+        } else if (input.touchpad.disableOnExternalMouse) {
+          kLog.warn(
+              "input: could not apply input.touchpad.disable_on_external_mouse to '{}': device does not support "
+              "disabling on external mouse",
+              deviceName(device)
+          );
+        }
         const bool hasDwtOverride = override != nullptr && override->disableWhileTyping.has_value();
         const std::optional<bool>& dwt =
             hasDwtOverride ? override->disableWhileTyping : input.touchpad.disableWhileTyping;

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -93,6 +93,12 @@ UMBRIEL_TEST(eachSectionIsReportedOnItsOwn) {
   }
   {
     Config after;
+    after.input.touchpad.disableOnExternalMouse = true;
+    CHECK(ConfigChange::between(before, after).input);
+    CHECK(ConfigEffects::between(before, after).input);
+  }
+  {
+    Config after;
     after.input.middleClickPaste = !after.input.middleClickPaste;
     const ConfigChange change = ConfigChange::between(before, after);
     CHECK(change.input);

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -946,6 +946,7 @@ accel_profile = "adaptive"
 sensitivity = 0.1
 scroll_factor = 1.5
 disable_while_typing = true
+disable_on_external_mouse = true
 
 [input.mouse]
 accel_profile = "custom 0.2 0.0 0.5 1.0 2.0"
@@ -990,6 +991,7 @@ sensitivity = -0.5
   CHECK(input.touchpad.sensitivity == std::optional<double>(0.1));
   CHECK(input.touchpad.scrollFactor == std::optional<double>(1.5));
   CHECK(input.touchpad.disableWhileTyping == std::optional<bool>(true));
+  CHECK(input.touchpad.disableOnExternalMouse == std::optional<bool>(true));
   CHECK_EQ(input.devices.size(), size_t{3});
 
   const auto* keyboard = input.findDevice("Acme Split Keyboard");
@@ -1046,6 +1048,11 @@ UMBRIEL_TEST(touchpadScrollFactorDefaultsToUnset) {
 UMBRIEL_TEST(touchpadDisableWhileTypingDefaultsToUnset) {
   const umbriel::Config defaults;
   CHECK(!defaults.input.touchpad.disableWhileTyping.has_value());
+}
+
+UMBRIEL_TEST(touchpadDisableOnExternalMouseDefaultsToUnset) {
+  const umbriel::Config defaults;
+  CHECK(!defaults.input.touchpad.disableOnExternalMouse.has_value());
 }
 
 UMBRIEL_TEST(touchpadTapDefaultsToEnabled) {


### PR DESCRIPTION
## Summary

This PR add `disable_on_external_mouse` for touchpad. When true touchpad gets disable when external mouse is plugged, if its get unplugged then touchpad automatically get enable.

## Motivation

Sometimes we don't want touchpad to be active when using external mouse.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Testing

- `just format && just test && just lint && just check` everything is clean
- Installed the branch and tested natively, works as expected.

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Checklist

- [x] This PR is ready for review.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`.
- [x] I ran the relevant build, test, lint, or verification commands.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
