### PR TITLE
fix: struts breaking scrolling gaps of fullscreen and maximize to edges columns

### DIFF
--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -286,4 +286,6 @@ restores its exact previous box, including its last dropped position. Both
 directions use the `animation.windows_move` transition.
 `window-toggle-maximize-to-edges` drops layout struts, gaps, and borders, while
 layer-shell exclusive zones remain visible. A column's full-width restore state
-survives that toggle and a fullscreen round trip.
+survives that toggle and a fullscreen round trip. In the scrolling layout the
+strip reserves the strut band such a column reaches past, so neighboring
+columns keep their gap instead of sitting underneath the window.

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -103,24 +103,25 @@ namespace umbriel {
       return false;
     }
 
-    int primaryStrutBefore(const Layout& layout) {
-      const auto& struts = layout.layoutConfig()->struts;
+    // Fullscreen and maximize-to-edges views are presented against the wider
+    // usable area, so they bleed one strut past each end of the strut-inset
+    // strip. The strip reserves that overhang, otherwise the neighboring column
+    // lands underneath the window. Fullscreen is presented against the whole
+    // output, so only its strut share is reserved and it still bleeds over a
+    // layer-shell exclusive zone.
+    struct ColumnBleed {
+      int before = 0;
+      int after = 0;
+    };
+
+    ColumnBleed columnBleed(const Column& column, const Layout& layout) {
+      if (!columnFillsViewport(column, layout)) {
+        return {};
+      }
+      const LayoutStruts& struts = layout.layoutConfig()->struts;
       const bool vertical = layout.layoutConfig()->scrolling.direction == ScrollingDirection::Vertical;
-      return vertical ? struts.top : struts.left;
-    }
-
-    int primaryStrutAfter(const Layout& layout) {
-      const auto& struts = layout.layoutConfig()->struts;
-      const bool vertical = layout.layoutConfig()->scrolling.direction == ScrollingDirection::Vertical;
-      return vertical ? struts.bottom : struts.right;
-    }
-
-    int columnBleedBefore(const Column& column, const Layout& layout) {
-      return columnFillsViewport(column, layout) ? primaryStrutBefore(layout) : 0;
-    }
-
-    int columnBleedAfter(const Column& column, const Layout& layout) {
-      return columnFillsViewport(column, layout) ? primaryStrutAfter(layout) : 0;
+      return vertical ? ColumnBleed{.before = struts.top, .after = struts.bottom}
+                      : ColumnBleed{.before = struts.left, .after = struts.right};
     }
 
   } // namespace
@@ -355,11 +356,13 @@ namespace umbriel {
     const int gap = m_config->totalGap;
     int x = centeringOffset(viewportPrimary);
     for (int i = 0; i < end; ++i) {
-      const Column& column = m_columns[static_cast<size_t>(i)];
-      x += columnBleedBefore(column, *this) + columnWidth(i, viewportPrimary) + gap + columnBleedAfter(column, *this);
+      const ColumnBleed bleed = columnBleed(m_columns[static_cast<size_t>(i)], *this);
+      x += bleed.before + columnWidth(i, viewportPrimary) + gap + bleed.after;
     }
-    if (columnIndex >= 0 && columnIndex < static_cast<int>(m_columns.size())) {
-      x += columnBleedBefore(m_columns[static_cast<size_t>(columnIndex)], *this);
+    if (columnIndex >= 0 && end < static_cast<int>(m_columns.size())) {
+      // The column's own leading bleed. Presentation subtracts the same strut,
+      // so the window's leading edge lands where the strip band starts.
+      x += columnBleed(m_columns[static_cast<size_t>(end)], *this).before;
     }
     return x;
   }
@@ -371,11 +374,8 @@ namespace umbriel {
     const int gap = m_config->totalGap;
     int total = -gap;
     for (size_t i = 0; i < m_columns.size(); ++i) {
-      const Column& column = m_columns[i];
-      total += columnBleedBefore(column, *this)
-          + columnWidth(static_cast<int>(i), viewportPrimary)
-          + gap
-          + columnBleedAfter(column, *this);
+      const ColumnBleed bleed = columnBleed(m_columns[i], *this);
+      total += bleed.before + columnWidth(static_cast<int>(i), viewportPrimary) + gap + bleed.after;
     }
     return std::max(0, total);
   }
@@ -660,10 +660,13 @@ namespace umbriel {
     if (column.views.size() != 1) {
       return 0.0;
     }
-    const double span = static_cast<double>(columnWidth(columnIndex, viewportPrimary))
-        + m_config->totalGap
-        + columnBleedAfter(column, *this);
-    const double hidden = m_scroll - static_cast<double>(columnX(columnIndex, viewportPrimary));
+    // The lane frees its bleed on both sides too. columnX() already includes the
+    // leading one, so measure the hidden extent from where that bleed starts.
+    const ColumnBleed bleed = columnBleed(column, *this);
+    const auto span = static_cast<double>(
+        bleed.before + columnWidth(columnIndex, viewportPrimary) + m_config->totalGap + bleed.after
+    );
+    const double hidden = m_scroll - static_cast<double>(columnX(columnIndex, viewportPrimary) - bleed.before);
     return std::clamp(hidden, 0.0, span);
   }
 
@@ -698,16 +701,17 @@ namespace umbriel {
     int runningColumnX = centeringOffset(viewportPrimary);
     for (size_t columnIndex = 0; columnIndex < m_columns.size(); ++columnIndex) {
       Column& column = m_columns[columnIndex];
-      runningColumnX += columnBleedBefore(column, *this);
+      const ColumnBleed bleed = columnBleed(column, *this);
+      runningColumnX += bleed.before;
       const int primarySize = columnWidth(static_cast<int>(columnIndex), viewportPrimary);
       if (column.views.empty()) {
-        runningColumnX += primarySize + gap + columnBleedAfter(column, *this);
+        runningColumnX += primarySize + gap + bleed.after;
         continue;
       }
       ensureWeightCount(column);
       const int primary =
           (v ? usable.y : usable.x) + edgePad + runningColumnX - static_cast<int>(std::lround(m_scroll));
-      runningColumnX += primarySize + gap + columnBleedAfter(column, *this);
+      runningColumnX += primarySize + gap + bleed.after;
       const int rowCount = static_cast<int>(column.views.size());
       const int gapsTotal = std::max(0, rowCount - 1) * gap;
       const int stackCross = std::max(rowCount, availableCross - gapsTotal);

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -103,6 +103,26 @@ namespace umbriel {
       return false;
     }
 
+    int primaryStrutBefore(const Layout& layout) {
+      const auto& struts = layout.layoutConfig()->struts;
+      const bool vertical = layout.layoutConfig()->scrolling.direction == ScrollingDirection::Vertical;
+      return vertical ? struts.top : struts.left;
+    }
+
+    int primaryStrutAfter(const Layout& layout) {
+      const auto& struts = layout.layoutConfig()->struts;
+      const bool vertical = layout.layoutConfig()->scrolling.direction == ScrollingDirection::Vertical;
+      return vertical ? struts.bottom : struts.right;
+    }
+
+    int columnBleedBefore(const Column& column, const Layout& layout) {
+      return columnFillsViewport(column, layout) ? primaryStrutBefore(layout) : 0;
+    }
+
+    int columnBleedAfter(const Column& column, const Layout& layout) {
+      return columnFillsViewport(column, layout) ? primaryStrutAfter(layout) : 0;
+    }
+
   } // namespace
 
   bool ScrollingLayout::vertical() const { return m_config->scrolling.direction == ScrollingDirection::Vertical; }
@@ -335,7 +355,11 @@ namespace umbriel {
     const int gap = m_config->totalGap;
     int x = centeringOffset(viewportPrimary);
     for (int i = 0; i < end; ++i) {
-      x += columnWidth(i, viewportPrimary) + gap;
+      const Column& column = m_columns[static_cast<size_t>(i)];
+      x += columnBleedBefore(column, *this) + columnWidth(i, viewportPrimary) + gap + columnBleedAfter(column, *this);
+    }
+    if (columnIndex >= 0 && columnIndex < static_cast<int>(m_columns.size())) {
+      x += columnBleedBefore(m_columns[static_cast<size_t>(columnIndex)], *this);
     }
     return x;
   }
@@ -347,7 +371,11 @@ namespace umbriel {
     const int gap = m_config->totalGap;
     int total = -gap;
     for (size_t i = 0; i < m_columns.size(); ++i) {
-      total += columnWidth(static_cast<int>(i), viewportPrimary) + gap;
+      const Column& column = m_columns[i];
+      total += columnBleedBefore(column, *this)
+          + columnWidth(static_cast<int>(i), viewportPrimary)
+          + gap
+          + columnBleedAfter(column, *this);
     }
     return std::max(0, total);
   }
@@ -628,10 +656,13 @@ namespace umbriel {
     }
     // A stack losing one row leaves the horizontal geometry alone; only the
     // last view out takes the column, and the space, with it.
-    if (m_columns[static_cast<size_t>(columnIndex)].views.size() != 1) {
+    const Column& column = m_columns[static_cast<size_t>(columnIndex)];
+    if (column.views.size() != 1) {
       return 0.0;
     }
-    const double span = static_cast<double>(columnWidth(columnIndex, viewportPrimary)) + m_config->totalGap;
+    const double span = static_cast<double>(columnWidth(columnIndex, viewportPrimary))
+        + m_config->totalGap
+        + columnBleedAfter(column, *this);
     const double hidden = m_scroll - static_cast<double>(columnX(columnIndex, viewportPrimary));
     return std::clamp(hidden, 0.0, span);
   }
@@ -667,15 +698,16 @@ namespace umbriel {
     int runningColumnX = centeringOffset(viewportPrimary);
     for (size_t columnIndex = 0; columnIndex < m_columns.size(); ++columnIndex) {
       Column& column = m_columns[columnIndex];
+      runningColumnX += columnBleedBefore(column, *this);
       const int primarySize = columnWidth(static_cast<int>(columnIndex), viewportPrimary);
       if (column.views.empty()) {
-        runningColumnX += primarySize + gap;
+        runningColumnX += primarySize + gap + columnBleedAfter(column, *this);
         continue;
       }
       ensureWeightCount(column);
       const int primary =
           (v ? usable.y : usable.x) + edgePad + runningColumnX - static_cast<int>(std::lround(m_scroll));
-      runningColumnX += primarySize + gap;
+      runningColumnX += primarySize + gap + columnBleedAfter(column, *this);
       const int rowCount = static_cast<int>(column.views.size());
       const int gapsTotal = std::max(0, rowCount - 1) * gap;
       const int stackCross = std::max(rowCount, availableCross - gapsTotal);

--- a/tests/harness/checks/152_layout_struts.sh
+++ b/tests/harness/checks/152_layout_struts.sh
@@ -2,8 +2,9 @@
 # harness: outputs=1
 # Layout struts reserve signed logical space for normal tiled windows after a
 # real layer-shell exclusive zone. Floating windows, maximize-to-edges, and
-# fullscreen keep their broader Niri-style areas, and reload removes struts
-# from already mapped workspaces.
+# fullscreen keep their own broader areas while the scrolling strip reserves the
+# strut band they bleed into, and reload removes struts from already mapped
+# workspaces.
 set -euo pipefail
 
 readonly CLIENT="${UMBRIEL_FRACTIONAL_CLIENT:-./build-debug/fractional-client}"
@@ -248,6 +249,21 @@ assert_box strut-scroll-h 608 604 25 79
 capture_maximized_to_edges strut-scroll-h
 "$UMBRIEL" msg window-toggle-maximize-to-edges > /dev/null
 assert_box strut-scroll-h 608 604 25 79
+
+# A maximize-to-edges window is presented against the usable area, past the
+# struts the strip is inset by, so the strip has to reserve that band: the
+# neighboring column keeps one gap of clearance instead of ending up underneath
+# the window.
+spawn_client strut-scroll-neighbor
+focus_window strut-scroll-neighbor
+assert_box strut-scroll-neighbor 608 604 641 79
+focus_window strut-scroll-h
+"$UMBRIEL" msg window-toggle-maximize-to-edges > /dev/null
+capture_maximized_to_edges strut-scroll-h
+assert_box strut-scroll-neighbor 608 604 1288 79
+"$UMBRIEL" msg window-toggle-maximize-to-edges > /dev/null
+assert_box strut-scroll-h 608 604 25 79
+assert_box strut-scroll-neighbor 608 604 641 79
 
 "$UMBRIEL" msg workspace-switch:scroll-v > /dev/null
 spawn_client strut-scroll-v

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -585,6 +585,35 @@ UMBRIEL_TEST(maximizedToEdgesColumnFillsTheUsableAreaIgnoringFractions) {
   CHECK(!fixture.layout.isFullWidth(1));
 }
 
+// A column that fills the viewport is presented against the usable area rather than the strut-inset strip, so the
+// strip has to reserve the strut band the window bleeds into. Without that reservation the next column keeps its old
+// offset and the window paints over it.
+UMBRIEL_TEST(aFillingColumnReservesTheStrutBandItBleedsInto) {
+  Fixture fixture;
+  fixture.config.struts = {.left = 17, .right = 23};
+  fixture.addColumns(2);
+  CHECK(fixture.layout.setWidthFraction(1, 0.5));
+  fixture.layout.setConstraints([](const View* view) {
+    return LayoutConstraints{.maximizedToEdges = view == stub(0)};
+  });
+  const int filling = kViewport + 2 * fixture.config.edgePad;
+  CHECK_EQ(fixture.layout.columnWidth(0, kViewport), filling);
+  // Leading strut for the filling column, trailing strut before its neighbor.
+  CHECK_EQ(fixture.layout.columnX(0, kViewport), 17);
+  CHECK_EQ(fixture.layout.columnX(1, kViewport), 17 + filling + fixture.config.totalGap + 23);
+}
+
+UMBRIEL_TEST(aFillingColumnInAVerticalStripReservesTheTopAndBottomStruts) {
+  Fixture fixture(ScrollingDirection::Vertical);
+  fixture.config.struts = {.left = 17, .right = 23, .top = 31, .bottom = 41};
+  fixture.addColumns(2);
+  CHECK(fixture.layout.setWidthFraction(1, 0.5));
+  fixture.layout.setConstraints([](const View* view) { return LayoutConstraints{.fullscreen = view == stub(0)}; });
+  const int filling = kVerticalViewport + 2 * fixture.config.edgePad;
+  CHECK_EQ(fixture.layout.columnX(0, kVerticalViewport), 31);
+  CHECK_EQ(fixture.layout.columnX(1, kVerticalViewport), 31 + filling + fixture.config.totalGap + 41);
+}
+
 UMBRIEL_TEST(preservedFullWidthSurvivesEdgeMaximizeToggle) {
   Fixture fixture;
   fixture.addColumns(1);
@@ -711,6 +740,26 @@ UMBRIEL_TEST(theShiftIsTheColumnWidthPlusOneGap) {
   fixture.layout.setScroll(636);
   // 624 wide + 12 of gap: the whole span the column occupied.
   CHECK_EQ(fixture.layout.scrollShiftForColumnRemoval(0, kViewport), 636.0);
+}
+
+UMBRIEL_TEST(closingAnOffScreenFillingColumnCompensatesItsBleedToo) {
+  Fixture fixture;
+  fixture.config.struts = {.left = 17, .right = 23};
+  fixture.addColumns(3);
+  fixture.layout.setConstraints([](const View* view) {
+    return LayoutConstraints{.maximizedToEdges = view == stub(0)};
+  });
+  // 17 of leading strut, 1280 of column, 12 of gap and 23 of trailing strut: the whole span column 0 held.
+  const double span = 17 + (kViewport + 2 * fixture.config.edgePad) + fixture.config.totalGap + 23;
+  fixture.layout.setScroll(span);
+  const int before = screenX(fixture.layout, 1);
+
+  const double shift = fixture.layout.scrollShiftForColumnRemoval(0, kViewport);
+  CHECK_EQ(shift, span);
+  fixture.layout.removeView(stub(0));
+  fixture.layout.setScroll(fixture.layout.scroll() - shift);
+
+  CHECK_EQ(screenX(fixture.layout, 0), before);
 }
 
 UMBRIEL_TEST(aColumnAtTheViewportEdgeIsNotCompensated) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
add the gaps for fullscreen and maximize-to-edges when struts are configured

## Motivation

<!-- What problem does this solve? -->
fullscreen and maximized to edges windows over other windows when struts are configured.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Closes #85

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just format`
`just test`
`just lint`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
