### PR TITLE
feat(drm): add GPU selection and exclusion

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -80,6 +80,7 @@ distribution-provided LTO and archive member pruning.
 - wayland-protocols 1.47 or newer
 - xkbcommon
 - libinput 1.23 or newer
+- libudev
 - pixman 0.43 or newer
 - libdrm 2.4.129 or newer
 - Cairo and PangoCairo

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ The scene graph and renderer live in [`umbrielfx/`](umbrielfx/) and build as par
 ### System build
 
 Install a C++23 compiler, Meson, Ninja, pkg-config, wayland-scanner, and development packages for wlroots 0.20,
-Wayland, xkbcommon, libinput, pixman, libdrm, EGL, GLES2, GBM, lcms2, Cairo, Pango, tomlplusplus, and
-nlohmann-json. Then build Umbriel:
+Wayland, xkbcommon, libinput, libudev, pixman, libdrm, EGL, GLES2, GBM, lcms2, Cairo, Pango, tomlplusplus,
+and nlohmann-json. Then build Umbriel:
 
 ```sh
 just release

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -15,6 +15,7 @@ boundaries, or regression-sensitive behavior.
 - [Xwayland input stability](xwayland-input-stability.md)
 - [Client buffer constraints](client-buffer-constraints.md)
 - [Scene helper ownership](scene-helper-ownership.md)
+- [DRM device policy](drm-device-policy.md)
 
 ## Pointer drag completion
 

--- a/docs/design/configuration-reload.md
+++ b/docs/design/configuration-reload.md
@@ -43,6 +43,9 @@ Output state and workspace inventory are independent effects.
   the overview.
 - `general.autostart` commands run only during startup, never during reload.
 - `general.xwayland` changes require a compositor restart.
+- `[drm]` is captured before backend creation. A reload records the new values
+  and reports that a restart is required, but never changes live devices or the
+  renderer.
 - `[environment]` values are applied and synchronized to the systemd user
   manager only during startup. A reload does not mutate the compositor, user
   manager, or existing process environments. Traditional D-Bus activation sees

--- a/docs/design/drm-device-policy.md
+++ b/docs/design/drm-device-policy.md
@@ -1,0 +1,144 @@
+# DRM device policy
+
+Umbriel must decide which GPUs it can use before wlroots opens a KMS node.
+Filtering after `wlr_backend_autocreate()` is too late: wlroots has already
+opened every discovered card and installed its own hotplug monitor.
+`WLR_DRM_DEVICES` cannot provide the same contract because it encodes multiple
+paths with `:`, which is also part of a PCI by-path name.
+
+`BackendManager` keeps this behavior behind one boundary. `Server` receives a
+backend, a session, and a renderer factory. It does not know whether the
+manager used wlroots discovery or Umbriel's filtered native path.
+
+## Compatibility path
+
+When `[drm]` is absent or empty, `BackendManager` calls
+`wlr_backend_autocreate()` and `fx_renderer_create()` without changing the
+environment. This path preserves the previous behavior.
+
+A nonempty `[drm]` section stays inactive for Wayland, X11, and headless
+backends. In a native session, `render_device` overrides
+`WLR_RENDER_DRM_DEVICE`, and exclusions override `WLR_DRM_DEVICES`. A
+render-only configuration preserves `WLR_DRM_DEVICES`.
+
+`BackendManager` hides only the overridden variables while wlroots creates the
+backend, then restores them. Renderer creation normally receives an explicit
+DRM file descriptor. The fallback for a backend without a DRM file descriptor
+hides only `WLR_RENDER_DRM_DEVICE`.
+
+## Filtered native path
+
+Exclusions require a custom native path. Startup follows this sequence:
+
+1. Create an active wlroots session and add libinput in the requested
+   `WLR_BACKENDS` order.
+2. Resolve the ignored paths and enumerate the seat's DRM card nodes through
+   udev.
+3. Exclude matching physical GPUs and recheck each allowed card before and
+   after the privileged open.
+4. Create an independent backend for each allowed KMS node. The first
+   successful backend becomes the primary.
+5. Create the renderer from an explicit DRM file descriptor through GBM.
+6. Inspect open character-device file descriptors after renderer and allocator
+   creation. Fail startup if one belongs to an excluded GPU.
+
+Enumeration matches wlroots 0.20.2, including the ten-second waits and
+boot-display preference. Device filtering is the only change before open.
+Allowed DRM backends remain independent afterward so no hidden renderer can
+enumerate excluded EGL devices.
+
+`DrmDeviceIdentity` joins card and render nodes through their parent sysfs
+device. A selector can match a canonical node path, a udev link, a device
+number, the parent sysfs path, or a PCI address. A render-node path therefore
+excludes the same GPU's card node.
+
+If an ignored path disappears, the policy clears its device number but keeps
+its last parent and PCI identity. A later card add or session resume resolves
+the path again. An invalid existing path blocks new device opens. A path that
+has never resolved and is not advertised as a udev link cannot identify an
+unbound GPU, so VFIO configurations also need `ignored_pci_addresses`.
+
+## Runtime transitions
+
+The manager listens for session card-add, active, and destroy signals. It also
+listens for the destruction of libinput and every DRM backend.
+
+- A card add or session resume reruns path resolution and enumeration.
+- A newly available allowed card becomes a secondary backend and starts
+  immediately if the main backend has started.
+- If an existing path selector starts matching a secondary GPU, the manager
+  removes that backend.
+- If an existing path selector starts matching the primary GPU or renderer
+  GPU, the manager ends the session.
+- Loss of the primary GPU, libinput, or the native session ends the session.
+- A failed hotplug reconciliation gets one idle retry. It does not enter a
+  retry loop.
+
+The primary GPU never changes in a running session. Existing outputs,
+allocators, and renderer state depend on that choice, so live promotion would
+leave mixed ownership across wlroots objects.
+
+## Renderer selection
+
+`render_device` accepts a render node. Umbriel resolves the path and checks all
+exclusions before opening it. Umbriel then checks the opened file descriptor
+and verifies that umbrielfx selected the same physical GPU. These checks prevent
+a path replacement from changing the selected GPU.
+
+An unavailable, invalid, excluded, or unusable renderer produces a warning.
+Umbriel then uses the primary allowed GPU. With exclusions, both paths create
+the renderer through GBM and never use global EGL device enumeration. Some
+GLVND vendors retain file descriptors for every GPU they probe, even when they
+select another GPU as the renderer.
+
+Allowed secondary GPUs import the compositor's DMA-BUFs directly. Umbriel does
+not give them a wlroots parent because that creates an internal multi-GPU blit
+renderer through EGL device enumeration. Drivers with incompatible DMA-BUF
+formats or modifiers therefore cannot use an output on the secondary GPU under
+strict exclusion.
+
+After renderer and allocator creation, Umbriel scans its open character-device
+file descriptors and resolves each one through udev. Startup fails if a device
+number, physical device, or PCI address matches an exclusion. This catches
+driver behavior outside the DRM backend before the compositor starts.
+`WLR_RENDERER_FORCE_SOFTWARE=1` is incompatible with exclusions because
+umbrielfx's software path enumerates EGL devices.
+
+Proprietary NVIDIA per-GPU nodes do not expose a udev parent on every driver
+version. Umbriel maps `/dev/nvidiaN` through
+`/proc/driver/nvidia/gpus/*/information` before applying the same PCI exclusion
+check. Incomplete or unreadable metadata fails the audit instead of weakening
+it. Shared control nodes such as `/dev/nvidiactl` are not attributed to one
+physical GPU.
+
+Renderer recovery uses the immutable startup policy. A configuration reload
+can record new `[drm]` values, but those values cannot affect a recovered
+renderer until Umbriel restarts.
+
+## Verification
+
+Run the automated checks from the repository root:
+
+```sh
+just test debug
+just verify debug
+just lint debug
+```
+
+The unit tests cover configuration, physical GPU matching, path identity,
+device filtering, and backend selection. The headless checks use a nonempty
+`[drm]` section to verify that native-only policy stays inactive. The
+`umbrielfx` tests cover GBM renderer identity and file descriptor ownership.
+
+Automated checks cannot reproduce native GPU lifecycle events. Before a
+release, test these cases on a dual-GPU host:
+
+- Path and PCI exclusion
+- Explicit renderer selection and fallback
+- Secondary GPU add and remove
+- Suspend and resume
+- Startup with every GPU excluded
+- Primary GPU loss
+
+Run the hardware tests from a separate TTY. Primary GPU loss intentionally
+ends the compositor.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -6,6 +6,10 @@ Umbriel checks `$XDG_CONFIG_HOME/umbriel/config.toml` first, followed by each
 The packaged file is [`examples/config.toml`](../../examples/config.toml) and
 can be copied into your user config directory as a starting point. Umbriel
 does not create or modify a user config automatically.
+Initial configuration errors retain the compatibility fallback to built-in
+defaults. When a nonempty `[drm]` policy is present, initial errors are fatal
+because falling back would silently allow GPUs that the policy meant to exclude.
+Warnings do not prevent the session from starting.
 
 ## Starting configuration
 
@@ -77,6 +81,68 @@ honor_restored_maximize = false
 | `show_cheatsheet`         | bool         | `true`                  | Show the keybinds cheatsheet overlay on startup. If an included file is still missing, Umbriel waits for it to load before showing the overlay. Press any key or mouse button to dismiss, or toggle at runtime via `cheatsheet-toggle`. |
 | `focus_on_activate`       | bool         | `false`                 | Let unsolicited activation requests add focus and reveal their target. When false, a mapped target is only marked urgent, while an unmapped target still follows its normal `default_focused` map policy. Tokens issued by `spawn:` and client tokens validated from focused input represent user launch intent and may focus the target. Window rules override this per application. |
 | `honor_restored_maximize` | bool         | `false`                 | Honor maximized state requested by applications before their first buffer maps. The first visible configure then uses the final maximized layout target. A request sent after mapping is a normal runtime maximize request and can resize an already visible window. Later maximize requests are always honored. Applies to newly opened windows. |
+
+## DRM devices
+
+The optional `[drm]` section selects the renderer GPU and excludes GPUs from a
+native session. It is inactive for nested Wayland, X11, and headless backends.
+All keys are optional and require a restart.
+
+```toml
+[drm]
+render_device = "/dev/dri/by-path/pci-0000:05:00.0-render"
+ignored_devices = ["/dev/dri/by-path/pci-0000:01:00.0-card"]
+# Add the PCI address when the GPU may have no DRM node, such as with VFIO.
+ignored_pci_addresses = ["0000:01:00.0"]
+```
+
+An incorrect exclusion can prevent startup. Losing the primary GPU ends the
+session. Keep another TTY or session available while testing changes.
+
+| Key                     | Type         | Default | Description |
+| ----------------------- | ------------ | ------- | ----------- |
+| `render_device`         | string       | unset   | Absolute render-node path for the renderer. If Umbriel cannot use it, Umbriel warns and falls back to the primary allowed GPU. |
+| `ignored_devices`       | string array | `[]`    | Absolute DRM card or render-node paths. Either node excludes the whole physical GPU. A missing path remains active and resolves again on GPU add or session resume. |
+| `ignored_pci_addresses` | string array | `[]`    | PCI addresses in full `domain:bus:slot.function` form. This option can identify a GPU without a DRM node. Umbriel stores addresses in lowercase. |
+
+`umbriel validate` checks path and PCI syntax but does not inspect hardware.
+Device type, permissions, seat membership, and KMS support are checked when a
+native session starts. An existing path that is not a DRM node is a startup
+error.
+
+Prefer stable `/dev/dri/by-path` links over numbered `cardN` and `renderDN`
+paths because numbered paths can change across boots. Use a PCI address if the
+GPU may start unbound or attached to VFIO. A path alone cannot identify a GPU
+if the path has never existed and udev does not advertise it.
+
+Umbriel excludes GPUs before opening their KMS nodes and prefers the allowed
+boot-display GPU as primary. Startup fails if no allowed GPU initializes or if
+a graphics driver opens an excluded GPU.
+
+### Limits
+
+The DRM policy has these limits:
+
+- A renderer GPU that differs from the primary GPU requires compatible DMA-BUF
+  formats and modifiers. It can also increase copying and memory bandwidth.
+- Secondary GPUs import DMA-BUFs directly. An incompatible GPU cannot drive an
+  output.
+- Losing the primary GPU ends the session. Umbriel does not change the primary
+  while allocators and outputs use it.
+- `WLR_RENDERER_FORCE_SOFTWARE=1` is incompatible with exclusions.
+
+### Environment compatibility
+
+`render_device` overrides `WLR_RENDER_DRM_DEVICE`. Exclusions override
+`WLR_DRM_DEVICES`, but a configuration with only `render_device` preserves
+`WLR_DRM_DEVICES`.
+
+With exclusions, `WLR_BACKENDS` may contain one `drm` entry and one optional
+`libinput` entry. Other combinations that include `drm`, such as
+`drm,headless`, fail at startup.
+
+See [DRM device policy](../design/drm-device-policy.md) for the backend and
+renderer design.
 
 ## Environment
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -19,6 +19,14 @@ show_cheatsheet = true         # show keybinds overlay on startup
 focus_on_activate = false      # unsolicited requests cannot add focus; trusted launches may still focus
 honor_restored_maximize = false # let apps restore their saved maximized state
 
+# Native sessions only. All values are optional and require a restart. An
+# unavailable render device falls back to the primary allowed GPU. Prefer
+# by-path links, and add the PCI address if the GPU may have no DRM node.
+# [drm]
+# render_device = "/dev/dri/by-path/pci-0000:05:00.0-render"
+# ignored_devices = ["/dev/dri/by-path/pci-0000:01:00.0-card"]
+# ignored_pci_addresses = ["0000:01:00.0"]
+
 # Applied only at session startup. Native sessions also publish these values to
 # newly started systemd session services and applications they launch. D-Bus
 # receives only graphical connection variables. Nested sessions do not modify the

--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,16 @@ build_tests = tests_opt.enabled() or (
   and get_option('b_sanitize') == 'none'
 )
 
+if cpp.get_define('WLR_HAS_SESSION', prefix: '#include <wlr/config.h>', dependencies: wlroots_dep) != '1'
+  error('Umbriel requires wlroots built with session support')
+endif
+if cpp.get_define('WLR_HAS_DRM_BACKEND', prefix: '#include <wlr/config.h>', dependencies: wlroots_dep) != '1'
+  error('Umbriel requires wlroots built with the DRM backend')
+endif
+if cpp.get_define('WLR_HAS_LIBINPUT_BACKEND', prefix: '#include <wlr/config.h>', dependencies: wlroots_dep) != '1'
+  error('Umbriel requires wlroots built with the libinput backend')
+endif
+
 # jemalloc keeps a long-running compositor's heap compact: fewer arenas and fast page decay bound RSS. It interposes malloc only on glibc, so other libc builds
 # skip it (auto) or fail (enabled).
 jemalloc_option = get_option('jemalloc')
@@ -94,6 +104,7 @@ nlohmann_json_dep = dependency('nlohmann_json')
 cairo_dep = dependency('cairo')
 pangocairo_dep = dependency('pangocairo')
 libdrm_dep = dependency('libdrm', version: '>=2.4.129')
+libudev_dep = dependency('libudev')
 
 wayland_scanner = find_program('wayland-scanner')
 
@@ -402,6 +413,7 @@ pure_sources = files(
   'src/layout/master.cpp',
   'src/output/direction.cpp',
   'src/output/identity.cpp',
+  'src/server/drm_policy.cpp',
   'src/scene/cheatsheet_rows.cpp',
   'src/overview/shortcut_labels.cpp',
   'src/view/border_ring.cpp',
@@ -443,6 +455,7 @@ core_sources = files(
   'src/config/config_watcher.cpp',
   'src/layout/drop_target.cpp',
   'src/server/wine_color_manager.cpp',
+  'src/server/backend_manager.cpp',
   'src/server/server.cpp',
   'src/server/server_events.cpp',
   'src/server/server_keybinds.cpp',
@@ -497,6 +510,7 @@ umbriel_core_deps = [
   cairo_dep,
   pangocairo_dep,
   libdrm_dep,
+  libudev_dep,
   nlohmann_json_dep,
   layer_shell_protocol_dep,
 ]

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,6 +10,7 @@
   wlroots_0_20,
   libxkbcommon,
   libinput,
+  systemd,
   pixman,
   cairo,
   pango,
@@ -53,6 +54,7 @@ stdenv.mkDerivation {
     wlroots_0_20
     libxkbcommon
     libinput
+    systemd
     pixman
     tomlplusplus
     libGL

--- a/src/config/change.cpp
+++ b/src/config/change.cpp
@@ -175,6 +175,7 @@ namespace umbriel {
         .layout = true,
         .workspaces = true,
         .general = true,
+        .drm = true,
         .environment = true,
         .events = true,
         .input = true,
@@ -197,6 +198,7 @@ namespace umbriel {
         .layout = before.layout != after.layout,
         .workspaces = before.workspaces != after.workspaces,
         .general = before.general != after.general,
+        .drm = before.drm != after.drm,
         .environment = before.environment != after.environment,
         .events = before.events != after.events,
         .input = before.input != after.input,
@@ -228,6 +230,7 @@ namespace umbriel {
     add(layout, "layout");
     add(workspaces, "workspaces");
     add(general, "general");
+    add(drm, "drm");
     add(environment, "environment");
     add(events, "events");
     add(input, "input");

--- a/src/config/change.h
+++ b/src/config/change.h
@@ -17,6 +17,7 @@ namespace umbriel {
     bool layout = false;
     bool workspaces = false;
     bool general = false;
+    bool drm = false;
     bool environment = false;
     bool events = false;
     bool input = false;
@@ -36,6 +37,7 @@ namespace umbriel {
           || layout
           || workspaces
           || general
+          || drm
           || environment
           || events
           || input

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -144,6 +144,99 @@ namespace umbriel {
       emitDiag(ConfigDiagnostic::Severity::Error, &src, std::format(fmt, std::forward<A>(args)...));
     }
 
+    std::optional<std::string> normalizePciAddress(std::string_view value) {
+      constexpr std::array<size_t, 3> separators{4, 7, 10};
+      if (value.size() != 12
+          || value[separators[0]] != ':'
+          || value[separators[1]] != ':'
+          || value[separators[2]] != '.'
+          || (value[8] != '0' && value[8] != '1')
+          || value.back() < '0'
+          || value.back() > '7') {
+        return std::nullopt;
+      }
+      for (size_t index = 0; index < value.size(); ++index) {
+        if (std::ranges::find(separators, index) != separators.end()) {
+          continue;
+        }
+        if (std::isxdigit(static_cast<unsigned char>(value[index])) == 0) {
+          return std::nullopt;
+        }
+      }
+      return lowercase(value);
+    }
+
+    std::optional<std::string> readDrmPath(const toml::node& node, std::string_view context) {
+      const auto value = node.value<std::string>();
+      if (!value) {
+        errorAt(node.source(), "{} must be a string", context);
+        return std::nullopt;
+      }
+      if (value->empty()) {
+        errorAt(node.source(), "{} cannot be empty", context);
+        return std::nullopt;
+      }
+      if (value->contains('\0')) {
+        errorAt(node.source(), "{} cannot contain NUL", context);
+        return std::nullopt;
+      }
+      const std::filesystem::path path(*value);
+      if (!path.is_absolute()) {
+        errorAt(node.source(), R"({} must be an absolute path (got "{}"))", context, *value);
+        return std::nullopt;
+      }
+      // Keep the exact spelling: lexical normalization changes the meaning of
+      // `..` when an earlier path component is a symlink.
+      return value;
+    }
+
+    void readDrmPathList(const toml::node& node, std::string_view context, std::vector<std::string>& target) {
+      const toml::array* values = node.as_array();
+      if (values == nullptr) {
+        errorAt(node.source(), "{} must be an array of absolute paths", context);
+        return;
+      }
+      for (const toml::node& entry : *values) {
+        const auto path = readDrmPath(entry, context);
+        if (!path) {
+          continue;
+        }
+        if (std::ranges::find(target, *path) != target.end()) {
+          warnAt(entry.source(), R"(ignoring duplicate {} entry "{}")", context, *path);
+          continue;
+        }
+        target.push_back(*path);
+      }
+    }
+
+    void readDrmPciList(const toml::node& node, std::string_view context, std::vector<std::string>& target) {
+      const toml::array* values = node.as_array();
+      if (values == nullptr) {
+        errorAt(node.source(), "{} must be an array of PCI addresses", context);
+        return;
+      }
+      for (const toml::node& entry : *values) {
+        const auto value = entry.value<std::string>();
+        if (!value) {
+          errorAt(entry.source(), "{} entries must be strings", context);
+          continue;
+        }
+        const auto address = normalizePciAddress(*value);
+        if (!address) {
+          errorAt(
+              entry.source(), R"(invalid {} entry "{}" (expected domain:bus:slot.function, for example 0000:01:00.0))",
+              context, *value
+          );
+          continue;
+        }
+        if (std::ranges::find(target, *address) != target.end()) {
+          warnAt(entry.source(), R"(ignoring duplicate {} entry "{}")", context, *address);
+          continue;
+        }
+        target.push_back(*address);
+      }
+    }
+
     std::filesystem::path userConfigPath() {
       if (const char* xdgConfigHome = std::getenv("XDG_CONFIG_HOME");
           xdgConfigHome != nullptr && xdgConfigHome[0] != '\0') {
@@ -995,6 +1088,35 @@ namespace umbriel {
             .boolean("honor_restored_maximize", loaded.general.honorRestoredMaximize)
             .strings("autostart", loaded.general.autostart);
       });
+    }
+
+    void readDrm(Section& root, Config& loaded) {
+      const toml::node* node = root.take("drm");
+      if (node == nullptr) {
+        return;
+      }
+      const toml::table* table = node->as_table();
+      if (table == nullptr) {
+        errorAt(node->source(), "drm must be a table");
+        return;
+      }
+
+      if (const toml::node* render = table->get("render_device")) {
+        loaded.drm.renderDevice = readDrmPath(*render, "drm.render_device");
+      }
+      if (const toml::node* ignored = table->get("ignored_devices")) {
+        readDrmPathList(*ignored, "drm.ignored_devices", loaded.drm.ignoredDevices);
+      }
+      if (const toml::node* ignoredPci = table->get("ignored_pci_addresses")) {
+        readDrmPciList(*ignoredPci, "drm.ignored_pci_addresses", loaded.drm.ignoredPciAddresses);
+      }
+
+      constexpr std::array<std::string_view, 3> knownKeys{"render_device", "ignored_devices", "ignored_pci_addresses"};
+      for (const auto& [key, value] : *table) {
+        if (std::ranges::find(knownKeys, key.str()) == knownKeys.end()) {
+          errorAt(value.source(), "unknown key drm.{}", key.str());
+        }
+      }
     }
 
     void readEnvironment(Section& root, Config& loaded) {
@@ -1879,17 +2001,33 @@ namespace umbriel {
       }
     }
 
-    bool parseInto(Config& out) {
+    struct ConfigParseAttempt {
+      bool success = false;
+      bool drmPolicyRequested = false;
+    };
+
+    bool hasRequestedDrmPolicy(const toml::table& root) {
+      const toml::node* node = root.get("drm");
+      if (node == nullptr) {
+        return false;
+      }
+      const toml::table* table = node->as_table();
+      return table == nullptr || !table->empty();
+    }
+
+    ConfigParseAttempt parseInto(Config& out) {
       ConfigStore& store = configStore();
       store.beginLoad();
 
       std::error_code error;
       if (!std::filesystem::is_regular_file(store.rootPath(), error) || error) {
-        return false;
+        return {};
       }
 
+      bool drmPolicyRequested = false;
       try {
         auto result = configmerge::mergeWithIncludes(store.rootPath());
+        drmPolicyRequested = result.parseErrorMayDiscardDrmPolicy || hasRequestedDrmPolicy(result.merged);
         store.setMissingIncludes(result.missingIncludes);
         for (auto& diagnostic : result.diagnostics) {
           store.addDiagnostic(std::move(diagnostic));
@@ -1898,7 +2036,7 @@ namespace umbriel {
           store.addWatchPath(path);
         }
         if (result.hadParseError) {
-          return false;
+          return {.success = false, .drmPolicyRequested = drmPolicyRequested};
         }
 
         Config loaded;
@@ -1911,6 +2049,7 @@ namespace umbriel {
           readHotCorners(root, loaded);
           readLayout(root, loaded);
           readGeneral(root, loaded);
+          readDrm(root, loaded);
           readEnvironment(root, loaded);
           readEvents(root, loaded);
           readWorkspaceSettings(root, loaded);
@@ -1928,17 +2067,17 @@ namespace umbriel {
           return d.severity == ConfigDiagnostic::Severity::Error;
         });
         if (hasErrors) {
-          return false;
+          return {.success = false, .drmPolicyRequested = drmPolicyRequested};
         }
 
         out = std::move(loaded);
-        return true;
+        return {.success = true, .drmPolicyRequested = drmPolicyRequested};
       } catch (const std::exception& exception) {
         emitDiag(ConfigDiagnostic::Severity::Error, nullptr, std::format("config load error: {}", exception.what()));
       } catch (...) {
         emitDiag(ConfigDiagnostic::Severity::Error, nullptr, "config load error: unknown error");
       }
-      return false;
+      return {.success = false, .drmPolicyRequested = drmPolicyRequested};
     }
 
   } // namespace
@@ -1971,38 +2110,48 @@ namespace umbriel {
     }
   } // namespace
 
-  void ConfigStore::load(const char* explicitPath) {
+  bool ConfigStore::load(const char* explicitPath) {
     setRootPath(
         explicitPath == nullptr ? defaultConfigPath() : std::filesystem::path(explicitPath), explicitPath != nullptr
     );
 
     Config loaded;
     loaded.keybinds = defaultKeybinds();
-    if (!parseInto(loaded) && rootFileMissing(m_rootPath)) {
-      if (m_explicitPath) {
+    const bool missing = rootFileMissing(m_rootPath);
+    const ConfigParseAttempt attempt = parseInto(loaded);
+    if (!attempt.success) {
+      if (missing && !m_explicitPath) {
+        kLog.info("no config file found: {}, using defaults", m_rootPath.string());
+      }
+      if (missing && m_explicitPath) {
         emitDiag(
             ConfigDiagnostic::Severity::Error, nullptr, std::format("config file not found: {}", m_rootPath.string())
         );
-      } else {
-        kLog.info("no config file found: {}, using defaults", m_rootPath.string());
       }
+      sortDiagnostics();
+      if (attempt.drmPolicyRequested) {
+        return false;
+      }
+      (void)commit(std::move(loaded), missing);
+      return true;
     }
     sortDiagnostics();
-    (void)commit(std::move(loaded), rootFileMissing(m_rootPath));
+    (void)commit(std::move(loaded), false);
+    return true;
   }
 
   ConfigReloadResult ConfigStore::reload() {
     Config loaded;
-    const bool ok = parseInto(loaded);
+    const ConfigParseAttempt attempt = parseInto(loaded);
     sortDiagnostics();
-    if (!ok) {
+    if (!attempt.success) {
       kLog.warn("config reload failed; keeping previous configuration");
       return {};
     }
     return commit(std::move(loaded), rootFileMissing(m_rootPath));
   }
 
-  void loadConfig(const char* explicitPath) { configStore().load(explicitPath); }
+  bool loadConfig(const char* explicitPath) { return configStore().load(explicitPath); }
 
   ConfigReloadResult reloadConfig() { return configStore().reload(); }
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -595,6 +595,20 @@ namespace umbriel {
       bool operator==(const General&) const = default;
     } general;
 
+    struct Drm {
+      // Native-session renderer override. Runtime failures fall back to the
+      // first allowed DRM backend rather than invalidating the config file.
+      std::optional<std::string> renderDevice;
+      // Absolute card or render-node paths. Either node excludes the whole GPU.
+      std::vector<std::string> ignoredDevices;
+      // Canonical PCI domain:bus:slot.function addresses.
+      std::vector<std::string> ignoredPciAddresses;
+
+      [[nodiscard]] bool hasExclusions() const { return !ignoredDevices.empty() || !ignoredPciAddresses.empty(); }
+      [[nodiscard]] bool configured() const { return renderDevice.has_value() || hasExclusions(); }
+      bool operator==(const Drm&) const = default;
+    } drm;
+
     struct Environment {
       // Ordered NAME=value pairs exported to the compositor and the native session's systemd user manager.
       std::vector<std::pair<std::string, std::string>> variables;
@@ -708,7 +722,7 @@ namespace umbriel {
   };
 
   [[nodiscard]] const Config& config();
-  void loadConfig(const char* explicitPath);
+  [[nodiscard]] bool loadConfig(const char* explicitPath);
   [[nodiscard]] ConfigReloadResult reloadConfig();
   [[nodiscard]] const std::vector<std::filesystem::path>& configWatchPaths();
   [[nodiscard]] const std::vector<ConfigDiagnostic>& configDiagnostics();

--- a/src/config/config_merge.cpp
+++ b/src/config/config_merge.cpp
@@ -116,6 +116,107 @@ namespace umbriel::configmerge {
       return message.substr(0, recordedKey + 1) + "'" + key + "'";
     }
 
+    enum class MultilineString {
+      None,
+      Basic,
+      Literal,
+    };
+
+    std::string structuralTomlLine(std::string_view line, MultilineString& multiline) {
+      std::string code;
+      for (size_t index = 0; index < line.size();) {
+        if (multiline == MultilineString::Basic) {
+          if (line.substr(index).starts_with(R"(""")")) {
+            multiline = MultilineString::None;
+            index += 3;
+          } else if (line[index] == '\\' && index + 1 < line.size()) {
+            index += 2;
+          } else {
+            ++index;
+          }
+          continue;
+        }
+        if (multiline == MultilineString::Literal) {
+          if (line.substr(index).starts_with("'''")) {
+            multiline = MultilineString::None;
+            index += 3;
+          } else {
+            ++index;
+          }
+          continue;
+        }
+
+        if (line[index] == '#') {
+          break;
+        }
+        if (line.substr(index).starts_with(R"(""")")) {
+          multiline = MultilineString::Basic;
+          index += 3;
+          continue;
+        }
+        if (line.substr(index).starts_with("'''")) {
+          multiline = MultilineString::Literal;
+          index += 3;
+          continue;
+        }
+        if (line[index] == '"' || line[index] == '\'') {
+          const char quote = line[index];
+          code.push_back(line[index++]);
+          bool escaped = false;
+          while (index < line.size()) {
+            const char character = line[index++];
+            code.push_back(character);
+            if (quote == '"' && character == '\\' && !escaped) {
+              escaped = true;
+              continue;
+            }
+            if (character == quote && !escaped) {
+              break;
+            }
+            escaped = false;
+          }
+          continue;
+        }
+        code.push_back(line[index++]);
+      }
+      return code;
+    }
+
+    // toml++ does not return a partial table on syntax errors. Inspect only
+    // structural source tokens so a malformed policy still fails closed, while
+    // comments and multiline string contents cannot look like a real [drm]
+    // section.
+    bool parseErrorMayDiscardDrmPolicy(const std::filesystem::path& path) {
+      std::ifstream input(path);
+      std::string line;
+      MultilineString multiline = MultilineString::None;
+      bool inDrmTable = false;
+      while (std::getline(input, line)) {
+        std::string code = structuralTomlLine(line, multiline);
+        std::erase_if(code, [](unsigned char character) { return std::isspace(character) != 0; });
+        if (code == "[drm]") {
+          inDrmTable = true;
+          continue;
+        }
+        const bool drmTable = code.starts_with("[drm") && (code.size() == 4 || code[4] == '.' || code[4] == ']');
+        const bool drmArray = code.starts_with("[[drm") && (code.size() == 5 || code[5] == '.' || code[5] == ']');
+        if (drmTable || drmArray) {
+          return true;
+        }
+        if (code.starts_with('[')) {
+          inDrmTable = false;
+          continue;
+        }
+        if (code.empty()) {
+          continue;
+        }
+        if (inDrmTable || code.starts_with("drm.") || (code.starts_with("drm=") && code != "drm={}")) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     std::string expandEnvironment(std::string_view input) {
       std::string result;
       result.reserve(input.size());
@@ -288,6 +389,8 @@ namespace umbriel::configmerge {
         parsed = toml::parse_file(path.string());
       } catch (const toml::parse_error& error) {
         result.hadParseError = true;
+        result.parseErrorMayDiscardDrmPolicy =
+            result.parseErrorMayDiscardDrmPolicy || parseErrorMayDiscardDrmPolicy(path);
         const auto key = canonicalKey(path);
         if (std::ranges::find(result.loadedFiles, key) == result.loadedFiles.end()) {
           result.loadedFiles.push_back(key);

--- a/src/config/config_merge.h
+++ b/src/config/config_merge.h
@@ -14,6 +14,7 @@ namespace umbriel::configmerge {
     std::vector<std::filesystem::path> loadedFiles;
     std::vector<ConfigDiagnostic> diagnostics;
     bool hadParseError = false;
+    bool parseErrorMayDiscardDrmPolicy = false;
     bool missingIncludes = false;
   };
 

--- a/src/config/store.h
+++ b/src/config/store.h
@@ -18,9 +18,10 @@ namespace umbriel {
   // which is cheaper and less error-prone than every consumer being individually re-notified from Server::applyConfig.
   class ConfigStore {
   public:
-    // Resolve the user, system, or packaged config and load it. Falls back to
-    // built-in defaults when no file exists.
-    void load(const char* explicitPath);
+    // Resolve the user, system, or packaged config and load it. Initial errors
+    // retain the compatibility fallback to defaults unless doing so would
+    // silently discard a requested DRM policy.
+    [[nodiscard]] bool load(const char* explicitPath);
     // Re-parse. On failure the previous configuration is kept and the generation
     // does not move: a config with a syntax error must not take the session down.
     [[nodiscard]] ConfigReloadResult reload();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ namespace {
       }
     }
 
-    umbriel::loadConfig(configPath);
+    (void)umbriel::loadConfig(configPath);
     const auto& diags = umbriel::configDiagnostics();
     if (diags.empty()) {
       std::println("config: ok ({})", umbriel::configRootPath().string());
@@ -310,7 +310,10 @@ int main(int argc, char** argv) {
 
   try {
     kLog.info("starting umbriel version={} commit={}", umbriel::build_info::version(), umbriel::build_info::revision());
-    umbriel::loadConfig(configPath);
+    if (!umbriel::loadConfig(configPath)) {
+      kLog.error("initial configuration is invalid; refusing to start");
+      return EXIT_FAILURE;
+    }
     umbriel::Server server;
 
     // SIGINT and SIGTERM are handled on the event loop by the server itself. SIG_IGN for SIGCHLD reaps spawned children

--- a/src/server/backend_manager.cpp
+++ b/src/server/backend_manager.cpp
@@ -1,0 +1,1258 @@
+#include "server/backend_manager.h"
+
+#include "core/log.h"
+#include "server/drm_policy.h"
+#include "wlr.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <filesystem>
+#include <fstream>
+#include <libudev.h>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+
+namespace umbriel {
+
+  namespace {
+
+    constexpr Logger kLog("drm");
+    constexpr auto kDeviceWaitTimeout = std::chrono::seconds(10);
+
+    class UniqueFd {
+    public:
+      explicit UniqueFd(int fd = -1) : m_fd(fd) {}
+      ~UniqueFd() {
+        if (m_fd >= 0) {
+          close(m_fd);
+        }
+      }
+      UniqueFd(const UniqueFd&) = delete;
+      UniqueFd& operator=(const UniqueFd&) = delete;
+      [[nodiscard]] int get() const { return m_fd; }
+
+    private:
+      int m_fd;
+    };
+
+    class ScopedEnvironmentUnset {
+    public:
+      explicit ScopedEnvironmentUnset(std::string name) : m_name(std::move(name)) {
+        if (const char* value = std::getenv(m_name.c_str())) {
+          m_previous = value;
+        }
+        m_ok = unsetenv(m_name.c_str()) == 0;
+        if (!m_ok) {
+          kLog.error("failed to unset {}: {}", m_name, std::strerror(errno));
+        }
+      }
+
+      ~ScopedEnvironmentUnset() {
+        const int result = m_previous ? setenv(m_name.c_str(), m_previous->c_str(), 1) : unsetenv(m_name.c_str());
+        if (result != 0) {
+          kLog.error("failed to restore {}: {}", m_name, std::strerror(errno));
+        }
+      }
+
+      ScopedEnvironmentUnset(const ScopedEnvironmentUnset&) = delete;
+      ScopedEnvironmentUnset& operator=(const ScopedEnvironmentUnset&) = delete;
+      [[nodiscard]] bool ok() const { return m_ok; }
+
+    private:
+      std::string m_name;
+      std::optional<std::string> m_previous;
+      bool m_ok = false;
+    };
+
+    struct UdevDeviceDeleter {
+      void operator()(udev_device* device) const {
+        if (device != nullptr) {
+          udev_device_unref(device);
+        }
+      }
+    };
+    struct UdevEnumerateDeleter {
+      void operator()(udev_enumerate* enumerate) const {
+        if (enumerate != nullptr) {
+          udev_enumerate_unref(enumerate);
+        }
+      }
+    };
+    using UdevDevice = std::unique_ptr<udev_device, UdevDeviceDeleter>;
+    using UdevEnumerate = std::unique_ptr<udev_enumerate, UdevEnumerateDeleter>;
+
+    bool hasNumericSuffix(std::string_view value, std::string_view prefix) {
+      if (!value.starts_with(prefix) || value.size() == prefix.size()) {
+        return false;
+      }
+      return std::ranges::all_of(value.substr(prefix.size()), [](char character) {
+        return character >= '0' && character <= '9';
+      });
+    }
+
+    bool isDrmNode(udev_device* device) {
+      const char* subsystem = udev_device_get_subsystem(device);
+      const char* sysname = udev_device_get_sysname(device);
+      return subsystem != nullptr
+          && std::string_view(subsystem) == "drm"
+          && sysname != nullptr
+          && (hasNumericSuffix(sysname, "card") || hasNumericSuffix(sysname, "renderD"));
+    }
+
+    std::string physicalDevicePath(udev_device* device) {
+      for (udev_device* parent = udev_device_get_parent(device); parent != nullptr;
+           parent = udev_device_get_parent(parent)) {
+        const char* subsystem = udev_device_get_subsystem(parent);
+        if (subsystem != nullptr && std::string_view(subsystem) == "drm") {
+          continue;
+        }
+        if (const char* syspath = udev_device_get_syspath(parent)) {
+          return syspath;
+        }
+      }
+      return {};
+    }
+
+    std::optional<std::string> pciAddress(udev_device* device) {
+      udev_device* pci = udev_device_get_parent_with_subsystem_devtype(device, "pci", nullptr);
+      if (pci == nullptr) {
+        return std::nullopt;
+      }
+      const char* sysname = udev_device_get_sysname(pci);
+      return sysname == nullptr ? std::nullopt : std::optional<std::string>(sysname);
+    }
+
+    std::optional<DrmDeviceIdentity> identityFromUdev(udev_device* device, std::string_view fallbackNode = {}) {
+      if (device == nullptr || !isDrmNode(device)) {
+        return std::nullopt;
+      }
+
+      DrmDeviceIdentity identity;
+      if (const char* node = udev_device_get_devnode(device)) {
+        identity.node = node;
+      } else {
+        identity.node = fallbackNode;
+      }
+      identity.device = udev_device_get_devnum(device);
+      identity.physicalDevice = physicalDevicePath(device);
+      identity.pciAddress = pciAddress(device);
+      if (const char* seat = udev_device_get_property_value(device, "ID_SEAT")) {
+        identity.seat = seat;
+      } else {
+        identity.seat = "seat0";
+      }
+      for (udev_list_entry* entry = udev_device_get_devlinks_list_entry(device); entry != nullptr;
+           entry = udev_list_entry_get_next(entry)) {
+        if (const char* link = udev_list_entry_get_name(entry)) {
+          identity.devlinks.emplace_back(link);
+        }
+      }
+      return identity;
+    }
+
+    std::optional<DrmDeviceIdentity> identityFromDevnum(udev* context, dev_t device, std::string_view node = {}) {
+      if (context == nullptr) {
+        return std::nullopt;
+      }
+      UdevDevice udevDevice(udev_device_new_from_devnum(context, 'c', device));
+      return identityFromUdev(udevDevice.get(), node);
+    }
+
+    std::optional<DrmDeviceIdentity>
+    physicalIdentityFromDevnum(udev* context, dev_t device, std::string_view fallbackNode = {}) {
+      if (context == nullptr) {
+        return std::nullopt;
+      }
+      UdevDevice udevDevice(udev_device_new_from_devnum(context, 'c', device));
+
+      DrmDeviceIdentity identity;
+      if (udevDevice != nullptr && udev_device_get_devnode(udevDevice.get()) != nullptr) {
+        const char* node = udev_device_get_devnode(udevDevice.get());
+        identity.node = node;
+      } else {
+        identity.node = fallbackNode;
+      }
+      identity.device = device;
+      if (udevDevice != nullptr) {
+        identity.physicalDevice = physicalDevicePath(udevDevice.get());
+        identity.pciAddress = pciAddress(udevDevice.get());
+      }
+      return identity;
+    }
+
+    std::optional<unsigned int> nvidiaDeviceMinor(const std::filesystem::path& informationPath) {
+      std::ifstream information(informationPath);
+      std::string line;
+      while (std::getline(information, line)) {
+        if (const auto minorNumber = parseNvidiaDeviceMinor(line)) {
+          return minorNumber;
+        }
+      }
+      return std::nullopt;
+    }
+
+    std::optional<std::vector<std::pair<dev_t, std::string>>> nvidiaPciDevices() {
+      std::error_code error;
+      std::filesystem::directory_iterator gpu("/proc/driver/nvidia/gpus", error);
+      if (error) {
+        if (error == std::errc::no_such_file_or_directory) {
+          return std::vector<std::pair<dev_t, std::string>>{};
+        }
+        kLog.error("cannot inspect proprietary NVIDIA GPU metadata: {}", error.message());
+        return std::nullopt;
+      }
+
+      std::vector<std::pair<dev_t, std::string>> devices;
+      const std::filesystem::directory_iterator end;
+      while (gpu != end) {
+        const auto minorNumber = nvidiaDeviceMinor(gpu->path() / "information");
+        if (!minorNumber) {
+          kLog.error("cannot resolve proprietary NVIDIA GPU metadata in {}", gpu->path().string());
+          return std::nullopt;
+        }
+        const std::filesystem::path node = "/dev" / std::filesystem::path("nvidia" + std::to_string(*minorNumber));
+        struct stat statBuffer{};
+        if (stat(node.c_str(), &statBuffer) == 0 && S_ISCHR(statBuffer.st_mode)) {
+          devices.emplace_back(statBuffer.st_rdev, gpu->path().filename().string());
+        }
+        gpu.increment(error);
+        if (error) {
+          kLog.error("cannot continue inspecting proprietary NVIDIA GPU metadata: {}", error.message());
+          return std::nullopt;
+        }
+      }
+      return devices;
+    }
+
+    enum class PathResolutionKind {
+      Resolved,
+      Missing,
+      Invalid,
+    };
+
+    struct PathResolution {
+      PathResolutionKind kind = PathResolutionKind::Invalid;
+      std::optional<DrmDeviceIdentity> identity;
+      std::string error;
+    };
+
+    PathResolution resolveDrmPath(udev* context, const std::string& path) {
+      struct stat statBuffer{};
+      if (stat(path.c_str(), &statBuffer) != 0) {
+        if (errno == ENOENT || errno == ENOTDIR) {
+          return {.kind = PathResolutionKind::Missing, .identity = std::nullopt, .error = {}};
+        }
+        return {
+            .kind = PathResolutionKind::Invalid,
+            .identity = std::nullopt,
+            .error = std::string("stat failed: ") + std::strerror(errno),
+        };
+      }
+      if (!S_ISCHR(statBuffer.st_mode)) {
+        return {
+            .kind = PathResolutionKind::Invalid,
+            .identity = std::nullopt,
+            .error = "not a character device",
+        };
+      }
+      auto identity = identityFromDevnum(context, statBuffer.st_rdev, path);
+      if (!identity) {
+        return {
+            .kind = PathResolutionKind::Invalid,
+            .identity = std::nullopt,
+            .error = "not a DRM card or render node",
+        };
+      }
+      return {.kind = PathResolutionKind::Resolved, .identity = std::move(identity), .error = {}};
+    }
+
+    bool environmentFlagEnabled(const char* name) {
+      const char* value = std::getenv(name);
+      return value != nullptr && std::string_view(value) == "1";
+    }
+
+    const char* exclusionMatchName(DrmExclusionMatch match) {
+      switch (match) {
+      case DrmExclusionMatch::Path:
+        return "path";
+      case DrmExclusionMatch::DeviceNumber:
+        return "device number";
+      case DrmExclusionMatch::PhysicalDevice:
+        return "physical GPU";
+      case DrmExclusionMatch::PciAddress:
+        return "PCI address";
+      case DrmExclusionMatch::None:
+        return "none";
+      }
+      return "unknown";
+    }
+
+    void disconnectListener(wl_listener& listener) {
+      if (listener.notify == nullptr) {
+        return;
+      }
+      wl_list_remove(&listener.link);
+      listener.notify = nullptr;
+    }
+
+  } // namespace
+
+  class BackendManager::Impl {
+  public:
+    Impl(wl_display* display, Config::Drm config)
+        : m_display(display), m_loop(wl_display_get_event_loop(display)), m_config(std::move(config)) {
+      m_ignoredPaths.reserve(m_config.ignoredDevices.size());
+      m_pathStatuses.resize(m_config.ignoredDevices.size());
+      for (const std::string& path : m_config.ignoredDevices) {
+        m_ignoredPaths.push_back({
+            .path = path,
+            .device = std::nullopt,
+            .physicalDevice = {},
+            .pciAddress = std::nullopt,
+        });
+      }
+    }
+
+    ~Impl() {
+      m_destroying = true;
+      if (m_retrySource != nullptr) {
+        wl_event_source_remove(m_retrySource);
+      }
+      disconnectSessionListeners();
+      if (m_backend != nullptr) {
+        wlr_backend_destroy(m_backend);
+      }
+      m_drmBackends.clear();
+      if (m_ownsSession && m_session != nullptr) {
+        wlr_session_destroy(m_session);
+      }
+    }
+
+    [[nodiscard]] bool initialize() {
+      const char* configuredBackends = std::getenv("WLR_BACKENDS");
+      const DrmBackendEnvironment environment = resolveDrmBackendEnvironment(
+          configuredBackends == nullptr ? std::nullopt : std::optional<std::string_view>(configuredBackends),
+          std::getenv("WAYLAND_DISPLAY") != nullptr, std::getenv("WAYLAND_SOCKET") != nullptr,
+          std::getenv("DISPLAY") != nullptr
+      );
+      m_policyActive = m_config.configured() && environment.native;
+      if (m_config.configured() && !environment.native) {
+        kLog.info("configuration is inactive because the selected backend is nested or headless");
+      }
+
+      if (!m_policyActive || !m_config.hasExclusions()) {
+        return initializeAutomatic();
+      }
+
+      if (!environment.exclusionsSupported) {
+        kLog.error(
+            "DRM exclusion supports one drm backend and at most one libinput backend; mixed native backends cannot be "
+            "filtered safely"
+        );
+        return false;
+      }
+      return initializeFiltered(
+          environment.createLibinput, environment.libinputBeforeDrm, environment.allowMissingLibinput
+      );
+    }
+
+    [[nodiscard]] wlr_backend* backend() const { return m_backend; }
+    [[nodiscard]] wlr_session* session() const { return m_session; }
+
+    [[nodiscard]] wlr_renderer* createRenderer() {
+      if (!m_policyActive) {
+        return fx_renderer_create(m_backend);
+      }
+
+      m_rendererDevice.reset();
+      if (!activePolicyStillAllowed("before renderer creation")) {
+        return nullptr;
+      }
+
+      const bool forceSoftware = environmentFlagEnabled("WLR_RENDERER_FORCE_SOFTWARE");
+      if (forceSoftware && m_config.hasExclusions()) {
+        kLog.error("WLR_RENDERER_FORCE_SOFTWARE=1 cannot guarantee DRM exclusions; refusing to enumerate EGL devices");
+        return nullptr;
+      }
+
+      wlr_renderer* renderer = nullptr;
+      if (m_config.renderDevice && !forceSoftware) {
+        renderer = createConfiguredRenderer(*m_config.renderDevice);
+        if (renderer == nullptr) {
+          kLog.warn("falling back to the first allowed backend renderer");
+        }
+      } else if (m_config.renderDevice) {
+        kLog.info("WLR_RENDERER_FORCE_SOFTWARE=1 overrides drm.render_device");
+      }
+
+      if (renderer == nullptr) {
+        if (m_config.hasExclusions()) {
+          renderer = createPrimaryRenderer();
+        } else if (forceSoftware) {
+          renderer = fx_renderer_create(m_backend);
+        } else {
+          renderer = createBackendRenderer();
+        }
+      }
+      if (renderer == nullptr) {
+        return nullptr;
+      }
+      if (!m_rendererDevice) {
+        m_rendererDevice = rendererIdentity(renderer);
+      }
+      if (!verifyOpenDevices("after renderer creation")) {
+        wlr_renderer_destroy(renderer);
+        m_rendererDevice.reset();
+        return nullptr;
+      }
+      return renderer;
+    }
+
+    [[nodiscard]] bool verifyOpenDevices(std::string_view context) {
+      return !m_policyActive
+          || !m_config.hasExclusions()
+          || (activePolicyStillAllowed(context) && verifyNoExcludedDeviceIsOpen(context));
+    }
+
+    void markStarted() { m_started = true; }
+
+  private:
+    struct DrmBackendRecord {
+      Impl* owner = nullptr;
+      wlr_backend* backend = nullptr;
+      DrmDeviceIdentity identity;
+      wl_listener destroy{};
+    };
+
+    struct PathStatus {
+      PathResolutionKind kind = PathResolutionKind::Missing;
+      bool initialized = false;
+      std::string error;
+    };
+
+    [[nodiscard]] bool initializeAutomatic() {
+      if (!m_policyActive) {
+        m_backend = wlr_backend_autocreate(m_loop, &m_session);
+        return m_backend != nullptr;
+      }
+
+      logEnvironmentPrecedence();
+      ScopedEnvironmentUnset renderDevice("WLR_RENDER_DRM_DEVICE");
+      if (!renderDevice.ok()) {
+        return false;
+      }
+      m_backend = wlr_backend_autocreate(m_loop, &m_session);
+      return m_backend != nullptr;
+    }
+
+    [[nodiscard]] bool initializeFiltered(bool createLibinput, bool libinputBeforeDrm, bool allowMissingLibinput) {
+      logEnvironmentPrecedence();
+      ScopedEnvironmentUnset drmDevices("WLR_DRM_DEVICES");
+      ScopedEnvironmentUnset renderDevice("WLR_RENDER_DRM_DEVICE");
+      if (!drmDevices.ok() || !renderDevice.ok()) {
+        return false;
+      }
+      m_backend = wlr_multi_backend_create(m_loop);
+      if (m_backend == nullptr) {
+        kLog.error("failed to create the filtered multi-backend");
+        return false;
+      }
+
+      m_session = wlr_session_create(m_loop);
+      m_ownsSession = true;
+      if (m_session == nullptr) {
+        kLog.error("failed to create a native session");
+        return false;
+      }
+      connectSessionListeners();
+      if (!waitForActiveSession()) {
+        return false;
+      }
+      if (!refreshIgnoredPaths(true)) {
+        return false;
+      }
+      if (createLibinput && libinputBeforeDrm && !createLibinputBackend(allowMissingLibinput)) {
+        return false;
+      }
+
+      auto candidates = enumerateDrmCards();
+      if (!candidates) {
+        return false;
+      }
+      if (candidates->empty()) {
+        kLog.info("waiting up to 10 seconds for a DRM card");
+        if (!waitForDrmCard()) {
+          return false;
+        }
+        candidates = enumerateDrmCards();
+        if (!candidates) {
+          return false;
+        }
+      }
+      if (candidates->empty()) {
+        kLog.error("no DRM cards were found for seat {}", m_session->seat);
+        return false;
+      }
+
+      for (unsigned int attempt = 0; attempt < 2 && m_primary == nullptr; ++attempt) {
+        if (const size_t learned = learnDrmPathSelectorIdentities(m_ignoredPaths, *candidates); learned > 0) {
+          kLog.info("learned {} missing ignored DRM selector identity from udev links", learned);
+        }
+        const auto allowed = allowedDrmDeviceIndices(*candidates, m_ignoredPaths, m_config.ignoredPciAddresses);
+        logExcludedCandidates(*candidates);
+        if (allowed.empty()) {
+          kLog.error("all DRM cards on seat {} are excluded", m_session->seat);
+          return false;
+        }
+
+        for (const size_t index : allowed) {
+          (void)openCandidate((*candidates)[index]);
+        }
+        if (m_primary == nullptr && attempt == 0) {
+          kLog.warn("no allowed DRM card initialized; retrying once from a fresh udev enumeration");
+          if (!refreshIgnoredPaths(true)) {
+            return false;
+          }
+          candidates = enumerateDrmCards();
+          if (!candidates || candidates->empty()) {
+            break;
+          }
+        }
+      }
+      if (m_primary == nullptr) {
+        kLog.error("could not create a backend on any allowed DRM card");
+        return false;
+      }
+      if (createLibinput && !libinputBeforeDrm && !createLibinputBackend(allowMissingLibinput)) {
+        return false;
+      }
+
+      m_initializing = false;
+      if (m_reconcilePending && !reconcile()) {
+        scheduleRetry();
+      }
+      return true;
+    }
+
+    void logEnvironmentPrecedence() const {
+      if (m_config.hasExclusions() && std::getenv("WLR_DRM_DEVICES") != nullptr) {
+        kLog.warn("ignoring inherited WLR_DRM_DEVICES because DRM exclusions are configured");
+      }
+      if (std::getenv("WLR_RENDER_DRM_DEVICE") != nullptr) {
+        kLog.warn("ignoring inherited WLR_RENDER_DRM_DEVICE because [drm] is configured");
+      }
+    }
+
+    [[nodiscard]] bool waitForActiveSession() {
+      if (m_session->active) {
+        return true;
+      }
+      kLog.info("waiting up to 10 seconds for the native session to become active");
+      const auto deadline = std::chrono::steady_clock::now() + kDeviceWaitTimeout;
+      while (m_session != nullptr && !m_session->active) {
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+        if (remaining.count() <= 0) {
+          break;
+        }
+        if (wl_event_loop_dispatch(m_loop, static_cast<int>(remaining.count())) < 0) {
+          kLog.error("failed while waiting for the session: {}", std::strerror(errno));
+          return false;
+        }
+      }
+      if (m_session == nullptr || !m_session->active) {
+        kLog.error("timed out waiting for the native session");
+        return false;
+      }
+      return true;
+    }
+
+    [[nodiscard]] bool waitForDrmCard() {
+      m_addSeen = false;
+      const auto deadline = std::chrono::steady_clock::now() + kDeviceWaitTimeout;
+      while (m_session != nullptr && !m_addSeen) {
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+        if (remaining.count() <= 0) {
+          break;
+        }
+        if (wl_event_loop_dispatch(m_loop, static_cast<int>(remaining.count())) < 0) {
+          kLog.error("failed while waiting for a DRM card: {}", std::strerror(errno));
+          return false;
+        }
+      }
+      return m_session != nullptr;
+    }
+
+    [[nodiscard]] bool createLibinputBackend(bool allowMissing) {
+      wlr_backend* backend = wlr_libinput_backend_create(m_session);
+      if (backend == nullptr) {
+        if (allowMissing && environmentFlagEnabled("WLR_LIBINPUT_NO_DEVICES")) {
+          kLog.info("starting without libinput because WLR_LIBINPUT_NO_DEVICES=1");
+          return true;
+        }
+        kLog.error("failed to create the libinput backend");
+        return false;
+      }
+      if (!wlr_multi_backend_add(m_backend, backend)) {
+        kLog.error("failed to add libinput to the multi-backend");
+        wlr_backend_destroy(backend);
+        return false;
+      }
+      m_libinputDestroy.notify = onLibinputDestroy;
+      wl_signal_add(&backend->events.destroy, &m_libinputDestroy);
+      return true;
+    }
+
+    [[nodiscard]] std::optional<std::vector<DrmDeviceIdentity>> enumerateDrmCards() const {
+      UdevEnumerate enumerate(udev_enumerate_new(m_session->udev));
+      if (!enumerate) {
+        kLog.error("failed to allocate a udev DRM enumeration");
+        return std::nullopt;
+      }
+      udev_enumerate_add_match_subsystem(enumerate.get(), "drm");
+      udev_enumerate_add_match_sysname(enumerate.get(), "card[0-9]*");
+      if (udev_enumerate_scan_devices(enumerate.get()) != 0) {
+        kLog.error("failed to enumerate DRM cards through udev");
+        return std::nullopt;
+      }
+
+      std::vector<DrmDeviceIdentity> candidates;
+      for (udev_list_entry* entry = udev_enumerate_get_list_entry(enumerate.get()); entry != nullptr;
+           entry = udev_list_entry_get_next(entry)) {
+        const char* syspath = udev_list_entry_get_name(entry);
+        if (syspath == nullptr) {
+          continue;
+        }
+        UdevDevice device(udev_device_new_from_syspath(m_session->udev, syspath));
+        if (!device) {
+          continue;
+        }
+        const char* seat = udev_device_get_property_value(device.get(), "ID_SEAT");
+        seat = seat == nullptr ? "seat0" : seat;
+        if (m_session->seat[0] != '\0' && std::string_view(m_session->seat) != seat) {
+          continue;
+        }
+        auto identity = identityFromUdev(device.get());
+        if (!identity || identity->node.empty()) {
+          continue;
+        }
+
+        bool bootDisplay = false;
+        if (const char* value = udev_device_get_sysattr_value(device.get(), "boot_display")) {
+          bootDisplay = std::string_view(value) == "1";
+        }
+        if (!bootDisplay) {
+          udev_device* pci = udev_device_get_parent_with_subsystem_devtype(device.get(), "pci", nullptr);
+          if (pci != nullptr) {
+            if (const char* value = udev_device_get_sysattr_value(pci, "boot_vga")) {
+              bootDisplay = std::string_view(value) == "1";
+            }
+          }
+        }
+        candidates.push_back(std::move(*identity));
+        if (bootDisplay) {
+          // Match wlr_session_find_gpus(): retain udev enumeration order, but
+          // move the boot display to the first slot.
+          std::swap(candidates.front(), candidates.back());
+        }
+      }
+      return candidates;
+    }
+
+    void logExcludedCandidates(const std::vector<DrmDeviceIdentity>& candidates) const {
+      for (const DrmDeviceIdentity& candidate : candidates) {
+        const DrmExclusionMatch match = drmExclusionMatch(candidate, m_ignoredPaths, m_config.ignoredPciAddresses);
+        if (match != DrmExclusionMatch::None) {
+          kLog.info("excluding {} before open (matched {})", candidate.node, exclusionMatchName(match));
+        }
+      }
+    }
+
+    [[nodiscard]] bool refreshIgnoredPaths(bool initial) {
+      bool valid = true;
+      for (size_t index = 0; index < m_ignoredPaths.size(); ++index) {
+        DrmPathSelectorIdentity& selector = m_ignoredPaths[index];
+        PathStatus& previous = m_pathStatuses[index];
+        PathResolution resolution = resolveDrmPath(m_session->udev, selector.path);
+
+        const bool changed =
+            !previous.initialized || previous.kind != resolution.kind || previous.error != resolution.error;
+        if (resolution.kind == PathResolutionKind::Resolved) {
+          selector.device = resolution.identity->device;
+          selector.physicalDevice = resolution.identity->physicalDevice;
+          selector.pciAddress = resolution.identity->pciAddress;
+          if (changed) {
+            kLog.info("resolved ignored DRM selector {}", selector.path);
+          }
+        } else {
+          selector.device.reset();
+          if (resolution.kind == PathResolutionKind::Missing) {
+            if (changed) {
+              kLog.warn("ignored DRM selector {} is missing; it remains armed", selector.path);
+            }
+          } else {
+            valid = false;
+            if (changed) {
+              kLog.error("ignored DRM selector {} is invalid: {}", selector.path, resolution.error);
+            }
+          }
+        }
+        previous = {.kind = resolution.kind, .initialized = true, .error = std::move(resolution.error)};
+      }
+      if (!valid && !initial) {
+        kLog.error("not opening new DRM cards until every ignored path is valid or missing");
+      }
+      return valid;
+    }
+
+    [[nodiscard]] bool openCandidate(const DrmDeviceIdentity& candidate) {
+      if (!refreshIgnoredPaths(m_initializing)) {
+        return false;
+      }
+      struct stat preOpenStat{};
+      if (stat(candidate.node.c_str(), &preOpenStat) != 0 || !S_ISCHR(preOpenStat.st_mode)) {
+        kLog.warn("allowed DRM card {} disappeared before open", candidate.node);
+        return false;
+      }
+      if (preOpenStat.st_rdev != candidate.device) {
+        kLog.warn("allowed DRM card {} was re-enumerated before open; deferring it", candidate.node);
+        return false;
+      }
+      auto identity = identityFromDevnum(m_session->udev, preOpenStat.st_rdev, candidate.node);
+      if (!identity) {
+        kLog.warn("allowed DRM card {} no longer has a valid udev identity", candidate.node);
+        return false;
+      }
+      const DrmExclusionMatch preOpenMatch = drmExclusionMatch(*identity, m_ignoredPaths, m_config.ignoredPciAddresses);
+      if (preOpenMatch != DrmExclusionMatch::None) {
+        kLog.info(
+            "excluding {} at the final pre-open check (matched {})", candidate.node, exclusionMatchName(preOpenMatch)
+        );
+        return true;
+      }
+
+      wlr_device* device = wlr_session_open_file(m_session, identity->node.c_str());
+      if (device == nullptr) {
+        kLog.warn("failed to open allowed DRM card {}", identity->node);
+        return false;
+      }
+      if (device->dev != identity->device) {
+        kLog.warn("DRM card {} changed identity while opening; deferring it", identity->node);
+        wlr_session_close_file(m_session, device);
+        return false;
+      }
+      // Resolve selectors again after the privileged open. A by-path symlink
+      // can be retargeted between the pre-open check and libseat opening the
+      // card; the opened identity must be checked against that newest state.
+      if (!refreshIgnoredPaths(m_initializing)) {
+        wlr_session_close_file(m_session, device);
+        return false;
+      }
+      auto openedIdentity = identityFromDevnum(m_session->udev, device->dev, identity->node);
+      if (!openedIdentity
+          || drmExclusionMatch(*openedIdentity, m_ignoredPaths, m_config.ignoredPciAddresses)
+              != DrmExclusionMatch::None) {
+        kLog.error("DRM card {} became excluded while opening; closing it without creating a backend", identity->node);
+        wlr_session_close_file(m_session, device);
+        return true;
+      }
+      if (drmIsKMS(device->fd) == 0) {
+        kLog.warn("allowed DRM node {} is not KMS-capable", identity->node);
+        wlr_session_close_file(m_session, device);
+        return false;
+      }
+
+      const bool primary = m_primary == nullptr;
+      // A parent makes wlroots create an internal multi-GPU renderer through
+      // EGL device enumeration. Independent backends keep exclusions strict;
+      // secondary outputs import the compositor's DMA-BUFs directly instead.
+      wlr_backend* drm = wlr_drm_backend_create(m_session, device, nullptr);
+      if (drm == nullptr) {
+        closeDeviceIfOwned(device);
+        kLog.warn("failed to create a DRM backend for {}", identity->node);
+        return false;
+      }
+      if (!wlr_multi_backend_add(m_backend, drm)) {
+        kLog.warn("failed to add {} to the multi-backend", identity->node);
+        wlr_backend_destroy(drm);
+        return false;
+      }
+
+      auto record = std::make_unique<DrmBackendRecord>();
+      record->owner = this;
+      record->backend = drm;
+      record->identity = std::move(*openedIdentity);
+      record->destroy.notify = onDrmBackendDestroy;
+      wl_signal_add(&drm->events.destroy, &record->destroy);
+      if (primary) {
+        m_primary = drm;
+        kLog.info("selected {} as the primary DRM card", identity->node);
+      } else {
+        kLog.info("added allowed secondary DRM card {}", identity->node);
+      }
+      m_drmBackends.push_back(std::move(record));
+
+      if (m_started && !wlr_backend_start(drm)) {
+        kLog.warn("failed to start hotplugged DRM card {}", identity->node);
+        wlr_multi_backend_remove(m_backend, drm);
+        wlr_backend_destroy(drm);
+        return false;
+      }
+      return true;
+    }
+
+    void closeDeviceIfOwned(wlr_device* candidate) const {
+      wlr_device* device = nullptr;
+      wl_list_for_each(device, &m_session->devices, link) {
+        if (device == candidate) {
+          wlr_session_close_file(m_session, device);
+          return;
+        }
+      }
+    }
+
+    [[nodiscard]] bool activePolicyStillAllowed(std::string_view context) {
+      if (m_session == nullptr) {
+        kLog.error("native session is unavailable {}", context);
+        return false;
+      }
+      if (!refreshIgnoredPaths(false)) {
+        return false;
+      }
+      std::vector<DrmDeviceIdentity> identities;
+      identities.reserve(m_drmBackends.size());
+      for (const auto& record : m_drmBackends) {
+        identities.push_back(record->identity);
+      }
+      (void)learnDrmPathSelectorIdentities(m_ignoredPaths, identities);
+
+      for (const auto& record : m_drmBackends) {
+        if (drmExclusionMatch(record->identity, m_ignoredPaths, m_config.ignoredPciAddresses)
+            != DrmExclusionMatch::None) {
+          kLog.error(
+              "{} DRM card {} is excluded {}", record->backend == m_primary ? "primary" : "secondary",
+              record->identity.node, context
+          );
+          return false;
+        }
+      }
+      if (m_rendererDevice
+          && drmExclusionMatch(*m_rendererDevice, m_ignoredPaths, m_config.ignoredPciAddresses)
+              != DrmExclusionMatch::None) {
+        kLog.error("renderer DRM device {} is excluded {}", m_rendererDevice->node, context);
+        return false;
+      }
+      return true;
+    }
+
+    [[nodiscard]] bool reconcile() {
+      m_reconcilePending = false;
+      if (m_session == nullptr || !m_session->active || m_primary == nullptr) {
+        return m_primary != nullptr;
+      }
+
+      const bool selectorsValid = refreshIgnoredPaths(false);
+      auto candidates = enumerateDrmCards();
+      if (!candidates) {
+        return false;
+      }
+      (void)learnDrmPathSelectorIdentities(m_ignoredPaths, *candidates);
+
+      std::vector<DrmActiveDevice> active;
+      active.reserve(m_drmBackends.size());
+      for (const auto& record : m_drmBackends) {
+        active.push_back({.identity = record->identity, .primary = record->backend == m_primary});
+      }
+      const DrmReconcilePlan plan = planDrmReconciliation(
+          active, m_rendererDevice, *candidates, m_ignoredPaths, m_config.ignoredPciAddresses, selectorsValid
+      );
+      if (plan.termination == DrmReconcileTermination::RendererExcluded) {
+        kLog.error("the active renderer GPU is now excluded; terminating the session");
+        wl_display_terminate(m_display);
+        return true;
+      }
+      if (plan.termination == DrmReconcileTermination::PrimaryExcluded) {
+        kLog.error("the primary DRM card is now excluded; terminating the session");
+        wl_display_terminate(m_display);
+        return true;
+      }
+
+      std::vector<wlr_backend*> remove;
+      remove.reserve(plan.removeActiveIndices.size());
+      for (const size_t index : plan.removeActiveIndices) {
+        remove.push_back(m_drmBackends[index]->backend);
+      }
+      for (wlr_backend* backend : remove) {
+        kLog.warn("removing a secondary DRM backend that is now excluded");
+        wlr_multi_backend_remove(m_backend, backend);
+        wlr_backend_destroy(backend);
+      }
+
+      bool success = true;
+      for (const size_t index : plan.addCandidateIndices) {
+        success = openCandidate((*candidates)[index]) && success;
+      }
+      return selectorsValid && success;
+    }
+
+    void requestReconcile() {
+      if (m_initializing) {
+        m_reconcilePending = true;
+        return;
+      }
+      if (m_retrySource != nullptr) {
+        wl_event_source_remove(m_retrySource);
+        m_retrySource = nullptr;
+      }
+      if (m_reconciling) {
+        m_reconcilePending = true;
+        return;
+      }
+      m_reconciling = true;
+      bool success = true;
+      do {
+        success = reconcile() && success;
+      } while (m_reconcilePending);
+      m_reconciling = false;
+      if (!success) {
+        scheduleRetry();
+      }
+    }
+
+    void scheduleRetry() {
+      if (m_retrySource != nullptr || m_destroying) {
+        return;
+      }
+      m_retrySource = wl_event_loop_add_idle(m_loop, onRetry, this);
+      if (m_retrySource == nullptr) {
+        kLog.warn("failed to schedule one DRM reconciliation retry");
+      }
+    }
+
+    [[nodiscard]] wlr_renderer* createConfiguredRenderer(const std::string& path) {
+      if (!refreshIgnoredPaths(false)) {
+        kLog.warn("cannot safely use configured renderer while an ignored path is invalid");
+        return nullptr;
+      }
+      PathResolution resolved = resolveDrmPath(m_session == nullptr ? nullptr : m_session->udev, path);
+      if (resolved.kind == PathResolutionKind::Missing) {
+        kLog.warn("configured DRM render device {} is missing", path);
+        return nullptr;
+      }
+      if (resolved.kind == PathResolutionKind::Invalid) {
+        kLog.warn("configured DRM render device {} is invalid: {}", path, resolved.error);
+        return nullptr;
+      }
+      if (drmExclusionMatch(*resolved.identity, m_ignoredPaths, m_config.ignoredPciAddresses)
+          != DrmExclusionMatch::None) {
+        kLog.warn("configured DRM render device {} belongs to an excluded GPU", path);
+        return nullptr;
+      }
+
+      UniqueFd fd(open(path.c_str(), O_RDWR | O_CLOEXEC));
+      if (fd.get() < 0) {
+        kLog.warn("failed to open configured DRM render device {}: {}", path, std::strerror(errno));
+        return nullptr;
+      }
+      struct stat statBuffer{};
+      if (fstat(fd.get(), &statBuffer) != 0 || !S_ISCHR(statBuffer.st_mode)) {
+        kLog.warn("configured DRM render device {} changed while opening", path);
+        return nullptr;
+      }
+      if (statBuffer.st_rdev != resolved.identity->device) {
+        kLog.warn("configured DRM render device {} was retargeted while opening", path);
+        return nullptr;
+      }
+      if (!refreshIgnoredPaths(false)) {
+        kLog.warn("cannot safely use configured renderer while an ignored path is invalid");
+        return nullptr;
+      }
+      auto openedIdentity = identityFromDevnum(m_session->udev, statBuffer.st_rdev, path);
+      if (!openedIdentity || drmGetNodeTypeFromFd(fd.get()) != DRM_NODE_RENDER) {
+        kLog.warn("configured DRM render device {} is not a render node", path);
+        return nullptr;
+      }
+      if (m_session->seat[0] != '\0' && openedIdentity->seat != m_session->seat) {
+        kLog.warn(
+            "configured DRM render device {} belongs to seat {}, not {}", path, openedIdentity->seat, m_session->seat
+        );
+        return nullptr;
+      }
+      if (drmExclusionMatch(*openedIdentity, m_ignoredPaths, m_config.ignoredPciAddresses) != DrmExclusionMatch::None) {
+        kLog.warn("configured DRM render device {} resolved to an excluded GPU", path);
+        return nullptr;
+      }
+
+      wlr_renderer* renderer = m_config.hasExclusions() ? fx_renderer_create_with_drm_fd_gbm(fd.get())
+                                                        : fx_renderer_create_with_drm_fd(fd.get());
+      if (renderer == nullptr) {
+        kLog.warn("failed to initialize the renderer on {}", path);
+        return nullptr;
+      }
+      auto rendererDevice = rendererIdentity(renderer);
+      if (!rendererDevice || !sameDrmPhysicalDevice(*openedIdentity, *rendererDevice)) {
+        kLog.error("renderer initialized on a different DRM device than {}", path);
+        wlr_renderer_destroy(renderer);
+        return nullptr;
+      }
+      m_rendererDevice = std::move(*rendererDevice);
+      kLog.info("using configured DRM render device {}", path);
+      return renderer;
+    }
+
+    [[nodiscard]] wlr_renderer* createPrimaryRenderer() {
+      if (m_primary == nullptr) {
+        kLog.error("cannot create an exclusion-safe renderer without a primary DRM backend");
+        return nullptr;
+      }
+      const int fd = wlr_backend_get_drm_fd(m_primary);
+      if (fd < 0) {
+        kLog.error("the primary DRM backend did not expose a renderer device");
+        return nullptr;
+      }
+      wlr_renderer* renderer = fx_renderer_create_with_drm_fd_gbm(fd);
+      if (renderer == nullptr) {
+        return nullptr;
+      }
+
+      const auto primary =
+          std::ranges::find_if(m_drmBackends, [&](const auto& record) { return record->backend == m_primary; });
+      auto rendererDevice = rendererIdentity(renderer);
+      if (primary == m_drmBackends.end()
+          || !rendererDevice
+          || !sameDrmPhysicalDevice((*primary)->identity, *rendererDevice)) {
+        kLog.error("renderer did not initialize on the primary DRM device");
+        wlr_renderer_destroy(renderer);
+        return nullptr;
+      }
+      m_rendererDevice = std::move(*rendererDevice);
+      return renderer;
+    }
+
+    [[nodiscard]] wlr_renderer* createBackendRenderer() const {
+      const int fd = wlr_backend_get_drm_fd(m_backend);
+      if (fd >= 0) {
+        return fx_renderer_create_with_drm_fd(fd);
+      }
+
+      // A native backend normally exposes its DRM FD. Preserve umbrielfx's
+      // fallback for unusual mixed backends without letting an inherited
+      // renderer override take precedence over [drm].
+      ScopedEnvironmentUnset renderDevice("WLR_RENDER_DRM_DEVICE");
+      return renderDevice.ok() ? fx_renderer_create(m_backend) : nullptr;
+    }
+
+    [[nodiscard]] bool verifyNoExcludedDeviceIsOpen(std::string_view context) const {
+      std::error_code error;
+      std::filesystem::directory_iterator descriptor("/proc/self/fd", error);
+      if (error) {
+        kLog.error("cannot inspect open devices {}: {}", context, error.message());
+        return false;
+      }
+
+      const auto nvidiaPciByDevice = nvidiaPciDevices();
+      if (!nvidiaPciByDevice) {
+        return false;
+      }
+      const std::filesystem::directory_iterator end;
+      while (descriptor != end) {
+        struct stat statBuffer{};
+        if (stat(descriptor->path().c_str(), &statBuffer) == 0 && S_ISCHR(statBuffer.st_mode)) {
+          std::error_code targetError;
+          const std::filesystem::path target = std::filesystem::read_symlink(descriptor->path(), targetError);
+          const std::string fallbackNode = targetError ? descriptor->path().string() : target.string();
+          auto identity = physicalIdentityFromDevnum(m_session->udev, statBuffer.st_rdev, fallbackNode);
+          if (identity) {
+            if (!identity->pciAddress) {
+              const auto nvidia = std::ranges::find_if(*nvidiaPciByDevice, [&](const auto& device) {
+                return device.first == statBuffer.st_rdev;
+              });
+              if (nvidia != nvidiaPciByDevice->end()) {
+                identity->pciAddress = nvidia->second;
+              } else if (isNvidiaGpuDeviceNode(identity->node)) {
+                kLog.error(
+                    "cannot attribute open NVIDIA GPU device {} {} because its PCI metadata is unavailable",
+                    identity->node, context
+                );
+                return false;
+              }
+            }
+            const DrmExclusionMatch match = drmExclusionMatch(*identity, m_ignoredPaths, m_config.ignoredPciAddresses);
+            if (match != DrmExclusionMatch::None) {
+              kLog.error(
+                  "excluded device {} is open {} (matched {})", identity->node, context, exclusionMatchName(match)
+              );
+              return false;
+            }
+          }
+        }
+        descriptor.increment(error);
+        if (error) {
+          kLog.error("cannot continue inspecting open devices {}: {}", context, error.message());
+          return false;
+        }
+      }
+      return true;
+    }
+
+    [[nodiscard]] std::optional<DrmDeviceIdentity> rendererIdentity(wlr_renderer* renderer) const {
+      if (m_session == nullptr) {
+        return std::nullopt;
+      }
+      const int fd = wlr_renderer_get_drm_fd(renderer);
+      if (fd < 0) {
+        return std::nullopt;
+      }
+      struct stat statBuffer{};
+      if (fstat(fd, &statBuffer) != 0 || !S_ISCHR(statBuffer.st_mode)) {
+        return std::nullopt;
+      }
+      return identityFromDevnum(m_session->udev, statBuffer.st_rdev);
+    }
+
+    void connectSessionListeners() {
+      m_sessionAdd.notify = onSessionAdd;
+      wl_signal_add(&m_session->events.add_drm_card, &m_sessionAdd);
+      m_sessionActive.notify = onSessionActive;
+      wl_signal_add(&m_session->events.active, &m_sessionActive);
+      m_sessionDestroy.notify = onSessionDestroy;
+      wl_signal_add(&m_session->events.destroy, &m_sessionDestroy);
+    }
+
+    void disconnectSessionListeners() {
+      disconnectListener(m_sessionAdd);
+      disconnectListener(m_sessionActive);
+      disconnectListener(m_sessionDestroy);
+    }
+
+    static void onSessionAdd(wl_listener* listener, void* /*data*/) {
+      Impl* self;
+      self = wl_container_of(listener, self, m_sessionAdd);
+      self->m_addSeen = true;
+      self->requestReconcile();
+    }
+
+    static void onSessionActive(wl_listener* listener, void* /*data*/) {
+      Impl* self;
+      self = wl_container_of(listener, self, m_sessionActive);
+      if (self->m_session != nullptr && self->m_session->active) {
+        self->requestReconcile();
+      }
+    }
+
+    static void onSessionDestroy(wl_listener* listener, void* /*data*/) {
+      Impl* self;
+      self = wl_container_of(listener, self, m_sessionDestroy);
+      self->disconnectSessionListeners();
+      self->m_session = nullptr;
+      self->m_ownsSession = false;
+      if (!self->m_destroying) {
+        kLog.error("native session was lost; terminating Umbriel");
+        wl_display_terminate(self->m_display);
+      }
+    }
+
+    static void onLibinputDestroy(wl_listener* listener, void* /*data*/) {
+      Impl* self;
+      self = wl_container_of(listener, self, m_libinputDestroy);
+      disconnectListener(self->m_libinputDestroy);
+      if (!self->m_destroying) {
+        kLog.error("libinput backend was lost; terminating Umbriel");
+        wl_display_terminate(self->m_display);
+      }
+    }
+
+    static void onDrmBackendDestroy(wl_listener* listener, void* /*data*/) {
+      DrmBackendRecord* record;
+      record = wl_container_of(listener, record, destroy);
+      Impl* self = record->owner;
+      const bool primary = record->backend == self->m_primary;
+      disconnectListener(record->destroy);
+      if (primary) {
+        self->m_primary = nullptr;
+      }
+      const auto position =
+          std::ranges::find_if(self->m_drmBackends, [&](const auto& candidate) { return candidate.get() == record; });
+      if (position != self->m_drmBackends.end()) {
+        self->m_drmBackends.erase(position);
+      }
+      if (primary && !self->m_destroying) {
+        kLog.error("primary DRM backend was lost; terminating Umbriel");
+        wl_display_terminate(self->m_display);
+      } else if (!primary && !self->m_destroying) {
+        kLog.info("secondary DRM backend was removed");
+      }
+    }
+
+    static void onRetry(void* data) {
+      auto* self = static_cast<Impl*>(data);
+      self->m_retrySource = nullptr;
+      if (self->m_destroying) {
+        return;
+      }
+      self->m_reconciling = true;
+      do {
+        (void)self->reconcile();
+      } while (self->m_reconcilePending);
+      self->m_reconciling = false;
+    }
+
+    wl_display* m_display = nullptr;
+    wl_event_loop* m_loop = nullptr;
+    Config::Drm m_config;
+    bool m_policyActive = false;
+    bool m_ownsSession = false;
+    bool m_initializing = true;
+    bool m_started = false;
+    bool m_destroying = false;
+    bool m_addSeen = false;
+    bool m_reconcilePending = false;
+    bool m_reconciling = false;
+    wlr_backend* m_backend = nullptr;
+    wlr_backend* m_primary = nullptr;
+    wlr_session* m_session = nullptr;
+    wl_event_source* m_retrySource = nullptr;
+    std::vector<DrmPathSelectorIdentity> m_ignoredPaths;
+    std::vector<PathStatus> m_pathStatuses;
+    std::vector<std::unique_ptr<DrmBackendRecord>> m_drmBackends;
+    std::optional<DrmDeviceIdentity> m_rendererDevice;
+    wl_listener m_sessionAdd{};
+    wl_listener m_sessionActive{};
+    wl_listener m_sessionDestroy{};
+    wl_listener m_libinputDestroy{};
+  };
+
+  std::unique_ptr<BackendManager> BackendManager::create(wl_display* display, const Config::Drm& config) {
+    if (display == nullptr) {
+      return nullptr;
+    }
+    auto impl = std::make_unique<Impl>(display, config);
+    if (!impl->initialize()) {
+      return nullptr;
+    }
+    return std::unique_ptr<BackendManager>(new BackendManager(std::move(impl)));
+  }
+
+  BackendManager::BackendManager(std::unique_ptr<Impl> impl) : m_impl(std::move(impl)) {}
+  BackendManager::~BackendManager() = default;
+
+  wlr_backend* BackendManager::backend() const { return m_impl->backend(); }
+  wlr_session* BackendManager::session() const { return m_impl->session(); }
+  wlr_renderer* BackendManager::createRenderer() { return m_impl->createRenderer(); }
+  bool BackendManager::verifyOpenDevices(std::string_view context) { return m_impl->verifyOpenDevices(context); }
+  void BackendManager::markStarted() { m_impl->markStarted(); }
+
+} // namespace umbriel

--- a/src/server/backend_manager.h
+++ b/src/server/backend_manager.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "config/config.h"
+
+#include <memory>
+#include <string_view>
+
+struct wl_display;
+struct wlr_backend;
+struct wlr_renderer;
+struct wlr_session;
+
+namespace umbriel {
+
+  // Owns backend selection and the immutable DRM policy captured at startup.
+  // Server only needs the resulting wlroots objects and one renderer factory;
+  // filtering, hotplug, environment precedence, and cleanup stay here.
+  class BackendManager {
+  public:
+    [[nodiscard]] static std::unique_ptr<BackendManager> create(wl_display* display, const Config::Drm& config);
+    ~BackendManager();
+
+    BackendManager(const BackendManager&) = delete;
+    BackendManager& operator=(const BackendManager&) = delete;
+
+    [[nodiscard]] wlr_backend* backend() const;
+    [[nodiscard]] wlr_session* session() const;
+    [[nodiscard]] wlr_renderer* createRenderer();
+    [[nodiscard]] bool verifyOpenDevices(std::string_view context);
+    void markStarted();
+
+  private:
+    class Impl;
+    explicit BackendManager(std::unique_ptr<Impl> impl);
+
+    std::unique_ptr<Impl> m_impl;
+  };
+
+} // namespace umbriel

--- a/src/server/drm_policy.cpp
+++ b/src/server/drm_policy.cpp
@@ -1,0 +1,231 @@
+#include "server/drm_policy.h"
+
+#include <algorithm>
+#include <charconv>
+
+namespace umbriel {
+
+  namespace {
+    std::vector<std::string_view> backendNames(std::string_view configured) {
+      std::vector<std::string_view> names;
+      size_t offset = 0;
+      while (offset < configured.size()) {
+        offset = configured.find_first_not_of(',', offset);
+        if (offset == std::string_view::npos) {
+          break;
+        }
+        const size_t separator = configured.find(',', offset);
+        names.push_back(configured.substr(offset, separator - offset));
+        if (separator == std::string_view::npos) {
+          break;
+        }
+        offset = separator + 1;
+      }
+      return names;
+    }
+  } // namespace
+
+  bool sameDrmPhysicalDevice(const DrmDeviceIdentity& first, const DrmDeviceIdentity& second) {
+    if (first.pciAddress && second.pciAddress) {
+      return first.pciAddress == second.pciAddress;
+    }
+    if (!first.physicalDevice.empty() && !second.physicalDevice.empty()) {
+      return first.physicalDevice == second.physicalDevice;
+    }
+    return first.device == second.device;
+  }
+
+  DrmBackendEnvironment resolveDrmBackendEnvironment(
+      std::optional<std::string_view> wlrBackends, bool waylandDisplaySet, bool waylandSocketSet, bool x11DisplaySet
+  ) {
+    if (!wlrBackends) {
+      return {
+          .native = !waylandDisplaySet && !waylandSocketSet && !x11DisplaySet,
+          .exclusionsSupported = true,
+          .createLibinput = true,
+          .libinputBeforeDrm = true,
+          .allowMissingLibinput = true,
+      };
+    }
+
+    const auto names = backendNames(*wlrBackends);
+    const bool native = std::ranges::find(names, "drm") != names.end();
+    bool drmSeen = false;
+    bool libinputSeen = false;
+    bool libinputBeforeDrm = false;
+    bool supported = native;
+    for (const std::string_view name : names) {
+      if (name == "drm" && !drmSeen) {
+        drmSeen = true;
+      } else if (name == "libinput" && !libinputSeen) {
+        libinputSeen = true;
+        libinputBeforeDrm = !drmSeen;
+      } else {
+        supported = false;
+      }
+    }
+    return {
+        .native = native,
+        .exclusionsSupported = supported,
+        .createLibinput = libinputSeen,
+        .libinputBeforeDrm = libinputBeforeDrm,
+        .allowMissingLibinput = false,
+    };
+  }
+
+  DrmExclusionMatch drmExclusionMatch(
+      const DrmDeviceIdentity& device, std::span<const DrmPathSelectorIdentity> paths,
+      std::span<const std::string> pciAddresses
+  ) {
+    if (device.pciAddress && std::ranges::find(pciAddresses, *device.pciAddress) != pciAddresses.end()) {
+      return DrmExclusionMatch::PciAddress;
+    }
+
+    for (const DrmPathSelectorIdentity& selector : paths) {
+      if (device.node == selector.path || std::ranges::find(device.devlinks, selector.path) != device.devlinks.end()) {
+        return DrmExclusionMatch::Path;
+      }
+      if (selector.device && device.device == *selector.device) {
+        return DrmExclusionMatch::DeviceNumber;
+      }
+      if (!selector.physicalDevice.empty() && device.physicalDevice == selector.physicalDevice) {
+        return DrmExclusionMatch::PhysicalDevice;
+      }
+      if (selector.pciAddress && device.pciAddress == selector.pciAddress) {
+        return DrmExclusionMatch::PciAddress;
+      }
+    }
+    return DrmExclusionMatch::None;
+  }
+
+  size_t
+  learnDrmPathSelectorIdentities(std::span<DrmPathSelectorIdentity> paths, std::span<const DrmDeviceIdentity> devices) {
+    size_t learned = 0;
+    for (DrmPathSelectorIdentity& selector : paths) {
+      if (selector.device) {
+        continue;
+      }
+      const auto device = std::ranges::find_if(devices, [&](const DrmDeviceIdentity& candidate) {
+        return candidate.node == selector.path
+            || std::ranges::find(candidate.devlinks, selector.path) != candidate.devlinks.end();
+      });
+      if (device == devices.end()) {
+        continue;
+      }
+      selector.device = device->device;
+      selector.physicalDevice = device->physicalDevice;
+      selector.pciAddress = device->pciAddress;
+      ++learned;
+    }
+    return learned;
+  }
+
+  std::vector<size_t> allowedDrmDeviceIndices(
+      std::span<const DrmDeviceIdentity> devices, std::span<const DrmPathSelectorIdentity> paths,
+      std::span<const std::string> pciAddresses
+  ) {
+    std::vector<size_t> allowed;
+    allowed.reserve(devices.size());
+    for (size_t index = 0; index < devices.size(); ++index) {
+      if (drmExclusionMatch(devices[index], paths, pciAddresses) == DrmExclusionMatch::None) {
+        allowed.push_back(index);
+      }
+    }
+    return allowed;
+  }
+
+  std::optional<unsigned int> parseNvidiaDeviceMinor(std::string_view information) {
+    constexpr std::string_view prefix = "Device Minor:";
+    size_t offset = 0;
+    while (offset < information.size()) {
+      const size_t newline = information.find('\n', offset);
+      std::string_view line = information.substr(offset, newline - offset);
+      if (const size_t first = line.find_first_not_of(" \t"); first != std::string_view::npos) {
+        line.remove_prefix(first);
+      }
+      if (line.starts_with(prefix)) {
+        line.remove_prefix(prefix.size());
+        const size_t first = line.find_first_not_of(" \t");
+        if (first == std::string_view::npos) {
+          return std::nullopt;
+        }
+        line.remove_prefix(first);
+        const size_t last = line.find_last_not_of(" \t\r");
+        line = line.substr(0, last + 1);
+
+        unsigned int minorNumber = 0;
+        const auto [end, error] = std::from_chars(line.data(), line.data() + line.size(), minorNumber);
+        if (error != std::errc{} || end != line.data() + line.size()) {
+          return std::nullopt;
+        }
+        return minorNumber;
+      }
+      if (newline == std::string_view::npos) {
+        break;
+      }
+      offset = newline + 1;
+    }
+    return std::nullopt;
+  }
+
+  bool isNvidiaGpuDeviceNode(std::string_view node) {
+    constexpr std::string_view deletedSuffix = " (deleted)";
+    if (node.ends_with(deletedSuffix)) {
+      node.remove_suffix(deletedSuffix.size());
+    }
+    const size_t separator = node.find_last_of('/');
+    const std::string_view name = node.substr(separator == std::string_view::npos ? 0 : separator + 1);
+    constexpr std::string_view prefix = "nvidia";
+    if (!name.starts_with(prefix) || name.size() == prefix.size()) {
+      return false;
+    }
+    return std::ranges::all_of(name.substr(prefix.size()), [](char character) {
+      return character >= '0' && character <= '9';
+    });
+  }
+
+  DrmReconcilePlan planDrmReconciliation(
+      std::span<const DrmActiveDevice> active, const std::optional<DrmDeviceIdentity>& renderer,
+      std::span<const DrmDeviceIdentity> candidates, std::span<const DrmPathSelectorIdentity> paths,
+      std::span<const std::string> pciAddresses, bool selectorsValid
+  ) {
+    DrmReconcilePlan plan;
+    if (renderer && drmExclusionMatch(*renderer, paths, pciAddresses) != DrmExclusionMatch::None) {
+      plan.termination = DrmReconcileTermination::RendererExcluded;
+      return plan;
+    }
+
+    for (size_t index = 0; index < active.size(); ++index) {
+      const auto current = std::ranges::find_if(candidates, [&](const DrmDeviceIdentity& candidate) {
+        return sameDrmPhysicalDevice(active[index].identity, candidate);
+      });
+      const DrmDeviceIdentity& identity = current == candidates.end() ? active[index].identity : *current;
+      if (drmExclusionMatch(identity, paths, pciAddresses) == DrmExclusionMatch::None) {
+        continue;
+      }
+      if (active[index].primary) {
+        plan.termination = DrmReconcileTermination::PrimaryExcluded;
+        plan.removeActiveIndices.clear();
+        return plan;
+      }
+      plan.removeActiveIndices.push_back(index);
+    }
+
+    if (!selectorsValid) {
+      return plan;
+    }
+    for (size_t index = 0; index < candidates.size(); ++index) {
+      if (drmExclusionMatch(candidates[index], paths, pciAddresses) != DrmExclusionMatch::None) {
+        continue;
+      }
+      const bool alreadyActive = std::ranges::any_of(active, [&](const DrmActiveDevice& device) {
+        return sameDrmPhysicalDevice(device.identity, candidates[index]);
+      });
+      if (!alreadyActive) {
+        plan.addCandidateIndices.push_back(index);
+      }
+    }
+    return plan;
+  }
+
+} // namespace umbriel

--- a/src/server/drm_policy.h
+++ b/src/server/drm_policy.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+#include <vector>
+
+namespace umbriel {
+
+  // Identity shared by a GPU's card and render nodes. physicalDevice is the
+  // parent sysfs device, so selecting either node applies to the whole GPU.
+  struct DrmDeviceIdentity {
+    std::string node;
+    dev_t device = 0;
+    std::string physicalDevice;
+    std::optional<std::string> pciAddress;
+    std::vector<std::string> devlinks;
+    std::string seat;
+  };
+
+  // Runtime resolution of one configured path. A missing selector retains its
+  // last physical identity so a temporarily unbound GPU stays excluded.
+  struct DrmPathSelectorIdentity {
+    std::string path;
+    std::optional<dev_t> device;
+    std::string physicalDevice;
+    std::optional<std::string> pciAddress;
+  };
+
+  enum class DrmExclusionMatch {
+    None,
+    Path,
+    DeviceNumber,
+    PhysicalDevice,
+    PciAddress,
+  };
+
+  struct DrmBackendEnvironment {
+    bool native = false;
+    bool exclusionsSupported = false;
+    bool createLibinput = false;
+    bool libinputBeforeDrm = false;
+    bool allowMissingLibinput = false;
+    bool operator==(const DrmBackendEnvironment&) const = default;
+  };
+
+  struct DrmActiveDevice {
+    DrmDeviceIdentity identity;
+    bool primary = false;
+  };
+
+  enum class DrmReconcileTermination {
+    None,
+    RendererExcluded,
+    PrimaryExcluded,
+  };
+
+  struct DrmReconcilePlan {
+    DrmReconcileTermination termination = DrmReconcileTermination::None;
+    std::vector<size_t> removeActiveIndices;
+    std::vector<size_t> addCandidateIndices;
+  };
+
+  // Card and render nodes have different device numbers but share a physical
+  // GPU. Prefer stable PCI and sysfs identities before the node number.
+  [[nodiscard]] bool sameDrmPhysicalDevice(const DrmDeviceIdentity& first, const DrmDeviceIdentity& second);
+
+  // Mirrors wlroots' WLR_BACKENDS precedence and comma tokenization without
+  // touching process state. Presence of a display variable matters even when
+  // its value is empty, matching wlr_backend_autocreate().
+  [[nodiscard]] DrmBackendEnvironment resolveDrmBackendEnvironment(
+      std::optional<std::string_view> wlrBackends, bool waylandDisplaySet, bool waylandSocketSet, bool x11DisplaySet
+  );
+
+  [[nodiscard]] DrmExclusionMatch drmExclusionMatch(
+      const DrmDeviceIdentity& device, std::span<const DrmPathSelectorIdentity> paths,
+      std::span<const std::string> pciAddresses
+  );
+
+  // Fill unresolved path selectors from card nodes that advertise the exact
+  // path as a udev link. This keeps a missing on-disk link useful and lets its
+  // card identity exclude the corresponding render node too.
+  [[nodiscard]] size_t
+  learnDrmPathSelectorIdentities(std::span<DrmPathSelectorIdentity> paths, std::span<const DrmDeviceIdentity> devices);
+
+  [[nodiscard]] std::vector<size_t> allowedDrmDeviceIndices(
+      std::span<const DrmDeviceIdentity> devices, std::span<const DrmPathSelectorIdentity> paths,
+      std::span<const std::string> pciAddresses
+  );
+
+  // Extracts the per-GPU device minor published by the proprietary NVIDIA
+  // driver. Some versions expose no udev parent for /dev/nvidiaN.
+  [[nodiscard]] std::optional<unsigned int> parseNvidiaDeviceMinor(std::string_view information);
+
+  // True only for proprietary NVIDIA per-GPU character devices. Shared nodes
+  // such as nvidiactl and nvidia-modeset do not identify one physical GPU.
+  [[nodiscard]] bool isNvidiaGpuDeviceNode(std::string_view node);
+
+  // Decide runtime removals, additions, and fail-closed termination without
+  // performing any wlroots operations. The manager applies this plan only
+  // after it has refreshed device identities and selector state.
+  [[nodiscard]] DrmReconcilePlan planDrmReconciliation(
+      std::span<const DrmActiveDevice> active, const std::optional<DrmDeviceIdentity>& renderer,
+      std::span<const DrmDeviceIdentity> candidates, std::span<const DrmPathSelectorIdentity> paths,
+      std::span<const std::string> pciAddresses, bool selectorsValid
+  );
+
+} // namespace umbriel

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -21,6 +21,7 @@
 #include "scene/config_banner.h"
 #include "scene/hint_rect.h"
 #include "scene/quit_confirm.h"
+#include "server/backend_manager.h"
 #include "server/ipc.h"
 #include "server/wine_color_manager.h"
 #include "view/view.h"
@@ -264,12 +265,14 @@ namespace umbriel {
     m_clientCreated.notify = onClientCreated;
     wl_display_add_client_created_listener(m_display, &m_clientCreated);
 
-    m_backend = wlr_backend_autocreate(wl_display_get_event_loop(m_display), &m_session);
-    if (m_backend == nullptr) {
+    m_backendManager = BackendManager::create(m_display, config().drm);
+    if (m_backendManager == nullptr) {
       throw std::runtime_error("failed to create wlr_backend");
     }
+    m_backend = m_backendManager->backend();
+    m_session = m_backendManager->session();
 
-    m_renderer = fx_renderer_create(m_backend);
+    m_renderer = m_backendManager->createRenderer();
     if (m_renderer == nullptr) {
       throw std::runtime_error("failed to create fx_renderer");
     }
@@ -302,6 +305,9 @@ namespace umbriel {
     m_allocator = wlr_allocator_autocreate(m_backend, m_renderer);
     if (m_allocator == nullptr) {
       throw std::runtime_error("failed to create wlr_allocator");
+    }
+    if (!m_backendManager->verifyOpenDevices("after allocator creation")) {
+      throw std::runtime_error("renderer or allocator opened an excluded GPU");
     }
 
     m_compositor = wlr_compositor_create(m_display, 5, m_renderer);
@@ -593,7 +599,9 @@ namespace umbriel {
     wlr_scene_node_destroy(&m_scene->tree.node);
     wlr_allocator_destroy(m_allocator);
     wlr_renderer_destroy(m_renderer);
-    wlr_backend_destroy(m_backend);
+    m_backendManager.reset();
+    m_backend = nullptr;
+    m_session = nullptr;
     wl_display_destroy(m_display);
   }
 
@@ -656,6 +664,7 @@ namespace umbriel {
       wlr_log(WLR_ERROR, "failed to start backend");
       return false;
     }
+    m_backendManager->markStarted();
 
     // These are delivered through the event loop, not a signal handler, so the shutdown path is ordinary code. Note the
     // side effect: wl_event_loop_add_signal blocks the signal process-wide, and a blocked mask survives fork and exec,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -91,6 +91,7 @@ namespace umbriel {
   struct Keybind;
 
   class Cursor;
+  class BackendManager;
   class FocusManager;
   class XwaylandSupervisor;
   class ConfigWatcher;
@@ -472,6 +473,7 @@ namespace umbriel {
     };
 
     wl_display* m_display = nullptr;
+    std::unique_ptr<BackendManager> m_backendManager;
     wlr_backend* m_backend = nullptr;
     wlr_session* m_session = nullptr;
     wlr_renderer* m_renderer = nullptr;

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -16,6 +16,7 @@
 #include "scene/cheatsheet.h"
 #include "scene/hint_rect.h"
 #include "scene/quit_confirm.h"
+#include "server/backend_manager.h"
 #include "server/ipc.h"
 #include "server/server.h"
 #include "view/popup.h"
@@ -466,6 +467,9 @@ namespace umbriel {
     cancelModifierTap();
     const ConfigReloadResult result = reloadConfig();
     if (result.success) {
+      if (result.change.drm) {
+        kLog.warn("DRM configuration changed; restart Umbriel to apply it");
+      }
       if (result.effects.invalidatesOverview()) {
         m_overview->forceClose();
       }
@@ -531,7 +535,7 @@ namespace umbriel {
     wlr_renderer* oldRenderer = m_renderer;
     wlr_allocator* oldAllocator = m_allocator;
 
-    wlr_renderer* newRenderer = fx_renderer_create(m_backend);
+    wlr_renderer* newRenderer = m_backendManager->createRenderer();
     if (newRenderer == nullptr) {
       kLog.error("could not recreate fx_renderer after GPU reset, terminating");
       stop();
@@ -541,6 +545,13 @@ namespace umbriel {
     if (newAllocator == nullptr) {
       kLog.error("could not recreate allocator after GPU reset, terminating");
       wlr_renderer_destroy(newRenderer);
+      stop();
+      return;
+    }
+    if (!m_backendManager->verifyOpenDevices("after renderer recovery")) {
+      wlr_allocator_destroy(newAllocator);
+      wlr_renderer_destroy(newRenderer);
+      kLog.error("renderer recovery opened an excluded GPU, terminating");
       stop();
       return;
     }

--- a/src/wlr.h
+++ b/src/wlr.h
@@ -6,6 +6,7 @@ extern "C" {
 #include <umbrielfx/render/fx_renderer/fx_renderer.h>
 #include <umbrielfx/types/wlr_scene.h>
 #include <wlr/backend.h>
+#include <wlr/backend/drm.h>
 #include <wlr/backend/headless.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/multi.h>

--- a/tests/harness/verify.sh
+++ b/tests/harness/verify.sh
@@ -278,7 +278,11 @@ start_instance() {
   # teardown instead of joining the harness's own group where it cannot be
   # signalled. The backgrounded child is not a group leader, so setsid execs in
   # place and SERVER_PID stays the compositor and its group id.
+  # Keep an inherited renderer selector paired with the caller's GLVND vendor
+  # settings. Removing only the selector can make a mixed-vendor host choose a
+  # render node that the forced EGL vendor cannot initialize.
   setsid env -u WAYLAND_DISPLAY -u DISPLAY -u DBUS_SESSION_BUS_ADDRESS \
+    -u WLR_DRM_DEVICES \
     XDG_RUNTIME_DIR="$RUNTIME_DIR" \
     WLR_BACKENDS=headless \
     WLR_LIBINPUT_NO_DEVICES=1 \

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -31,6 +31,7 @@ unit_tests = [
   ['config-section', ['unit/config_section.cpp'], []],
   ['config-change', ['unit/config_change.cpp'], []],
   ['config-load', ['unit/config_load.cpp'], [umbriel_core_dep]],
+  ['drm-policy', ['unit/drm_policy.cpp'], []],
   ['config-watcher', ['unit/config_watcher.cpp'], [umbriel_core_dep]],
   ['action-registry', ['unit/action_registry.cpp'], [umbriel_core_dep]],
   ['ipc-commands', ['unit/ipc_commands.cpp'], [umbriel_core_dep]],

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -28,6 +28,7 @@ UMBRIEL_TEST(aFirstLoadReportsEverything) {
   CHECK(change.appearance);
   CHECK(change.animation);
   CHECK(change.colors);
+  CHECK(change.drm);
   CHECK(change.events);
   CHECK(change.input);
   CHECK(change.outputs);
@@ -35,6 +36,15 @@ UMBRIEL_TEST(aFirstLoadReportsEverything) {
 
 UMBRIEL_TEST(eachSectionIsReportedOnItsOwn) {
   const Config before;
+
+  {
+    Config after;
+    after.drm.renderDevice = "/dev/dri/renderD128";
+    const ConfigChange change = ConfigChange::between(before, after);
+    CHECK(change.drm);
+    CHECK(!ConfigEffects::between(before, after).any());
+    CHECK_EQ(change.summary(), std::string("drm"));
+  }
 
   {
     Config after;

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -121,14 +121,14 @@ UMBRIEL_TEST(defaultConfigLookupPrefersUserThenSystem) {
   const ScopedEnvironment configDirs("XDG_CONFIG_DIRS", systemDir.string());
 
   ConfigStore& store = umbriel::configStore();
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
 
   CHECK_EQ(store.rootPath(), systemConfig);
   CHECK_EQ(store.config().layout.gap, 17);
   CHECK(!store.fileMissing());
 
   tree.write("user/umbriel/config.toml", "[layout]\ngap = 19\n");
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
 
   CHECK_EQ(store.rootPath(), userConfig);
   CHECK_EQ(store.config().layout.gap, 19);
@@ -1497,6 +1497,8 @@ _PRIVATE = "kept"
 "HAS-HYPHEN" = "ignored"
 NOT_A_STRING = 1
 WAYLAND_DISPLAY = "wrong"
+WLR_DRM_DEVICES = "/dev/dri/card0"
+WLR_RENDER_DRM_DEVICE = "/dev/dri/renderD128"
 )");
 
   ConfigStore& store = umbriel::configStore();
@@ -1504,7 +1506,7 @@ WAYLAND_DISPLAY = "wrong"
   const umbriel::ConfigReloadResult result = store.reload();
 
   CHECK(result.success);
-  CHECK_EQ(store.config().environment.variables.size(), size_t{2});
+  CHECK_EQ(store.config().environment.variables.size(), size_t{4});
   CHECK(
       std::ranges::find(store.config().environment.variables, std::pair{std::string{"DXVK_HDR"}, std::string{"1"}})
       != store.config().environment.variables.end()
@@ -1513,12 +1515,241 @@ WAYLAND_DISPLAY = "wrong"
       std::ranges::find(store.config().environment.variables, std::pair{std::string{"_PRIVATE"}, std::string{"kept"}})
       != store.config().environment.variables.end()
   );
+  CHECK(
+      std::ranges::find(
+          store.config().environment.variables, std::pair{std::string{"WLR_DRM_DEVICES"}, std::string{"/dev/dri/card0"}}
+      )
+      != store.config().environment.variables.end()
+  );
+  CHECK(
+      std::ranges::find(
+          store.config().environment.variables,
+          std::pair{std::string{"WLR_RENDER_DRM_DEVICE"}, std::string{"/dev/dri/renderD128"}}
+      )
+      != store.config().environment.variables.end()
+  );
   CHECK(containsDiagnostic(store, R"(ignoring environment key "9INVALID" (expected [A-Za-z_][A-Za-z0-9_]*))"));
   CHECK(containsDiagnostic(store, R"(ignoring environment key "HAS-HYPHEN" (expected [A-Za-z_][A-Za-z0-9_]*))"));
   CHECK(containsDiagnostic(store, "ignoring environment.NOT_A_STRING (expected string)"));
   CHECK(containsDiagnostic(store, "ignoring environment.WAYLAND_DISPLAY (reserved by Umbriel)"));
   CHECK(!containsDiagnostic(store, "unknown key environment.DXVK_HDR"));
   CHECK(!containsDiagnostic(store, "unknown key environment._PRIVATE"));
+}
+
+UMBRIEL_TEST(drmConfigurationLoadsAndNormalizesSelectors) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+render_device = "/dev/dri/by-path/pci-0000:05:00.0-render"
+ignored_devices = [
+  "/dev/dri/by-path/pci-0000:01:00.0-card",
+  "/dev/dri/by-path/pci-0000:01:00.0-card",
+]
+ignored_pci_addresses = ["0000:01:00.0", "0000:01:00.0"]
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+  const umbriel::ConfigReloadResult result = store.reload();
+
+  CHECK(result.success);
+  CHECK(store.config().drm.configured());
+  CHECK(store.config().drm.hasExclusions());
+  CHECK_EQ(store.config().drm.renderDevice, std::optional<std::string>{"/dev/dri/by-path/pci-0000:05:00.0-render"});
+  CHECK_EQ(store.config().drm.ignoredDevices.size(), size_t{1});
+  CHECK_EQ(store.config().drm.ignoredPciAddresses, std::vector<std::string>{"0000:01:00.0"});
+  CHECK(containsDiagnostic(store, "ignoring duplicate drm.ignored_devices"));
+  CHECK(containsDiagnostic(store, "ignoring duplicate drm.ignored_pci_addresses"));
+
+  file.write(R"(
+[drm]
+ignored_pci_addresses = ["0000:AB:0C.7"]
+)");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().drm.ignoredPciAddresses, std::vector<std::string>{"0000:ab:0c.7"});
+}
+
+UMBRIEL_TEST(emptyDrmTableKeepsTheCompatibilityPath) {
+  const TempConfig file;
+  file.write("[drm]\n");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  CHECK(store.reload().success);
+  CHECK(!store.config().drm.configured());
+  CHECK(!store.config().drm.hasExclusions());
+}
+
+UMBRIEL_TEST(drmPathsPreserveSymlinkSensitiveComponents) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+render_device = "/dev/dri/selected/../renderD128"
+ignored_devices = ["/dev/dri/excluded/../card0"]
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().drm.renderDevice, std::optional<std::string>{"/dev/dri/selected/../renderD128"});
+  CHECK_EQ(store.config().drm.ignoredDevices, std::vector<std::string>{"/dev/dri/excluded/../card0"});
+}
+
+UMBRIEL_TEST(drmConfigurationRejectsUnsafeSelectors) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+render_device = "/dev/dri/renderD128"
+ignored_pci_addresses = ["0000:01:00.0"]
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+  CHECK(store.reload().success);
+  const umbriel::Config previous = store.config();
+
+  file.write(R"(
+[drm]
+render_device = "renderD128"
+ignored_devices = [1, "relative-card"]
+ignored_pci_addresses = ["01:00.0", "0000:01:00.8", "0000:01:20.0"]
+surprise = true
+)");
+
+  const umbriel::ConfigReloadResult result = store.reload();
+
+  CHECK(!result.success);
+  CHECK(store.config() == previous);
+  CHECK(containsDiagnostic(store, "drm.render_device must be an absolute path"));
+  CHECK(containsDiagnostic(store, "drm.ignored_devices must be a string"));
+  CHECK(containsDiagnostic(store, "drm.ignored_devices must be an absolute path"));
+  CHECK(containsDiagnostic(store, "invalid drm.ignored_pci_addresses entry"));
+  CHECK(containsDiagnostic(store, "unknown key drm.surprise"));
+}
+
+UMBRIEL_TEST(initialConfigErrorsDoNotCommitDefaults) {
+  const TempConfig file;
+  file.write("[drm]\nignored_pci_addresses = [\"invalid\"]\n");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+  const umbriel::Config previous = store.config();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(store.config() == previous);
+  CHECK(containsDiagnostic(store, "invalid drm.ignored_pci_addresses entry"));
+}
+
+UMBRIEL_TEST(initialNonDrmErrorsKeepCompatibilityDefaults) {
+  const TempConfig file;
+  file.write("workspace = \"invalid\"\n");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation + 1);
+  CHECK(!store.config().drm.configured());
+  CHECK(containsDiagnostic(store, "workspace must be a [[workspace]] array of tables"));
+}
+
+UMBRIEL_TEST(initialErrorsCannotDiscardRequestedDrmPolicy) {
+  const TempConfig file;
+  file.write(R"(
+workspace = "invalid"
+
+[drm]
+ignored_pci_addresses = ["0000:01:00.0"]
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "workspace must be a [[workspace]] array of tables"));
+}
+
+UMBRIEL_TEST(initialSyntaxErrorsCannotDiscardRequestedDrmPolicy) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+ignored_devices = ["/dev/dri/card0"
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "Error while parsing array"));
+}
+
+UMBRIEL_TEST(initialIncludedSyntaxErrorsCannotDiscardRequestedDrmPolicy) {
+  const TempConfig file;
+  file.write("[include]\nfiles = [\"" + file.includeName() + "\"]\n");
+  file.writeInclude(R"(
+[drm]
+ignored_pci_addresses = ["0000:01:00.0"
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "Error while parsing array"));
+}
+
+UMBRIEL_TEST(drmTextInMultilineStringKeepsSyntaxErrorCompatibilityFallback) {
+  const TempConfig file;
+  file.write(R"(
+note = """
+[drm]
+ignored_devices = ["/dev/dri/card0"]
+"""
+workspace =
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation + 1);
+  CHECK(!store.config().drm.configured());
+}
+
+UMBRIEL_TEST(emptyDrmTableKeepsSyntaxErrorCompatibilityFallback) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+
+[layout]
+gap =
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation + 1);
+  CHECK(!store.config().drm.configured());
+}
+
+UMBRIEL_TEST(initialMissingExplicitConfigKeepsCompatibilityDefaults) {
+  const TempConfig file;
+  std::filesystem::remove(file.path());
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation + 1);
+  CHECK(store.fileMissing());
+  CHECK(containsDiagnostic(store, "config file not found"));
 }
 
 UMBRIEL_TEST(eventsLoadCanonicalLidCommands) {

--- a/tests/unit/config_watcher.cpp
+++ b/tests/unit/config_watcher.cpp
@@ -63,7 +63,7 @@ UMBRIEL_TEST(anIncludedFileReloadsThroughASymlinkedConfigDirectory) {
   const SymlinkedConfigTree tree;
   const std::string root = tree.root().string();
   ConfigStore& store = umbriel::configStore();
-  store.load(root.c_str());
+  CHECK(store.load(root.c_str()));
 
   CHECK_EQ(store.config().layout.gap, 5);
   CHECK_EQ(store.config().appearance.borderWidth, 2);

--- a/tests/unit/drm_policy.cpp
+++ b/tests/unit/drm_policy.cpp
@@ -1,0 +1,248 @@
+#include "server/drm_policy.h"
+
+#include "check.h"
+
+#include <sys/sysmacros.h>
+
+using umbriel::allowedDrmDeviceIndices;
+using umbriel::DrmDeviceIdentity;
+using umbriel::DrmExclusionMatch;
+using umbriel::drmExclusionMatch;
+using umbriel::DrmPathSelectorIdentity;
+using umbriel::isNvidiaGpuDeviceNode;
+using umbriel::learnDrmPathSelectorIdentities;
+using umbriel::parseNvidiaDeviceMinor;
+using umbriel::planDrmReconciliation;
+using umbriel::resolveDrmBackendEnvironment;
+using umbriel::sameDrmPhysicalDevice;
+
+namespace {
+  const DrmDeviceIdentity kIntegrated{
+      .node = "/dev/dri/card0",
+      .device = makedev(226, 0),
+      .physicalDevice = "/sys/devices/pci0000:00/0000:00:02.0",
+      .pciAddress = "0000:00:02.0",
+      .devlinks = {"/dev/dri/by-path/pci-0000:00:02.0-card"},
+      .seat = "seat0",
+  };
+  const DrmDeviceIdentity kDiscrete{
+      .node = "/dev/dri/card1",
+      .device = makedev(226, 1),
+      .physicalDevice = "/sys/devices/pci0000:00/0000:01:00.0",
+      .pciAddress = "0000:01:00.0",
+      .devlinks = {"/dev/dri/by-path/pci-0000:01:00.0-card"},
+      .seat = "seat0",
+  };
+} // namespace
+
+UMBRIEL_TEST(pathAliasExcludesCardBeforeSelection) {
+  const std::vector<DrmPathSelectorIdentity> paths{{
+      .path = "/dev/dri/by-path/pci-0000:01:00.0-card",
+      .device = std::nullopt,
+      .physicalDevice = {},
+      .pciAddress = std::nullopt,
+  }};
+  const std::vector<DrmDeviceIdentity> devices{kIntegrated, kDiscrete};
+
+  CHECK(drmExclusionMatch(kDiscrete, paths, {}) == DrmExclusionMatch::Path);
+  CHECK_EQ(allowedDrmDeviceIndices(devices, paths, {}), std::vector<size_t>{0});
+}
+
+UMBRIEL_TEST(renderNodeIdentityExcludesTheWholePhysicalGpu) {
+  const std::vector<DrmPathSelectorIdentity> paths{{
+      .path = "/dev/dri/renderD129",
+      .device = makedev(226, 129),
+      .physicalDevice = kDiscrete.physicalDevice,
+      .pciAddress = kDiscrete.pciAddress,
+  }};
+
+  CHECK(drmExclusionMatch(kDiscrete, paths, {}) == DrmExclusionMatch::PhysicalDevice);
+  CHECK(drmExclusionMatch(kIntegrated, paths, {}) == DrmExclusionMatch::None);
+}
+
+UMBRIEL_TEST(cardAndRenderNodesCompareAsOnePhysicalGpu) {
+  DrmDeviceIdentity renderNode = kDiscrete;
+  renderNode.node = "/dev/dri/renderD129";
+  renderNode.device = makedev(226, 129);
+
+  CHECK(sameDrmPhysicalDevice(kDiscrete, renderNode));
+
+  renderNode.pciAddress = "0000:02:00.0";
+  CHECK(!sameDrmPhysicalDevice(kDiscrete, renderNode));
+
+  DrmDeviceIdentity platformDevice = kDiscrete;
+  platformDevice.pciAddress.reset();
+  renderNode = platformDevice;
+  renderNode.node = "/dev/dri/renderD129";
+  renderNode.device = makedev(226, 129);
+  CHECK(sameDrmPhysicalDevice(platformDevice, renderNode));
+}
+
+UMBRIEL_TEST(missingPathRetainsItsLastPhysicalIdentity) {
+  const std::vector<DrmPathSelectorIdentity> paths{{
+      .path = "/dev/dri/by-path/pci-0000:01:00.0-render",
+      .device = std::nullopt,
+      .physicalDevice = kDiscrete.physicalDevice,
+      .pciAddress = kDiscrete.pciAddress,
+  }};
+
+  CHECK(drmExclusionMatch(kDiscrete, paths, {}) == DrmExclusionMatch::PhysicalDevice);
+}
+
+UMBRIEL_TEST(missingPathLearnsPhysicalIdentityFromAdvertisedUdevLink) {
+  std::vector<DrmPathSelectorIdentity> paths{{
+      .path = "/dev/dri/by-path/pci-0000:01:00.0-card",
+      .device = std::nullopt,
+      .physicalDevice = {},
+      .pciAddress = std::nullopt,
+  }};
+  DrmDeviceIdentity renderNode = kDiscrete;
+  renderNode.node = "/dev/dri/renderD129";
+  renderNode.device = makedev(226, 129);
+  renderNode.devlinks = {"/dev/dri/by-path/pci-0000:01:00.0-render"};
+
+  CHECK_EQ(learnDrmPathSelectorIdentities(paths, std::span{&kDiscrete, size_t{1}}), size_t{1});
+  CHECK_EQ(paths.front().physicalDevice, kDiscrete.physicalDevice);
+  CHECK(drmExclusionMatch(renderNode, paths, {}) == DrmExclusionMatch::PhysicalDevice);
+}
+
+UMBRIEL_TEST(pciAddressExcludesAReenumeratedGpu) {
+  const std::vector<std::string> pciAddresses{"0000:01:00.0"};
+  DrmDeviceIdentity reenumerated = kDiscrete;
+  reenumerated.node = "/dev/dri/card7";
+  reenumerated.device = makedev(226, 7);
+  reenumerated.devlinks.clear();
+
+  CHECK(drmExclusionMatch(reenumerated, {}, pciAddresses) == DrmExclusionMatch::PciAddress);
+}
+
+UMBRIEL_TEST(allExcludedProducesNoBackendCandidates) {
+  const std::vector<DrmDeviceIdentity> devices{kIntegrated, kDiscrete};
+  const std::vector<std::string> pciAddresses{"0000:00:02.0", "0000:01:00.0"};
+
+  CHECK(allowedDrmDeviceIndices(devices, {}, pciAddresses).empty());
+}
+
+UMBRIEL_TEST(backendEnvironmentMatchesWlrootsPrecedence) {
+  CHECK_EQ(
+      resolveDrmBackendEnvironment(std::nullopt, false, false, false),
+      (umbriel::DrmBackendEnvironment{
+          .native = true,
+          .exclusionsSupported = true,
+          .createLibinput = true,
+          .libinputBeforeDrm = true,
+          .allowMissingLibinput = true,
+      })
+  );
+  CHECK(!resolveDrmBackendEnvironment(std::nullopt, true, false, false).native);
+  CHECK(!resolveDrmBackendEnvironment(std::nullopt, false, true, false).native);
+  CHECK(!resolveDrmBackendEnvironment(std::nullopt, false, false, true).native);
+  CHECK(!resolveDrmBackendEnvironment(std::string_view{}, false, false, false).native);
+}
+
+UMBRIEL_TEST(filteredBackendSupportsOnlyOneDrmAndOptionalLibinput) {
+  const auto drmOnly = resolveDrmBackendEnvironment("drm", true, true, true);
+  CHECK(drmOnly.native);
+  CHECK(drmOnly.exclusionsSupported);
+  CHECK(!drmOnly.createLibinput);
+
+  const auto native = resolveDrmBackendEnvironment(",drm,,libinput,", true, false, false);
+  CHECK(native.native);
+  CHECK(native.exclusionsSupported);
+  CHECK(native.createLibinput);
+  CHECK(!native.libinputBeforeDrm);
+
+  const auto inputFirst = resolveDrmBackendEnvironment("libinput,drm", false, false, false);
+  CHECK(inputFirst.exclusionsSupported);
+  CHECK(inputFirst.libinputBeforeDrm);
+
+  CHECK(!resolveDrmBackendEnvironment("drm,headless", false, false, false).exclusionsSupported);
+  CHECK(!resolveDrmBackendEnvironment("drm,drm", false, false, false).exclusionsSupported);
+  CHECK(!resolveDrmBackendEnvironment("drm, libinput", false, false, false).exclusionsSupported);
+}
+
+UMBRIEL_TEST(nvidiaDeviceMinorParsesDriverInformation) {
+  constexpr std::string_view information = R"(Model: NVIDIA GeForce RTX 5090
+Bus Location: 0000:01:00.0
+Device Minor: 	 0
+)";
+
+  CHECK_EQ(parseNvidiaDeviceMinor(information), std::optional<unsigned int>{0});
+  CHECK_EQ(parseNvidiaDeviceMinor("  Device Minor: 17\r\n"), std::optional<unsigned int>{17});
+  CHECK(!parseNvidiaDeviceMinor("Device Minor: none\n"));
+  CHECK(!parseNvidiaDeviceMinor("Device Minor: 3 trailing\n"));
+  CHECK(!parseNvidiaDeviceMinor("Model: no minor\n"));
+}
+
+UMBRIEL_TEST(nvidiaGpuDeviceNodeExcludesOnlyPerGpuNodes) {
+  CHECK(isNvidiaGpuDeviceNode("/dev/nvidia0"));
+  CHECK(isNvidiaGpuDeviceNode("/dev/nvidia17"));
+  CHECK(isNvidiaGpuDeviceNode("/dev/nvidia17 (deleted)"));
+  CHECK(!isNvidiaGpuDeviceNode("/dev/nvidia"));
+  CHECK(!isNvidiaGpuDeviceNode("/dev/nvidiactl"));
+  CHECK(!isNvidiaGpuDeviceNode("/dev/nvidia-modeset"));
+  CHECK(!isNvidiaGpuDeviceNode("/dev/nvidia0-extra"));
+}
+
+UMBRIEL_TEST(reconciliationTerminatesWhenRendererBecomesExcluded) {
+  DrmDeviceIdentity renderer = kDiscrete;
+  renderer.node = "/dev/dri/renderD129";
+  renderer.device = makedev(226, 129);
+  const std::vector<umbriel::DrmActiveDevice> active{{.identity = kIntegrated, .primary = true}};
+  const std::vector<DrmDeviceIdentity> candidates{kIntegrated, kDiscrete};
+  const std::vector<std::string> excluded{"0000:01:00.0"};
+
+  const auto plan = planDrmReconciliation(active, renderer, candidates, {}, excluded, true);
+
+  CHECK(plan.termination == umbriel::DrmReconcileTermination::RendererExcluded);
+  CHECK(plan.removeActiveIndices.empty());
+  CHECK(plan.addCandidateIndices.empty());
+}
+
+UMBRIEL_TEST(reconciliationTerminatesWhenPrimaryBecomesExcluded) {
+  const std::vector<umbriel::DrmActiveDevice> active{
+      {.identity = kIntegrated, .primary = true},
+      {.identity = kDiscrete, .primary = false},
+  };
+  const std::vector<DrmDeviceIdentity> candidates{kIntegrated, kDiscrete};
+  const std::vector<std::string> excluded{"0000:00:02.0"};
+
+  const auto plan = planDrmReconciliation(active, std::nullopt, candidates, {}, excluded, true);
+
+  CHECK(plan.termination == umbriel::DrmReconcileTermination::PrimaryExcluded);
+  CHECK(plan.removeActiveIndices.empty());
+  CHECK(plan.addCandidateIndices.empty());
+}
+
+UMBRIEL_TEST(reconciliationRemovesExcludedSecondaryAndAddsAllowedGpu) {
+  DrmDeviceIdentity replacement = kDiscrete;
+  replacement.node = "/dev/dri/card2";
+  replacement.device = makedev(226, 2);
+  replacement.physicalDevice = "/sys/devices/pci0000:00/0000:02:00.0";
+  replacement.pciAddress = "0000:02:00.0";
+  const std::vector<umbriel::DrmActiveDevice> active{
+      {.identity = kIntegrated, .primary = true},
+      {.identity = kDiscrete, .primary = false},
+  };
+  const std::vector<DrmDeviceIdentity> candidates{kIntegrated, kDiscrete, replacement};
+  const std::vector<std::string> excluded{"0000:01:00.0"};
+
+  const auto plan = planDrmReconciliation(active, std::nullopt, candidates, {}, excluded, true);
+
+  CHECK(plan.termination == umbriel::DrmReconcileTermination::None);
+  CHECK_EQ(plan.removeActiveIndices, std::vector<size_t>{1});
+  CHECK_EQ(plan.addCandidateIndices, std::vector<size_t>{2});
+}
+
+UMBRIEL_TEST(reconciliationSuppressesNewBackendsWhileSelectorsAreInvalid) {
+  const std::vector<umbriel::DrmActiveDevice> active{{.identity = kIntegrated, .primary = true}};
+  const std::vector<DrmDeviceIdentity> candidates{kIntegrated, kDiscrete};
+
+  const auto plan = planDrmReconciliation(active, std::nullopt, candidates, {}, {}, false);
+
+  CHECK(plan.termination == umbriel::DrmReconcileTermination::None);
+  CHECK(plan.removeActiveIndices.empty());
+  CHECK(plan.addCandidateIndices.empty());
+}
+
+int main() { return RUN_TESTS(); }

--- a/umbrielfx/include/umbrielfx/render/fx_renderer/fx_renderer.h
+++ b/umbrielfx/include/umbrielfx/render/fx_renderer/fx_renderer.h
@@ -11,6 +11,8 @@ struct fx_renderer;
 struct wlr_output;
 
 struct wlr_renderer *fx_renderer_create_with_drm_fd(int drm_fd);
+/* Creates through GBM without enumerating EGL devices. */
+struct wlr_renderer *fx_renderer_create_with_drm_fd_gbm(int drm_fd);
 struct wlr_renderer *fx_renderer_create(struct wlr_backend *backend);
 
 struct fx_renderer *fx_get_renderer(struct wlr_renderer *wlr_renderer);

--- a/umbrielfx/internal/render/egl.h
+++ b/umbrielfx/internal/render/egl.h
@@ -3,11 +3,17 @@
 
 #include <wlr/render/egl.h>
 
+enum wlr_egl_drm_fd_strategy {
+	WLR_EGL_DRM_FD_EGL_DEVICE_FIRST,
+	WLR_EGL_DRM_FD_GBM_EXACT,
+};
+
 struct wlr_egl {
 	EGLDisplay display;
 	EGLContext context;
 	EGLDeviceEXT device; // may be EGL_NO_DEVICE_EXT
 	struct gbm_device *gbm_device;
+	enum wlr_egl_drm_fd_strategy drm_fd_strategy;
 
 	struct {
 		// Display extensions
@@ -62,6 +68,12 @@ struct wlr_egl_context {
  * Will attempt to load all possibly required API functions.
  */
 struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd);
+
+/**
+ * Initializes an EGL context for the given DRM FD through GBM without
+ * enumerating EGL devices.
+ */
+struct wlr_egl *wlr_egl_create_with_drm_fd_gbm(int drm_fd);
 
 /**
  * Frees all related EGL resources, makes the context not-current and

--- a/umbrielfx/meson.build
+++ b/umbrielfx/meson.build
@@ -210,6 +210,22 @@ if build_tests
     )
   endforeach
 
+  umbrielfx_renderer_test = executable(
+    'umbrielfx-renderer-test',
+    'tests/renderer.c',
+    c_args: umbrielfx_c_args,
+    dependencies: umbrielfx_deps,
+    include_directories: [umbrielfx_inc, umbrielfx_internal_inc],
+    link_with: umbrielfx_lib,
+    build_by_default: false,
+  )
+
+  test(
+    'umbrielfx-renderer-gbm-device',
+    umbrielfx_renderer_test,
+    suite: 'umbrielfx',
+  )
+
   # The compositor calls scene helpers umbrielfx does not reimplement, so they
   # resolve to libwlroots and read umbrielfx's structs at wlroots' field offsets.
   # One source, built against each header, proves the offsets still agree.

--- a/umbrielfx/render/egl.c
+++ b/umbrielfx/render/egl.c
@@ -214,6 +214,7 @@ static struct wlr_egl *egl_create(void) {
 		wlr_log_errno(WLR_ERROR, "Allocation failed");
 		return NULL;
 	}
+	egl->drm_fd_strategy = WLR_EGL_DRM_FD_EGL_DEVICE_FIRST;
 
 	load_egl_proc(&egl->procs.eglGetPlatformDisplayEXT,
 		"eglGetPlatformDisplayEXT");
@@ -383,6 +384,9 @@ static bool egl_init_display(struct wlr_egl *egl, EGLDisplay display,
 
 static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 		void *remote_display, bool allow_software) {
+	// A GBM display is private to this wlr_egl because umbrielfx created the GBM
+	// device. It can always be terminated, even without reference tracking.
+	bool owns_display = platform == EGL_PLATFORM_GBM_KHR;
 	EGLint display_attribs[3] = {0};
 	size_t display_attribs_len = 0;
 
@@ -402,7 +406,7 @@ static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 	}
 
 	if (!egl_init_display(egl, display, allow_software)) {
-		if (egl->exts.KHR_display_reference) {
+		if (owns_display || egl->exts.KHR_display_reference) {
 			eglTerminate(display);
 		}
 		return false;
@@ -439,6 +443,11 @@ static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 		wlr_log(WLR_DEBUG, "Created EGL context using OpenGL ES 2.0");
 	} else {
 		wlr_log(WLR_ERROR, "Failed to create EGL context using OpenGL ES 2.0");
+		wlr_drm_format_set_finish(&egl->dmabuf_render_formats);
+		wlr_drm_format_set_finish(&egl->dmabuf_texture_formats);
+		if (owns_display || egl->exts.KHR_display_reference) {
+			eglTerminate(display);
+		}
 		return false;
 	}
 
@@ -558,6 +567,38 @@ static int open_render_node(int drm_fd) {
 	return render_fd;
 }
 
+static bool egl_init_with_gbm(struct wlr_egl *egl, int drm_fd,
+		bool allow_software) {
+	if (!egl->exts.KHR_platform_gbm) {
+		wlr_log(WLR_DEBUG, "KHR_platform_gbm not supported");
+		return false;
+	}
+
+	int gbm_fd = open_render_node(drm_fd);
+	if (gbm_fd < 0) {
+		wlr_log(WLR_ERROR, "Failed to open DRM render node");
+		return false;
+	}
+
+	egl->gbm_device = gbm_create_device(gbm_fd);
+	if (!egl->gbm_device) {
+		close(gbm_fd);
+		wlr_log(WLR_ERROR, "Failed to create GBM device");
+		return false;
+	}
+
+	if (egl_init(egl, EGL_PLATFORM_GBM_KHR, egl->gbm_device,
+			allow_software)) {
+		wlr_log(WLR_DEBUG, "Using EGL_PLATFORM_GBM_KHR");
+		return true;
+	}
+
+	gbm_device_destroy(egl->gbm_device);
+	egl->gbm_device = NULL;
+	close(gbm_fd);
+	return false;
+}
+
 struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd) {
 	bool allow_software = drm_fd < 0;
 
@@ -585,33 +626,32 @@ struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd) {
 		wlr_log(WLR_DEBUG, "EXT_platform_device not supported");
 	}
 
-	if (egl->exts.KHR_platform_gbm && drm_fd >= 0) {
-		int gbm_fd = open_render_node(drm_fd);
-		if (gbm_fd < 0) {
-			wlr_log(WLR_ERROR, "Failed to open DRM render node");
-			goto error;
-		}
-
-		egl->gbm_device = gbm_create_device(gbm_fd);
-		if (!egl->gbm_device) {
-			close(gbm_fd);
-			wlr_log(WLR_ERROR, "Failed to create GBM device");
-			goto error;
-		}
-
-		if (egl_init(egl, EGL_PLATFORM_GBM_KHR, egl->gbm_device, allow_software)) {
-			wlr_log(WLR_DEBUG, "Using EGL_PLATFORM_GBM_KHR");
-			return egl;
-		}
-
-		gbm_device_destroy(egl->gbm_device);
-		close(gbm_fd);
-	} else {
-		wlr_log(WLR_DEBUG, "KHR_platform_gbm not supported");
+	if (drm_fd >= 0 && egl_init_with_gbm(egl, drm_fd, allow_software)) {
+		return egl;
 	}
 
 error:
 	wlr_log(WLR_ERROR, "Failed to initialize EGL context");
+	free(egl);
+	eglReleaseThread();
+	return NULL;
+}
+
+struct wlr_egl *wlr_egl_create_with_drm_fd_gbm(int drm_fd) {
+	assert(drm_fd >= 0);
+
+	struct wlr_egl *egl = egl_create();
+	if (egl == NULL) {
+		wlr_log(WLR_ERROR, "Failed to create EGL context");
+		return NULL;
+	}
+	egl->drm_fd_strategy = WLR_EGL_DRM_FD_GBM_EXACT;
+
+	if (egl_init_with_gbm(egl, drm_fd, false)) {
+		return egl;
+	}
+
+	wlr_log(WLR_ERROR, "Failed to initialize EGL context through GBM");
 	free(egl);
 	eglReleaseThread();
 	return NULL;
@@ -659,7 +699,7 @@ void wlr_egl_destroy(struct wlr_egl *egl) {
 	eglMakeCurrent(egl->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 	eglDestroyContext(egl->display, egl->context);
 
-	if (egl->exts.KHR_display_reference) {
+	if (egl->gbm_device != NULL || egl->exts.KHR_display_reference) {
 		eglTerminate(egl->display);
 	}
 
@@ -1040,22 +1080,27 @@ static int dup_egl_device_drm_fd(struct wlr_egl *egl) {
 	return render_fd;
 }
 
-int wlr_egl_dup_drm_fd(struct wlr_egl *egl) {
-	int fd = dup_egl_device_drm_fd(egl);
-	if (fd >= 0) {
-		return fd;
-	}
-
-	// Fallback to GBM's FD if we can't use EGLDevice
+static int dup_gbm_drm_fd(struct wlr_egl *egl) {
 	if (egl->gbm_device == NULL) {
 		return -1;
 	}
 
-	fd = fcntl(gbm_device_get_fd(egl->gbm_device), F_DUPFD_CLOEXEC, 0);
+	int fd = fcntl(gbm_device_get_fd(egl->gbm_device), F_DUPFD_CLOEXEC, 0);
 	if (fd < 0) {
 		wlr_log_errno(WLR_ERROR, "Failed to dup GBM FD");
 	}
 	return fd;
+}
+
+int wlr_egl_dup_drm_fd(struct wlr_egl *egl) {
+	// GBM-exact renderers must keep the exact device they initialized.
+	// All other renderers retain wlroots' EGL-device-first compatibility path.
+	if (egl->drm_fd_strategy == WLR_EGL_DRM_FD_GBM_EXACT) {
+		return dup_gbm_drm_fd(egl);
+	}
+
+	int fd = dup_egl_device_drm_fd(egl);
+	return fd >= 0 ? fd : dup_gbm_drm_fd(egl);
 }
 
 EGLSyncKHR wlr_egl_create_sync(struct wlr_egl *egl, int fence_fd) {

--- a/umbrielfx/render/fx_renderer/fx_renderer.c
+++ b/umbrielfx/render/fx_renderer/fx_renderer.c
@@ -338,14 +338,20 @@ static void fx_log(GLenum src, GLenum type, GLuint id, GLenum severity,
 	_wlr_log(fx_log_importance_to_wlr(type), "[GLES2] %s", msg);
 }
 
-static struct wlr_renderer *renderer_autocreate(struct wlr_backend *backend, int drm_fd) {
+static struct wlr_renderer *renderer_autocreate(struct wlr_backend *backend,
+		int drm_fd, bool gbm_only) {
 	bool own_drm_fd = false;
 	if (!open_preferred_drm_fd(backend, &drm_fd, &own_drm_fd)) {
 		wlr_log(WLR_ERROR, "Cannot create GLES2 renderer: no DRM FD available");
 		return NULL;
 	}
 
-	struct wlr_egl *egl = wlr_egl_create_with_drm_fd(drm_fd);
+	struct wlr_egl *egl = gbm_only
+		? wlr_egl_create_with_drm_fd_gbm(drm_fd)
+		: wlr_egl_create_with_drm_fd(drm_fd);
+	if (own_drm_fd && drm_fd >= 0) {
+		close(drm_fd);
+	}
 	if (egl == NULL) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		return NULL;
@@ -358,21 +364,23 @@ static struct wlr_renderer *renderer_autocreate(struct wlr_backend *backend, int
 		return NULL;
 	}
 
-	if (own_drm_fd && drm_fd >= 0) {
-		close(drm_fd);
-	}
-
 	return renderer;
 }
 
 struct wlr_renderer *fx_renderer_create_with_drm_fd(int drm_fd) {
 	assert(drm_fd >= 0);
 
-	return renderer_autocreate(NULL, drm_fd);
+	return renderer_autocreate(NULL, drm_fd, false);
+}
+
+struct wlr_renderer *fx_renderer_create_with_drm_fd_gbm(int drm_fd) {
+	assert(drm_fd >= 0);
+
+	return renderer_autocreate(NULL, drm_fd, true);
 }
 
 struct wlr_renderer *fx_renderer_create(struct wlr_backend *backend) {
-	return renderer_autocreate(backend, -1);
+	return renderer_autocreate(backend, -1, false);
 }
 
 static bool link_shaders(struct fx_renderer *renderer) {

--- a/umbrielfx/tests/renderer.c
+++ b/umbrielfx/tests/renderer.c
@@ -1,0 +1,233 @@
+#include <dirent.h>
+#include <drm_fourcc.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/render/wlr_texture.h>
+#include <xf86drm.h>
+
+#include "umbrielfx/render/fx_renderer/fx_renderer.h"
+
+#define CREATE_CYCLES 8
+
+static bool same_drm_device(int first_fd, int second_fd) {
+	drmDevice *first = NULL;
+	drmDevice *second = NULL;
+	bool same = drmGetDevice2(first_fd, 0, &first) == 0 &&
+		drmGetDevice2(second_fd, 0, &second) == 0 &&
+		drmDevicesEqual(first, second);
+	drmFreeDevice(&first);
+	drmFreeDevice(&second);
+	return same;
+}
+
+static int count_open_fds(void) {
+	DIR *directory = opendir("/proc/self/fd");
+	if (directory == NULL) {
+		return -1;
+	}
+
+	int count = 0;
+	struct dirent *entry;
+	while ((entry = readdir(directory)) != NULL) {
+		if (strcmp(entry->d_name, ".") != 0 &&
+				strcmp(entry->d_name, "..") != 0) {
+			count++;
+		}
+	}
+	closedir(directory);
+	return count;
+}
+
+static void print_open_fds(void) {
+	DIR *directory = opendir("/proc/self/fd");
+	if (directory == NULL) {
+		return;
+	}
+	struct dirent *entry;
+	while ((entry = readdir(directory)) != NULL) {
+		if (entry->d_name[0] == '.') {
+			continue;
+		}
+		char target[256];
+		ssize_t length = readlinkat(dirfd(directory), entry->d_name,
+			target, sizeof(target) - 1);
+		if (length >= 0) {
+			target[length] = '\0';
+			fprintf(stderr, "  fd %s: %s\n", entry->d_name, target);
+		}
+	}
+	closedir(directory);
+}
+
+static struct wlr_renderer *create_owned_renderer(int drm_fd) {
+	(void)drm_fd;
+	return fx_renderer_create(NULL);
+}
+
+static bool renderer_matches(struct wlr_renderer *renderer, int drm_fd) {
+	int renderer_fd = wlr_renderer_get_drm_fd(renderer);
+	return renderer_fd >= 0 && same_drm_device(drm_fd, renderer_fd);
+}
+
+static bool renderer_is_usable(struct wlr_renderer *renderer) {
+	const uint32_t input = 0xFF224466;
+	uint32_t output = 0;
+	struct wlr_texture *texture = wlr_texture_from_pixels(renderer,
+		DRM_FORMAT_ARGB8888, sizeof(input), 1, 1, &input);
+	if (texture == NULL) {
+		return false;
+	}
+	bool ok = wlr_texture_read_pixels(texture,
+		&(struct wlr_texture_read_pixels_options) {
+			.data = &output,
+			.format = DRM_FORMAT_ARGB8888,
+			.stride = sizeof(output),
+		});
+	wlr_texture_destroy(texture);
+	return ok && output == input;
+}
+
+static bool replacement_survives_old_renderer_destroy(int drm_fd) {
+	struct wlr_renderer *old_renderer =
+		fx_renderer_create_with_drm_fd_gbm(drm_fd);
+	struct wlr_renderer *replacement =
+		fx_renderer_create_with_drm_fd_gbm(drm_fd);
+	if (old_renderer == NULL || replacement == NULL) {
+		if (old_renderer != NULL) {
+			wlr_renderer_destroy(old_renderer);
+		}
+		if (replacement != NULL) {
+			wlr_renderer_destroy(replacement);
+		}
+		return false;
+	}
+
+	wlr_renderer_destroy(old_renderer);
+	bool ok = renderer_matches(replacement, drm_fd) &&
+		renderer_is_usable(replacement);
+	wlr_renderer_destroy(replacement);
+	return ok;
+}
+
+static bool descriptors_are_stable(
+		int drm_fd, struct wlr_renderer *(*create_renderer)(int)) {
+	struct wlr_renderer *renderer = create_renderer(drm_fd);
+	if (renderer == NULL) {
+		fprintf(stderr, "FAIL: renderer creation failed\n");
+		return false;
+	}
+	if (!renderer_matches(renderer, drm_fd)) {
+		fprintf(stderr, "FAIL: renderer used a different DRM device\n");
+		wlr_renderer_destroy(renderer);
+		return false;
+	}
+	if (!renderer_is_usable(renderer)) {
+		fprintf(stderr, "FAIL: renderer could not upload and read back a texture\n");
+		wlr_renderer_destroy(renderer);
+		return false;
+	}
+	wlr_renderer_destroy(renderer);
+
+	int before = count_open_fds();
+	if (before < 0) {
+		fprintf(stderr, "FAIL: could not inspect /proc/self/fd\n");
+		return false;
+	}
+	for (int i = 0; i < CREATE_CYCLES; i++) {
+		renderer = create_renderer(drm_fd);
+		if (renderer == NULL) {
+			fprintf(stderr, "FAIL: renderer creation failed in cycle %d\n", i + 1);
+			return false;
+		}
+		if (!renderer_matches(renderer, drm_fd)) {
+			fprintf(stderr, "FAIL: renderer changed DRM device in cycle %d\n", i + 1);
+			wlr_renderer_destroy(renderer);
+			return false;
+		}
+		wlr_renderer_destroy(renderer);
+	}
+	int after = count_open_fds();
+	if (after != before) {
+		fprintf(stderr, "FAIL: open descriptor count changed from %d to %d\n",
+			before, after);
+		print_open_fds();
+		return false;
+	}
+	return true;
+}
+
+int main(void) {
+	drmDevice **devices = NULL;
+	int devices_len = drmGetDevices2(0, NULL, 0);
+	if (devices_len <= 0) {
+		fprintf(stderr, "SKIP: no DRM devices\n");
+		return 77;
+	}
+	devices = calloc(devices_len, sizeof(*devices));
+	if (devices == NULL) {
+		return EXIT_FAILURE;
+	}
+	devices_len = drmGetDevices2(0, devices, devices_len);
+	if (devices_len < 0) {
+		free(devices);
+		return EXIT_FAILURE;
+	}
+
+	bool tested = false;
+	bool passed = false;
+	for (int i = 0; i < devices_len && !tested; i++) {
+		if (!(devices[i]->available_nodes & (1 << DRM_NODE_RENDER))) {
+			continue;
+		}
+		const char *path = devices[i]->nodes[DRM_NODE_RENDER];
+		int drm_fd = open(path, O_RDWR | O_CLOEXEC);
+		if (drm_fd < 0) {
+			continue;
+		}
+		if (setenv("WLR_RENDER_DRM_DEVICE", path, 1) != 0) {
+			tested = true;
+			close(drm_fd);
+			break;
+		}
+
+		struct wlr_renderer *probe =
+			fx_renderer_create_with_drm_fd_gbm(drm_fd);
+		if (probe == NULL) {
+			close(drm_fd);
+			continue;
+		}
+		tested = true;
+		if (!renderer_matches(probe, drm_fd)) {
+			wlr_renderer_destroy(probe);
+			close(drm_fd);
+			break;
+		}
+		wlr_renderer_destroy(probe);
+
+		if (!replacement_survives_old_renderer_destroy(drm_fd)) {
+			fprintf(stderr,
+				"FAIL: replacement renderer did not survive old renderer teardown\n");
+		} else if (descriptors_are_stable(drm_fd,
+				fx_renderer_create_with_drm_fd_gbm)) {
+			passed = descriptors_are_stable(drm_fd, create_owned_renderer);
+		}
+		close(drm_fd);
+	}
+
+	drmFreeDevices(devices, devices_len);
+	free(devices);
+	if (!tested) {
+		fprintf(stderr, "SKIP: no usable DRM render node\n");
+		return 77;
+	}
+	if (!passed) {
+		fprintf(stderr, "FAIL: renderer changed GPU or leaked a descriptor\n");
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary

Add an optional native DRM policy for selecting the render device and excluding GPUs from Umbriel.

The GBM-only renderer portion supersedes `noctalia-dev/scenefx#1` now that SceneFX is maintained as the vendored `umbrielfx/` hard fork in this repository.

## Implementation

- add `drm.render_device`, `drm.ignored_devices`, and `drm.ignored_pci_addresses`
- enumerate eligible GPUs through udev before opening KMS devices
- create independent allowed DRM backends so wlroots cannot start a hidden EGL-enumerating multi-GPU renderer
- add an explicit GBM-only renderer path to the vendored `umbrielfx` code while preserving the existing renderer path
- verify the renderer remains on the selected physical GPU
- audit open device descriptors after renderer, allocator, and recovery setup
- fail closed on invalid selectors, incomplete NVIDIA metadata, or an exclusion guarantee failure
- preserve the existing backend and renderer behavior when no DRM policy is configured

Allowed secondary GPUs use direct DMA-BUF import. An output on a secondary GPU is unavailable when its driver is incompatible with the renderer GPU formats or modifiers.

## Verification

- Umbriel and `umbrielfx` tests: 46/46 passed
- GBM renderer identity, recreation, and descriptor ownership test passed on hardware
- focused compositor, security, and rendering checks: 18/18 passed
- a fresh Meson build succeeds without SceneFX submodule options
- clang-tidy reports only the two existing `main` findings in `tests/unit/keybind_parse.cpp:696-697`
- prior live dual-GPU testing retained only the selected AMD DRM descriptors and opened no excluded NVIDIA device
