### PR TITLE
feat(security): add per-app protocol grants via security_context_rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ To understand the values and philosophy guiding the project, read our [ethos](ht
 - An animated overview, directional focus, configurable keybinds, submaps, and activation policy
 - Blur, shadows, rounded corners, double borders, opacity, and animated position, size, and fade transitions
 - Keyboard, pointer, touch, touchpad gestures, XKB configuration, and text-input-v3/input-method-v2 input method support
-- [Restricted Wayland connections](docs/user/security.md) for sandbox engines through security-context-v1
+- [Restricted Wayland connections](docs/user/security.md) for sandbox engines through security-context-v1, with
+  per-application protocol grants
 - Layer shell, session locking, clipboard management, screen capture, output control, and gamma control
 - X11 application support through xwayland-satellite
 - Live-reloaded TOML configuration with diagnostics and includes, plus local IPC and runtime inspection commands

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -62,13 +62,16 @@ selector on that field. Unlike window and layer rules, a pattern must match
 the entire value: a substring match would let an application choose an ID that
 embeds another rule's pattern.
 
+A rule with a mistake is dropped. An unknown key, an empty or non-string
+selector, or an empty `allow_globals` rejects the entry with a warning.
+
 Rules are additive only. They cannot remove protocols from the base set, and
 `wp_security_context_manager_v1` remains blocked even when listed, so a
 granted client can never create a nested context and label itself into another
-application's rules. The registry is filtered when a client connects and again
-at every bind. A new rule therefore applies to applications launched after the
-reload, while revoking a grant also affects running applications: a client
-that later binds the revoked global is disconnected with a protocol error.
+application's rules. A client's grants are decided when it first reads the
+registry and stay fixed for that connection. A reload therefore affects
+applications launched afterwards; a running application keeps its grants until
+it is restarted.
 
 ## Security boundary
 

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -32,13 +32,54 @@ hidden from restricted clients until it has received a security review.
 Trusted host services such as xdg-desktop-portal can mediate capture and other
 privileged operations for a sandboxed application.
 
+## Per-application grants
+
+Some protocols have no portal equivalent. A status bar needs layer-shell, a
+clipboard manager needs data-control, and an input method needs input-method
+ownership. `[[security_context_rule]]` entries widen the allowed set for
+individual applications, matched against the metadata the sandbox engine
+supplies. Every matching rule contributes its globals.
+
+```toml
+[[security_context_rule]]
+match.sandbox_engine = 'org\.flatpak'
+match.app_id = 'org\.example\.ClipboardManager'
+allow_globals = ["ext_data_control_manager_v1"]
+```
+
+| Selector | Type | Description |
+|----------|------|-------------|
+| `match.sandbox_engine` | regex | Match the sandbox engine that labeled the connection. |
+| `match.app_id` | regex | Match the application ID the engine supplied. |
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `allow_globals` | string array | Wayland globals exposed in addition to the base allowed set. |
+
+Every selector is optional. A rule without selectors applies to every
+restricted client, and a client whose metadata omits a field never matches a
+selector on that field. Unlike window and layer rules, a pattern must match
+the entire value: a substring match would let an application choose an ID that
+embeds another rule's pattern.
+
+Rules are additive only. They cannot remove protocols from the base set, and
+`wp_security_context_manager_v1` remains blocked even when listed, so a
+granted client can never create a nested context and label itself into another
+application's rules. The registry is filtered when a client connects and again
+at every bind. A new rule therefore applies to applications launched after the
+reload, while revoking a grant also affects running applications: a client
+that later binds the revoked global is disconnected with a protocol error.
+
 ## Security boundary
 
 The protocol labels a new Wayland connection and lets Umbriel filter it. It
 does not constrain files, processes, devices, the network, D-Bus, or other host
 interfaces. The metadata is supplied by the sandbox engine and is not
-independently authenticated by Umbriel, so Umbriel does not use it to grant
-extra privileges.
+independently authenticated by Umbriel. Restricted clients cannot create
+security contexts, so labels always originate from an unrestricted process,
+and a per-application grant is only as trustworthy as the sandbox engine that
+labeled the connection. Without `[[security_context_rule]]` entries the
+metadata grants nothing.
 
 For the restriction to matter, the sandbox must not expose Umbriel's original
 Wayland socket. It must separately control Umbriel IPC through

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -466,3 +466,11 @@ match.namespace="^noctalia-(bar-[^\"]+|notification|dock|panel|attached-panel|os
 blur = true
 blur_ignore_alpha = 0.5
 blur_optimized = false
+
+# Security context rules (see docs/user/security.md) ----------------------
+
+# Grant a sandboxed clipboard manager the data-control protocol
+# [[security_context_rule]]
+# match.sandbox_engine = 'org\.flatpak'
+# match.app_id = 'org\.example\.ClipboardManager'
+# allow_globals = ["ext_data_control_manager_v1"]

--- a/src/config/change.cpp
+++ b/src/config/change.cpp
@@ -173,6 +173,7 @@ namespace umbriel {
         .outputs = true,
         .windowRules = true,
         .layerRules = true,
+        .securityContextRules = true,
         .workspaceRules = true,
     };
   }
@@ -194,6 +195,7 @@ namespace umbriel {
         .outputs = before.outputs != after.outputs,
         .windowRules = before.windowRules != after.windowRules,
         .layerRules = before.layerRules != after.layerRules,
+        .securityContextRules = before.securityContextRules != after.securityContextRules,
         .workspaceRules = before.workspaceRules != after.workspaceRules,
     };
   }
@@ -224,6 +226,7 @@ namespace umbriel {
     add(outputs, "outputs");
     add(windowRules, "window rules");
     add(layerRules, "layer rules");
+    add(securityContextRules, "security context rules");
     add(workspaceRules, "workspace rules");
     return out;
   }

--- a/src/config/change.h
+++ b/src/config/change.h
@@ -24,6 +24,7 @@ namespace umbriel {
     bool outputs = false;
     bool windowRules = false;
     bool layerRules = false;
+    bool securityContextRules = false;
     bool workspaceRules = false;
 
     [[nodiscard]] bool any() const {
@@ -42,6 +43,7 @@ namespace umbriel {
           || outputs
           || windowRules
           || layerRules
+          || securityContextRules
           || workspaceRules;
     }
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1790,6 +1790,8 @@ namespace umbriel {
       }
     }
 
+    // Any mistake rejects the whole entry: a rule missing its selector would
+    // apply to every restricted client.
     void readSecurityContextRules(Section& root, Config& loaded) {
       const toml::node* node = root.take("security_context_rule");
       if (node == nullptr) {
@@ -1812,39 +1814,34 @@ namespace umbriel {
         SecurityContextRule rule;
         bool valid = true;
 
+        const auto readPattern = [&](Section& match, std::string_view key, std::string& pattern, std::regex& regex) {
+          const toml::node* patternNode = match.take(key);
+          if (patternNode == nullptr) {
+            return;
+          }
+          const auto value = patternNode->value<std::string>();
+          if (!value || value->empty()) {
+            warnAt(patternNode->source(), "ignoring security_context_rule (match.{} must be a non-empty string)", key);
+            valid = false;
+            return;
+          }
+          pattern = *value;
+          try {
+            regex = std::regex(pattern);
+          } catch (const std::regex_error& error) {
+            warnAt(patternNode->source(), "invalid regex in security_context_rule.match.{}: {}", key, error.what());
+            valid = false;
+          }
+        };
+
         if (const toml::node* matchNode = keys.take("match")) {
           if (const auto* match = matchNode->as_table()) {
             Section matchKeys(*match, "security_context_rule.match", configStore().mutableDiagnostics());
-            if (const toml::node* engineNode = matchKeys.take("sandbox_engine")) {
-              if (const auto value = engineNode->value<std::string>()) {
-                rule.sandboxEnginePattern = *value;
-                try {
-                  rule.sandboxEngineRegex = std::regex(rule.sandboxEnginePattern);
-                } catch (const std::regex_error& error) {
-                  warnAt(
-                      engineNode->source(), "invalid regex in security_context_rule.match.sandbox_engine: {}",
-                      error.what()
-                  );
-                  valid = false;
-                }
-              } else {
-                warnAt(engineNode->source(), "ignoring security_context_rule.match.sandbox_engine (expected string)");
-                valid = false;
-              }
-            }
-            if (const toml::node* appIdNode = matchKeys.take("app_id")) {
-              if (const auto value = appIdNode->value<std::string>()) {
-                rule.appIdPattern = *value;
-                try {
-                  rule.appIdRegex = std::regex(rule.appIdPattern);
-                } catch (const std::regex_error& error) {
-                  warnAt(appIdNode->source(), "invalid regex in security_context_rule.match.app_id: {}", error.what());
-                  valid = false;
-                }
-              } else {
-                warnAt(appIdNode->source(), "ignoring security_context_rule.match.app_id (expected string)");
-                valid = false;
-              }
+            readPattern(matchKeys, "sandbox_engine", rule.sandboxEnginePattern, rule.sandboxEngineRegex);
+            readPattern(matchKeys, "app_id", rule.appIdPattern, rule.appIdRegex);
+            if (!matchKeys.allKeysKnown()) {
+              warnAt(matchNode->source(), "ignoring security_context_rule (unknown key in match)");
+              valid = false;
             }
           } else {
             warnAt(matchNode->source(), "ignoring security_context_rule.match (expected table)");
@@ -1860,6 +1857,14 @@ namespace umbriel {
               "ignoring wp_security_context_manager_v1 in security_context_rule.allow_globals (nested contexts stay "
               "blocked)"
           );
+        }
+        if (rule.allowGlobals.empty()) {
+          warnAt(entry.source(), "ignoring security_context_rule (allow_globals is empty)");
+          valid = false;
+        }
+        if (!keys.allKeysKnown()) {
+          warnAt(entry.source(), "ignoring security_context_rule (unknown key)");
+          valid = false;
         }
 
         if (!valid) {

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1790,6 +1790,85 @@ namespace umbriel {
       }
     }
 
+    void readSecurityContextRules(Section& root, Config& loaded) {
+      const toml::node* node = root.take("security_context_rule");
+      if (node == nullptr) {
+        return;
+      }
+      const auto* rules = node->as_array();
+      if (rules == nullptr) {
+        warnAt(node->source(), "ignoring security_context_rule (expected [[security_context_rule]] array of tables)");
+        return;
+      }
+
+      for (const auto& entry : *rules) {
+        const auto* section = entry.as_table();
+        if (section == nullptr) {
+          warnAt(entry.source(), "ignoring security_context_rule entry (expected table)");
+          continue;
+        }
+        Section keys(*section, "security_context_rule", configStore().mutableDiagnostics());
+
+        SecurityContextRule rule;
+        bool valid = true;
+
+        if (const toml::node* matchNode = keys.take("match")) {
+          if (const auto* match = matchNode->as_table()) {
+            Section matchKeys(*match, "security_context_rule.match", configStore().mutableDiagnostics());
+            if (const toml::node* engineNode = matchKeys.take("sandbox_engine")) {
+              if (const auto value = engineNode->value<std::string>()) {
+                rule.sandboxEnginePattern = *value;
+                try {
+                  rule.sandboxEngineRegex = std::regex(rule.sandboxEnginePattern);
+                } catch (const std::regex_error& error) {
+                  warnAt(
+                      engineNode->source(), "invalid regex in security_context_rule.match.sandbox_engine: {}",
+                      error.what()
+                  );
+                  valid = false;
+                }
+              } else {
+                warnAt(engineNode->source(), "ignoring security_context_rule.match.sandbox_engine (expected string)");
+                valid = false;
+              }
+            }
+            if (const toml::node* appIdNode = matchKeys.take("app_id")) {
+              if (const auto value = appIdNode->value<std::string>()) {
+                rule.appIdPattern = *value;
+                try {
+                  rule.appIdRegex = std::regex(rule.appIdPattern);
+                } catch (const std::regex_error& error) {
+                  warnAt(appIdNode->source(), "invalid regex in security_context_rule.match.app_id: {}", error.what());
+                  valid = false;
+                }
+              } else {
+                warnAt(appIdNode->source(), "ignoring security_context_rule.match.app_id (expected string)");
+                valid = false;
+              }
+            }
+          } else {
+            warnAt(matchNode->source(), "ignoring security_context_rule.match (expected table)");
+            valid = false;
+          }
+        }
+
+        keys.strings("allow_globals", rule.allowGlobals);
+        // The filter refuses this global regardless; warning here tells the user why.
+        if (std::erase(rule.allowGlobals, "wp_security_context_manager_v1") > 0) {
+          warnAt(
+              entry.source(),
+              "ignoring wp_security_context_manager_v1 in security_context_rule.allow_globals (nested contexts stay "
+              "blocked)"
+          );
+        }
+
+        if (!valid) {
+          continue;
+        }
+        loaded.securityContextRules.push_back(std::move(rule));
+      }
+    }
+
     bool parseInto(Config& out) {
       ConfigStore& store = configStore();
       store.beginLoad();
@@ -1830,6 +1909,7 @@ namespace umbriel {
           readKeybinds(root, loaded);
           readWindowRules(root, loaded);
           readLayerRules(root, loaded);
+          readSecurityContextRules(root, loaded);
           readWorkspaces(root, loaded);
         }
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -352,6 +352,23 @@ namespace umbriel {
     bool operator==(const ResolvedLayerRule&) const = default;
   };
 
+  // Grants extra globals to security-context clients whose metadata matches.
+  // Additive only: the base allowed set cannot be narrowed from configuration.
+  struct SecurityContextRule {
+    std::string sandboxEnginePattern;
+    std::string appIdPattern;
+    std::regex sandboxEngineRegex;
+    std::regex appIdRegex;
+    std::vector<std::string> allowGlobals;
+
+    // See WindowRule: the regexes are derived from the patterns.
+    [[nodiscard]] bool operator==(const SecurityContextRule& other) const {
+      return sandboxEnginePattern == other.sandboxEnginePattern
+          && appIdPattern == other.appIdPattern
+          && allowGlobals == other.allowGlobals;
+    }
+  };
+
   struct Config {
     struct Colors {
       std::array<float, 4> background{0.0784314F, 0.0784314F, 0.0980392F, 1.0F};
@@ -676,6 +693,7 @@ namespace umbriel {
     std::vector<OutputRule> outputs;
     std::vector<WindowRule> windowRules;
     std::vector<LayerRule> layerRules;
+    std::vector<SecurityContextRule> securityContextRules;
     std::vector<WorkspaceConfig> workspaceRules; // [[workspace]] layout rules
 
     bool operator==(const Config&) const = default;

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -290,11 +290,11 @@ namespace umbriel {
     return resolved;
   }
 
-  bool securityContextRuleAllowsGlobal(
-      const Config& config, const char* sandboxEngine, const char* appId, std::string_view interface
-  ) {
+  std::vector<std::string>
+  securityContextRuleGlobals(const Config& config, const char* sandboxEngine, const char* appId) {
     const std::string_view engineView = sandboxEngine != nullptr ? sandboxEngine : "";
     const std::string_view appIdView = appId != nullptr ? appId : "";
+    std::vector<std::string> globals;
     for (const auto& rule : config.securityContextRules) {
       // Unlike window rules, the whole value must match: a substring grant
       // would let an application choose an ID embedding someone else's pattern.
@@ -308,11 +308,13 @@ namespace umbriel {
           continue;
         }
       }
-      if (std::ranges::find(rule.allowGlobals, interface) != rule.allowGlobals.end()) {
-        return true;
+      for (const std::string& global : rule.allowGlobals) {
+        if (std::ranges::find(globals, global) == globals.end()) {
+          globals.push_back(global);
+        }
       }
     }
-    return false;
+    return globals;
   }
 
   bool anyWindowRuleHasTitlePattern(const Config& config) {

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -290,6 +290,31 @@ namespace umbriel {
     return resolved;
   }
 
+  bool securityContextRuleAllowsGlobal(
+      const Config& config, const char* sandboxEngine, const char* appId, std::string_view interface
+  ) {
+    const std::string_view engineView = sandboxEngine != nullptr ? sandboxEngine : "";
+    const std::string_view appIdView = appId != nullptr ? appId : "";
+    for (const auto& rule : config.securityContextRules) {
+      // Unlike window rules, the whole value must match: a substring grant
+      // would let an application choose an ID embedding someone else's pattern.
+      if (!rule.sandboxEnginePattern.empty()) {
+        if (engineView.empty() || !std::regex_match(engineView.begin(), engineView.end(), rule.sandboxEngineRegex)) {
+          continue;
+        }
+      }
+      if (!rule.appIdPattern.empty()) {
+        if (appIdView.empty() || !std::regex_match(appIdView.begin(), appIdView.end(), rule.appIdRegex)) {
+          continue;
+        }
+      }
+      if (std::ranges::find(rule.allowGlobals, interface) != rule.allowGlobals.end()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool anyWindowRuleHasTitlePattern(const Config& config) {
     return std::ranges::any_of(config.windowRules, [](const WindowRule& rule) { return !rule.titlePattern.empty(); });
   }

--- a/src/config/resolve.h
+++ b/src/config/resolve.h
@@ -16,6 +16,11 @@ namespace umbriel {
       bool focused
   );
   [[nodiscard]] ResolvedLayerRule resolveLayerRules(const Config& config, const char* layerNamespace);
+  // Whether any [[security_context_rule]] matching the client's metadata grants
+  // this global on top of the base allowed set.
+  [[nodiscard]] bool securityContextRuleAllowsGlobal(
+      const Config& config, const char* sandboxEngine, const char* appId, std::string_view interface
+  );
   [[nodiscard]] bool anyWindowRuleHasTitlePattern(const Config& config);
   // Return the sole fixed-output inventory containing this zero-based workspace
   // position. Null means no fixed owner or an ambiguous owner.

--- a/src/config/resolve.h
+++ b/src/config/resolve.h
@@ -16,11 +16,10 @@ namespace umbriel {
       bool focused
   );
   [[nodiscard]] ResolvedLayerRule resolveLayerRules(const Config& config, const char* layerNamespace);
-  // Whether any [[security_context_rule]] matching the client's metadata grants
-  // this global on top of the base allowed set.
-  [[nodiscard]] bool securityContextRuleAllowsGlobal(
-      const Config& config, const char* sandboxEngine, const char* appId, std::string_view interface
-  );
+  // The globals every [[security_context_rule]] matching the client's metadata
+  // grants on top of the base allowed set.
+  [[nodiscard]] std::vector<std::string>
+  securityContextRuleGlobals(const Config& config, const char* sandboxEngine, const char* appId);
   [[nodiscard]] bool anyWindowRuleHasTitlePattern(const Config& config);
   // Return the sole fixed-output inventory containing this zero-based workspace
   // position. Null means no fixed owner or an ambiguous owner.

--- a/src/config/section.cpp
+++ b/src/config/section.cpp
@@ -82,6 +82,12 @@ namespace umbriel {
     return *this;
   }
 
+  bool Section::allKeysKnown() const {
+    return std::ranges::all_of(m_table, [this](const auto& item) {
+      return std::ranges::find(m_seen, item.first.str()) != m_seen.end();
+    });
+  }
+
   Section& Section::integer(std::string_view key, int minimum, int maximum, std::optional<int>& target) {
     const toml::node* node = claim(key);
     if (node == nullptr) {

--- a/src/config/section.h
+++ b/src/config/section.h
@@ -68,6 +68,10 @@ namespace umbriel {
     // user-chosen names rather than a fixed vocabulary.
     Section& freeform();
 
+    // Whether every key in the table has been claimed, for readers that reject
+    // an entry on a stray key instead of only warning.
+    [[nodiscard]] bool allKeysKnown() const;
+
   private:
     [[nodiscard]] std::string qualified(std::string_view key) const;
     const toml::node* claim(std::string_view key);

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -3,6 +3,7 @@
 #include "config/config.h"
 #include "config/config_diag.h"
 #include "config/config_watcher.h"
+#include "config/resolve.h"
 #include "core/fdlimit.h"
 #include "core/log.h"
 #include "core/process.h"
@@ -46,6 +47,7 @@ namespace umbriel {
     constexpr size_t kWaylandClientBufferSize = 1024 * 1024;
     // Security-context clients only receive reviewed, ordinary application
     // protocols. New globals stay unavailable until they are classified here.
+    // [[security_context_rule]] widens the set for matching clients.
     constexpr std::array<std::string_view, 28> kAllowedSecurityContextGlobals{
         "wl_shm",
         "wl_drm",
@@ -125,8 +127,14 @@ namespace umbriel {
         return true;
       }
       const std::string_view interfaceName(interface->name);
-      if (server->clientHasSecurityContext(client) && !isAllowedSecurityContextGlobal(interfaceName)) {
-        return false;
+      if (const wlr_security_context_v1_state* context = server->clientSecurityContext(client);
+          context != nullptr && !isAllowedSecurityContextGlobal(interfaceName)) {
+        // Nested contexts stay blocked unconditionally: per-app grants are only
+        // trustworthy while labels originate from unrestricted clients.
+        if (interfaceName == "wp_security_context_manager_v1"
+            || !securityContextRuleAllowsGlobal(config(), context->sandbox_engine, context->app_id, interfaceName)) {
+          return false;
+        }
       }
       // A global filter is consulted both when a global is advertised and when
       // it is bound, so each client's decisions must remain stable for its
@@ -196,9 +204,11 @@ namespace umbriel {
 
   } // namespace
 
-  bool Server::clientHasSecurityContext(const wl_client* client) const {
-    return m_securityContextManager != nullptr
-        && wlr_security_context_manager_v1_lookup_client(m_securityContextManager, client) != nullptr;
+  const wlr_security_context_v1_state* Server::clientSecurityContext(const wl_client* client) const {
+    if (m_securityContextManager == nullptr) {
+      return nullptr;
+    }
+    return wlr_security_context_manager_v1_lookup_client(m_securityContextManager, client);
   }
 
   ContentType Server::surfaceContentType(wlr_surface* surface) const {

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -33,11 +33,13 @@
 #include <array>
 #include <csignal>
 #include <cstdlib>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unistd.h>
+#include <vector>
 
 namespace umbriel {
 
@@ -87,6 +89,8 @@ namespace umbriel {
       wl_listener destroy{};
       bool advertiseDecorationManagers = true;
       bool advertisePrimarySelection = true;
+      // Resolved on first use: security-context metadata is attached after the client-created signal.
+      std::optional<std::vector<std::string>> securityContextGlobals;
     };
 
     void onClientGlobalPolicyDestroy(wl_listener* listener, void* /*data*/) {
@@ -127,19 +131,26 @@ namespace umbriel {
         return true;
       }
       const std::string_view interfaceName(interface->name);
+      // A global filter is consulted both when a global is advertised and when
+      // it is bound, so each client's decisions must remain stable for its
+      // entire connection.
+      ClientGlobalPolicy* policy = clientGlobalPolicy(client);
       if (const wlr_security_context_v1_state* context = server->clientSecurityContext(client);
           context != nullptr && !isAllowedSecurityContextGlobal(interfaceName)) {
         // Nested contexts stay blocked unconditionally: per-app grants are only
         // trustworthy while labels originate from unrestricted clients.
-        if (interfaceName == "wp_security_context_manager_v1"
-            || !securityContextRuleAllowsGlobal(config(), context->sandbox_engine, context->app_id, interfaceName)) {
+        if (interfaceName == "wp_security_context_manager_v1") {
+          return false;
+        }
+        if (!policy->securityContextGlobals) {
+          policy->securityContextGlobals =
+              securityContextRuleGlobals(config(), context->sandbox_engine, context->app_id);
+        }
+        if (std::ranges::find(*policy->securityContextGlobals, interfaceName)
+            == policy->securityContextGlobals->end()) {
           return false;
         }
       }
-      // A global filter is consulted both when a global is advertised and when
-      // it is bound, so each client's decisions must remain stable for its
-      // entire connection.
-      const ClientGlobalPolicy* policy = clientGlobalPolicy(client);
       if (interfaceName == "zwp_primary_selection_device_manager_v1") {
         return policy->advertisePrimarySelection;
       }

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -48,6 +48,7 @@ struct wlr_scene_output_layout;
 struct wlr_scene_rect;
 struct wlr_scene_tree;
 struct wlr_security_context_manager_v1;
+struct wlr_security_context_v1_state;
 struct wlr_session;
 struct wlr_session_lock_manager_v1;
 struct wlr_session_lock_v1;
@@ -134,7 +135,9 @@ namespace umbriel {
     [[nodiscard]] wlr_allocator* allocator() const { return m_allocator; }
     [[nodiscard]] wlr_scene* scene() const { return m_scene; }
     [[nodiscard]] ContentType surfaceContentType(wlr_surface* surface) const;
-    [[nodiscard]] bool clientHasSecurityContext(const wl_client* client) const;
+    // The security-context metadata for a restricted client, or null for a
+    // client on the ordinary socket.
+    [[nodiscard]] const wlr_security_context_v1_state* clientSecurityContext(const wl_client* client) const;
     [[nodiscard]] wlr_color_manager_v1* colorManager() const { return m_colorManager; }
     [[nodiscard]] wlr_export_dmabuf_manager_v1* exportDmabufManager() const { return m_exportDmabufManager; }
     [[nodiscard]] wlr_tearing_control_manager_v1* tearingControlManager() const { return m_tearingControlManager; }

--- a/tests/harness/checks/536_security_context_rule.sh
+++ b/tests/harness/checks/536_security_context_rule.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # A [[security_context_rule]] grants extra globals to security-context clients whose metadata matches, on top of the
-# fixed base allowlist. Grants do not leak between rules, an unmatched app keeps the base set, and the security-context
-# manager itself stays blocked even when a rule lists it.
+# fixed base allowlist. Grants do not leak between rules, an unmatched app keeps the base set, the security-context
+# manager itself stays blocked even when a rule lists it, and a reload leaves connected clients as they were.
 set -euo pipefail
 
 readonly GLOBAL_CLIENT="${UMBRIEL_GLOBAL_CLIENT:-./build-debug/global-client}"
 readonly SECURITY_CONTEXT_CLIENT="${UMBRIEL_SECURITY_CONTEXT_CLIENT:-./build-debug/security-context-client}"
+readonly CLIENT_LOG="$UMBRIEL_RUNTIME_DIR/security-context-rule-client.log"
+readonly CONTROL_FIFO="$UMBRIEL_RUNTIME_DIR/security-context-rule-control"
 
 if [[ ! -x $GLOBAL_CLIENT || ! -x $SECURITY_CONTEXT_CLIENT ]]; then
   echo "required harness clients are not built"
@@ -15,6 +17,26 @@ fi
 # Baseline: without rules the globals granted below are hidden.
 "$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" zwlr_layer_shell_v1 absent
 "$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" ext_data_control_manager_v1 absent
+
+# A client connected before the reload keeps the registry it was given, even when it reads the registry again.
+mkfifo "$CONTROL_FIFO"
+exec {control_fd}<>"$CONTROL_FIFO"
+"$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" recheck zwlr_layer_shell_v1 absent <&"$control_fd" > "$CLIENT_LOG" 2>&1 &
+client_pid=$!
+
+for _ in $(seq 100); do
+  grep -q '^ready$' "$CLIENT_LOG" && break
+  if ! kill -0 "$client_pid" 2>/dev/null; then
+    wait "$client_pid" 2>/dev/null || true
+    echo "persistent restricted client exited before its recheck: $(< "$CLIENT_LOG")"
+    exit 1
+  fi
+  sleep 0.02
+done
+if ! grep -q '^ready$' "$CLIENT_LOG"; then
+  echo "persistent restricted client did not become ready: $(< "$CLIENT_LOG")"
+  exit 1
+fi
 
 cat >> "$UMBRIEL_CONFIG" << 'EOF'
 
@@ -36,6 +58,12 @@ EOF
 if ! tail -n 20 "$UMBRIEL_LOG" | grep -q "config reloaded (sections: security context rules; effects: none)"; then
   echo "reload did not report the security context rules section:"
   tail -n 5 "$UMBRIEL_LOG" | sed "s/^/    /"
+  exit 1
+fi
+
+printf '\n' >&"$control_fd"
+if ! wait "$client_pid"; then
+  echo "a connected client saw its grants change after the reload: $(< "$CLIENT_LOG")"
   exit 1
 fi
 

--- a/tests/harness/checks/536_security_context_rule.sh
+++ b/tests/harness/checks/536_security_context_rule.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# A [[security_context_rule]] grants extra globals to security-context clients whose metadata matches, on top of the
+# fixed base allowlist. Grants do not leak between rules, an unmatched app keeps the base set, and the security-context
+# manager itself stays blocked even when a rule lists it.
+set -euo pipefail
+
+readonly GLOBAL_CLIENT="${UMBRIEL_GLOBAL_CLIENT:-./build-debug/global-client}"
+readonly SECURITY_CONTEXT_CLIENT="${UMBRIEL_SECURITY_CONTEXT_CLIENT:-./build-debug/security-context-client}"
+
+if [[ ! -x $GLOBAL_CLIENT || ! -x $SECURITY_CONTEXT_CLIENT ]]; then
+  echo "required harness clients are not built"
+  exit 1
+fi
+
+# Baseline: without rules the globals granted below are hidden.
+"$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" zwlr_layer_shell_v1 absent
+"$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" ext_data_control_manager_v1 absent
+
+cat >> "$UMBRIEL_CONFIG" << 'EOF'
+
+[[security_context_rule]]
+match.sandbox_engine = '^org\.umbriel\.harness$'
+match.app_id = '^org\.umbriel\.SecurityContextTest$'
+allow_globals = ["zwlr_layer_shell_v1", "wp_security_context_manager_v1"]
+
+[[security_context_rule]]
+match.app_id = '^org\.umbriel\.OtherApp$'
+allow_globals = ["ext_data_control_manager_v1"]
+
+[[security_context_rule]]
+match.app_id = 'SecurityContextTest'
+allow_globals = ["ext_workspace_manager_v1"]
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+if ! tail -n 20 "$UMBRIEL_LOG" | grep -q "config reloaded (sections: security context rules; effects: none)"; then
+  echo "reload did not report the security context rules section:"
+  tail -n 5 "$UMBRIEL_LOG" | sed "s/^/    /"
+  exit 1
+fi
+
+# The matching rule grants layer-shell to connections made after the reload.
+"$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" zwlr_layer_shell_v1 present
+# The other rule's grant does not leak across app ids.
+"$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" ext_data_control_manager_v1 absent
+SECURITY_CONTEXT_APP_ID=org.umbriel.OtherApp "$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" \
+  ext_data_control_manager_v1 present
+SECURITY_CONTEXT_APP_ID=org.umbriel.OtherApp "$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" \
+  zwlr_layer_shell_v1 absent
+# A pattern must match the entire app ID; a substring grants nothing.
+"$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" ext_workspace_manager_v1 absent
+# Listing the manager in allow_globals never enables nested contexts.
+"$SECURITY_CONTEXT_CLIENT" "$GLOBAL_CLIENT" wp_security_context_manager_v1 absent
+# Clients on the ordinary socket are unaffected by the rules.
+"$GLOBAL_CLIENT" zwlr_layer_shell_v1 present
+
+echo "security context rules grant extra globals per matching app"

--- a/tests/harness/clients/security_context_client.cpp
+++ b/tests/harness/clients/security_context_client.cpp
@@ -114,10 +114,16 @@ int main(int argc, char** argv) {
     return 2;
   }
 
+  // Overridable so checks can exercise per-app security_context_rule matching.
+  const char* appId = std::getenv("SECURITY_CONTEXT_APP_ID");
+  if (appId == nullptr || *appId == '\0') {
+    appId = "org.umbriel.SecurityContextTest";
+  }
+
   wp_security_context_v1* context =
       wp_security_context_manager_v1_create_listener(state.manager, listenFd, closePipe[0]);
   wp_security_context_v1_set_sandbox_engine(context, "org.umbriel.harness");
-  wp_security_context_v1_set_app_id(context, "org.umbriel.SecurityContextTest");
+  wp_security_context_v1_set_app_id(context, appId);
   wp_security_context_v1_set_instance_id(context, socketName.c_str());
   wp_security_context_v1_commit(context);
   close(listenFd);

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -10,6 +10,7 @@ using umbriel::Keybind;
 using umbriel::LayerRule;
 using umbriel::ModifierKey;
 using umbriel::OutputRule;
+using umbriel::SecurityContextRule;
 using umbriel::WindowRule;
 
 UMBRIEL_TEST(anIdenticalConfigChangesNothing) {
@@ -217,6 +218,11 @@ UMBRIEL_TEST(listSectionsAreCompared) {
     Config after;
     after.layerRules.push_back(LayerRule{});
     CHECK(ConfigChange::between(before, after).layerRules);
+  }
+  {
+    Config after;
+    after.securityContextRules.push_back(SecurityContextRule{});
+    CHECK(ConfigChange::between(before, after).securityContextRules);
   }
 }
 

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -737,6 +737,38 @@ UMBRIEL_TEST(securityContextRulesLoadAndKeepTheManagerBlocked) {
   CHECK_EQ(store.config().securityContextRules[0].allowGlobals.size(), size_t{1});
   CHECK(store.config().securityContextRules[0].allowGlobals[0] == "zwlr_layer_shell_v1");
   CHECK(containsDiagnostic(store, "ignoring wp_security_context_manager_v1 in security_context_rule.allow_globals"));
+
+  // A mistake rejects the rule rather than widening it to every restricted client.
+  file.write("[[security_context_rule]]\nmatch.ap_id = 'org.example.Bar'\nallow_globals = [\"zwlr_layer_shell_v1\"]\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().securityContextRules.empty());
+  CHECK(containsDiagnostic(store, "ignoring security_context_rule (unknown key in match)"));
+
+  file.write("[[security_context_rule]]\nmatch.app_id = 'org.example.Bar'\nallow_glbals = [\"zwlr_layer_shell_v1\"]\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().securityContextRules.empty());
+  CHECK(containsDiagnostic(store, "ignoring security_context_rule (unknown key)"));
+
+  file.write("[[security_context_rule]]\nmatch.app_id = ''\nallow_globals = [\"zwlr_layer_shell_v1\"]\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().securityContextRules.empty());
+  CHECK(containsDiagnostic(store, "match.app_id must be a non-empty string"));
+
+  file.write("[[security_context_rule]]\nmatch.sandbox_engine = 5\nallow_globals = [\"zwlr_layer_shell_v1\"]\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().securityContextRules.empty());
+  CHECK(containsDiagnostic(store, "match.sandbox_engine must be a non-empty string"));
+
+  file.write("[[security_context_rule]]\nmatch.app_id = 'org.example.Bar'\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().securityContextRules.empty());
+  CHECK(containsDiagnostic(store, "ignoring security_context_rule (allow_globals is empty)"));
+
+  // Only the manager listed leaves nothing to grant.
+  file.write("[[security_context_rule]]\nallow_globals = [\"wp_security_context_manager_v1\"]\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().securityContextRules.empty());
+  CHECK(containsDiagnostic(store, "ignoring security_context_rule (allow_globals is empty)"));
 }
 
 UMBRIEL_TEST(windowContentTypeMatcherLoadsFixedVocabulary) {

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -706,6 +706,39 @@ UMBRIEL_TEST(windowOutputPoliciesLoadAndRejectInvalidValues) {
   CHECK(containsDiagnostic(store, "ignoring window_rule.hdr"));
 }
 
+UMBRIEL_TEST(securityContextRulesLoadAndKeepTheManagerBlocked) {
+  const TempConfig file;
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  file.write(
+      "[[security_context_rule]]\n"
+      "match.sandbox_engine = '^org\\.flatpak$'\n"
+      "match.app_id = '^org\\.example\\.Bar$'\n"
+      "allow_globals = [\"zwlr_layer_shell_v1\"]\n"
+  );
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().securityContextRules.size(), size_t{1});
+  CHECK(store.config().securityContextRules[0].sandboxEnginePattern == "^org\\.flatpak$");
+  CHECK(store.config().securityContextRules[0].appIdPattern == "^org\\.example\\.Bar$");
+  CHECK_EQ(store.config().securityContextRules[0].allowGlobals.size(), size_t{1});
+
+  file.write("[[security_context_rule]]\nmatch.app_id = '['\nallow_globals = [\"zwlr_layer_shell_v1\"]\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().securityContextRules.empty());
+  CHECK(containsDiagnostic(store, "invalid regex in security_context_rule.match.app_id"));
+
+  // Listing the manager is stripped with a warning; the rest of the rule loads.
+  file.write(
+      "[[security_context_rule]]\nallow_globals = [\"wp_security_context_manager_v1\", \"zwlr_layer_shell_v1\"]\n"
+  );
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().securityContextRules.size(), size_t{1});
+  CHECK_EQ(store.config().securityContextRules[0].allowGlobals.size(), size_t{1});
+  CHECK(store.config().securityContextRules[0].allowGlobals[0] == "zwlr_layer_shell_v1");
+  CHECK(containsDiagnostic(store, "ignoring wp_security_context_manager_v1 in security_context_rule.allow_globals"));
+}
+
 UMBRIEL_TEST(windowContentTypeMatcherLoadsFixedVocabulary) {
   const TempConfig file;
   ConfigStore& store = umbriel::configStore();

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -1,8 +1,10 @@
 #include "check.h"
 #include "config/resolve.h"
 
+#include <algorithm>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -538,19 +540,25 @@ UMBRIEL_TEST(securityContextRulesGrantGlobalsByMetadata) {
   partial.allowGlobals = {"zwlr_screencopy_manager_v1"};
   config.securityContextRules.push_back(std::move(partial));
 
-  CHECK(umbriel::securityContextRuleAllowsGlobal(config, "org.flatpak", "org.example.Bar", "zwlr_layer_shell_v1"));
+  const auto grants = [&](const char* engine, const char* appId, std::string_view global) {
+    const std::vector<std::string> globals = umbriel::securityContextRuleGlobals(config, engine, appId);
+    return std::ranges::find(globals, global) != globals.end();
+  };
+
+  CHECK(grants("org.flatpak", "org.example.Bar", "zwlr_layer_shell_v1"));
   // Every specified match key must hold.
-  CHECK(!umbriel::securityContextRuleAllowsGlobal(config, "org.flatpak", "org.example.Other", "zwlr_layer_shell_v1"));
-  CHECK(!umbriel::securityContextRuleAllowsGlobal(config, "waypak", "org.example.Bar", "zwlr_layer_shell_v1"));
+  CHECK(!grants("org.flatpak", "org.example.Other", "zwlr_layer_shell_v1"));
+  CHECK(!grants("waypak", "org.example.Bar", "zwlr_layer_shell_v1"));
   // Absent metadata never satisfies a pattern.
-  CHECK(!umbriel::securityContextRuleAllowsGlobal(config, nullptr, "org.example.Bar", "zwlr_layer_shell_v1"));
+  CHECK(!grants(nullptr, "org.example.Bar", "zwlr_layer_shell_v1"));
   // A rule without match keys applies to every client, but only for its own globals.
-  CHECK(umbriel::securityContextRuleAllowsGlobal(config, nullptr, nullptr, "ext_idle_notifier_v1"));
+  CHECK(grants(nullptr, nullptr, "ext_idle_notifier_v1"));
+  CHECK_EQ(umbriel::securityContextRuleGlobals(config, nullptr, nullptr).size(), size_t{1});
   // The whole value must match; a substring is not enough.
-  CHECK(
-      !umbriel::securityContextRuleAllowsGlobal(config, "org.flatpak", "org.example.Bar", "zwlr_screencopy_manager_v1")
-  );
-  CHECK(umbriel::securityContextRuleAllowsGlobal(config, nullptr, "example", "zwlr_screencopy_manager_v1"));
+  CHECK(!grants("org.flatpak", "org.example.Bar", "zwlr_screencopy_manager_v1"));
+  CHECK(grants(nullptr, "example", "zwlr_screencopy_manager_v1"));
+  // Matching rules pool their globals.
+  CHECK_EQ(umbriel::securityContextRuleGlobals(config, "org.flatpak", "org.example.Bar").size(), size_t{2});
 }
 
 int main() { return RUN_TESTS(); }

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -12,6 +12,7 @@ using umbriel::LayerRule;
 using umbriel::LayoutMode;
 using umbriel::OutputIdentity;
 using umbriel::OutputRule;
+using umbriel::SecurityContextRule;
 using umbriel::VrrMode;
 using umbriel::WindowRule;
 using umbriel::WorkspaceConfig;
@@ -514,6 +515,42 @@ UMBRIEL_TEST(layerRulesMergeMatchingFieldsInOrder) {
   CHECK(!unmatched.blur);
   CHECK(!unmatched.ignoreAlpha);
   CHECK(!unmatched.optimized);
+}
+
+UMBRIEL_TEST(securityContextRulesGrantGlobalsByMetadata) {
+  Config config;
+
+  SecurityContextRule scoped;
+  scoped.sandboxEnginePattern = "^org\\.flatpak$";
+  scoped.sandboxEngineRegex = std::regex(scoped.sandboxEnginePattern);
+  scoped.appIdPattern = "^org\\.example\\.Bar$";
+  scoped.appIdRegex = std::regex(scoped.appIdPattern);
+  scoped.allowGlobals = {"zwlr_layer_shell_v1"};
+  config.securityContextRules.push_back(std::move(scoped));
+
+  SecurityContextRule wildcard;
+  wildcard.allowGlobals = {"ext_idle_notifier_v1"};
+  config.securityContextRules.push_back(std::move(wildcard));
+
+  SecurityContextRule partial;
+  partial.appIdPattern = "example";
+  partial.appIdRegex = std::regex(partial.appIdPattern);
+  partial.allowGlobals = {"zwlr_screencopy_manager_v1"};
+  config.securityContextRules.push_back(std::move(partial));
+
+  CHECK(umbriel::securityContextRuleAllowsGlobal(config, "org.flatpak", "org.example.Bar", "zwlr_layer_shell_v1"));
+  // Every specified match key must hold.
+  CHECK(!umbriel::securityContextRuleAllowsGlobal(config, "org.flatpak", "org.example.Other", "zwlr_layer_shell_v1"));
+  CHECK(!umbriel::securityContextRuleAllowsGlobal(config, "waypak", "org.example.Bar", "zwlr_layer_shell_v1"));
+  // Absent metadata never satisfies a pattern.
+  CHECK(!umbriel::securityContextRuleAllowsGlobal(config, nullptr, "org.example.Bar", "zwlr_layer_shell_v1"));
+  // A rule without match keys applies to every client, but only for its own globals.
+  CHECK(umbriel::securityContextRuleAllowsGlobal(config, nullptr, nullptr, "ext_idle_notifier_v1"));
+  // The whole value must match; a substring is not enough.
+  CHECK(
+      !umbriel::securityContextRuleAllowsGlobal(config, "org.flatpak", "org.example.Bar", "zwlr_screencopy_manager_v1")
+  );
+  CHECK(umbriel::securityContextRuleAllowsGlobal(config, nullptr, "example", "zwlr_screencopy_manager_v1"));
 }
 
 int main() { return RUN_TESTS(); }


### PR DESCRIPTION
## Summary

adds `[[security_context_rule]]` config entries that grant extra wayland globals to security-context clients whose metadata matches. rules are keyed on `match.sandbox_engine` and `match.app_id` regexes and are additive only: the base allowed set can't be narrowed, and `wp_security_context_manager_v1` stays blocked even when listed, so a granted client can never create a nested context.

unlike window and layer rules the patterns must match the entire value (`regex_match`, not `regex_search`). app ids are chosen by the application's publisher, so a substring match would let an app pick an id that embeds another rule's pattern.

## Motivation

some protocols have no portal equivalent. a sandboxed status bar needs layer-shell, a clipboard manager needs data-control. right now the only options are the blanket allowlist or not sandboxing the app. this lets the user opt in to widening the set per application while keeping the default the same as current behaviour.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

n/a

## Testing

- `just format`
- `meson test -C build-debug` — 31/31 pass, includes new resolve/load/change tests
- `bash tests/harness/verify.sh ./build-debug/umbriel` (new check 536 covers grants, cross-rule isolation, substring rejection, the manager staying blocked, and the ordinary socket being unaffected)
- `run-clang-tidy -warnings-as-errors='*'` on changed files
- full harness run: 102/103. (`367_csd_crop_edge_coverage` fails on HEAD, unrelated to this change)

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] I read and followed the relevant guidance in `
- [x] I initialized and updated the SceneFX submodule where required.
- [x] I ran `just format`, or this PR has no C++ cha
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior whfficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I self-reviewed the changes.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

- the registry filter is consulted at connect and again at every bind, so a new rule applies to apps launched after the reload disconnects a running client that later binds the revoked global
- no `match.instance_id` for now: it's per-launch me static rules, and adding the selector later is non-breaking
- no enable flag: an empty rule set is the off state
- a granted global still falls through to the existing middle-click-paste and wine color-management checks
- `docs/user/security.md` documents the feature,`examples/config.toml` has no layer rule examples either so i figured it would be fine to not add example usage of this