### PR TITLE
feat: right click while dragging toggle floating

### DIFF
--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -8,6 +8,7 @@ place.
 ```toml
 [input]
 middle_click_paste = false
+window_drag_toggle = "floating"
 ```
 
 `middle_click_paste` controls the primary-selection clipboard. It defaults to
@@ -22,6 +23,9 @@ disabled are not offered the primary-selection protocol. The setting applies
 immediately on config reload, but protocol visibility is fixed when an
 application connects. Applications started while it was disabled must be
 restarted after re-enabling it.
+
+`window_drag_toggle` defines the action triggered by right-clicking while dragging
+a window. The options are `none` to disable, `floating` or `pinned`.
 
 ### Keyboard
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -239,7 +239,8 @@ new_on_top = true             # place new windows at the top of the stack
 # Input ----------------------------------------------------------------------
 
 [input]
-middle_click_paste = true      # primary-selection clipboard, applies on reload
+middle_click_paste = true       # primary-selection clipboard, applies on reload
+window_drag_toggle = "floating" # "none", "floating" or "pinned"
 
 [input.keyboard]
 # ASCII keybind fallback uses only layouts listed for this keyboard; a single

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -78,6 +78,20 @@ namespace umbriel {
       return std::nullopt;
     }
 
+    std::optional<WindowDragToggle> readWindowDragToggle(const toml::node& node) {
+      const auto value = node.value<std::string>();
+      if (value == "none") {
+        return WindowDragToggle::None;
+      }
+      if (value == "floating") {
+        return WindowDragToggle::Floating;
+      }
+      if (value == "pinned") {
+        return WindowDragToggle::Pinned;
+      }
+      return std::nullopt;
+    }
+
     std::optional<HdrMode> readHdrMode(const toml::node& node) {
       const auto value = node.value<std::string>();
       if (value == "off") {
@@ -1158,6 +1172,13 @@ namespace umbriel {
       auto& in = loaded.input;
       root.sub("input", [&](Section& s) {
         s.boolean("middle_click_paste", in.middleClickPaste);
+        if (const toml::node* node = s.take("window_drag_toggle")) {
+          if (const auto value = readWindowDragToggle(*node)) {
+            in.windowDragToggle = *value;
+          } else {
+            warnAt(node->source(), R"(ignoring input.window_drag_toggle (expected "none", "floating", or "pinned"))");
+          }
+        }
         s.sub("keyboard", [&](Section& k) {
           k.text("layout", in.keyboard.layout)
               .text("variant", in.keyboard.variant)

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -131,6 +131,13 @@ namespace umbriel {
     Global,
     Window,
   };
+
+  enum class WindowDragToggle : uint8_t {
+    None,
+    Floating,
+    Pinned,
+  };
+
   enum class HdrMode {
     Off,
     On,
@@ -603,6 +610,7 @@ namespace umbriel {
       // Advertise and accept the primary-selection clipboard used for
       // middle-click paste.
       bool middleClickPaste = true;
+      WindowDragToggle windowDragToggle = WindowDragToggle::Floating;
 
       struct Keyboard {
         // Comma-separated XKB layout list ("us,de"); the first entry is active at startup. `options` carries XKB option

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -1773,10 +1773,10 @@ namespace umbriel {
     if (button != toggleButton) {
       return;
     }
-    m_server->hideInsertHint();
     if (config().input.windowDragToggle == WindowDragToggle::None) {
       return;
     }
+    m_server->hideInsertHint();
 
     if (auto* grab = std::get_if<TiledMoveGrab>(&m_grab)) {
       View* view = grab->view;

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -1774,6 +1774,9 @@ namespace umbriel {
       return;
     }
     m_server->hideInsertHint();
+    if (config().input.windowDragToggle == WindowDragToggle::None) {
+      return;
+    }
 
     if (auto* grab = std::get_if<TiledMoveGrab>(&m_grab)) {
       View* view = grab->view;
@@ -1787,7 +1790,11 @@ namespace umbriel {
         }
         view->enterDragPresentation();
       }
-      view->setFloating(true, false);
+      if (config().input.windowDragToggle == WindowDragToggle::Pinned) {
+        view->setPinned(true, false);
+      } else {
+        view->setFloating(true, false);
+      }
       // Preserve the cursor's relative position within the window across the size change
       const std::array<int, 2> floatSize = view->floatingSize();
       const wlr_box& geo = view->toplevel()->base->geometry;
@@ -1812,7 +1819,11 @@ namespace umbriel {
     }
 
     Workspace* workspace = view->workspace();
-    view->setFloating(false, false);
+    if (config().input.windowDragToggle == WindowDragToggle::Pinned) {
+      view->setPinned(false, false);
+    } else {
+      view->setFloating(false, false);
+    }
     int sourceColumn = -1;
     std::optional<DropColumnWidth> sourceWidth = std::nullopt;
     if (workspace != nullptr) {

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -19,6 +19,7 @@
 #include "view/xdg_size.h"
 // clang-format off
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <linux/input-event-codes.h>
@@ -596,6 +597,7 @@ namespace umbriel {
     }
     const bool restoreDragPresentation = std::holds_alternative<FloatingMoveGrab>(m_grab)
         || (std::get_if<TiledMoveGrab>(&m_grab) != nullptr && !std::get<TiledMoveGrab>(m_grab).pending);
+    const bool leavingFloatingMove = std::holds_alternative<FloatingMoveGrab>(m_grab);
     if (std::holds_alternative<FloatingResizeGrab>(m_grab) && view != nullptr) {
       view->finishFloatingResize();
     }
@@ -603,6 +605,9 @@ namespace umbriel {
     m_moveButton = 0;
     if (restoreDragPresentation && view != nullptr) {
       view->restoreHomePresentation();
+    }
+    if (leavingFloatingMove && view != nullptr && view->mapped()) {
+      view->finishSizeAnimation();
     }
     refreshInteractiveCursor();
   }
@@ -787,6 +792,7 @@ namespace umbriel {
     if (m_moveButton != 0 && button != m_moveButton) {
       if (state == WL_POINTER_BUTTON_STATE_PRESSED) {
         m_swallowedButtons.push_back(button);
+        toggleFloatingDuringMove(button);
       }
       return;
     }
@@ -1760,6 +1766,78 @@ namespace umbriel {
 
     resetMode();
     m_server->focusView(view, FocusReason::DragDrop);
+  }
+
+  void Cursor::toggleFloatingDuringMove(uint32_t button) {
+    const uint32_t toggleButton = m_moveButton == BTN_LEFT ? BTN_RIGHT : BTN_LEFT;
+    if (button != toggleButton) {
+      return;
+    }
+    m_server->hideInsertHint();
+
+    if (auto* grab = std::get_if<TiledMoveGrab>(&m_grab)) {
+      View* view = grab->view;
+      if (view == nullptr || !view->mapped()) {
+        return;
+      }
+      if (grab->pending) {
+        grab->pending = false;
+        if (grab->sourceWorkspace != nullptr) {
+          grab->sourceWorkspace->layoutDetach(grab->view);
+        }
+        view->enterDragPresentation();
+      }
+      view->setFloating(true, false);
+      // Preserve the cursor's relative position within the window across the size change
+      const std::array<int, 2> floatSize = view->floatingSize();
+      const wlr_box& geo = view->toplevel()->base->geometry;
+      const double windowWidth = std::max(1, geo.width);
+      const double windowHeight = std::max(1, geo.height);
+      const double offsetX = static_cast<double>(floatSize[0]) * (grab->offsetX / windowWidth);
+      const double offsetY = static_cast<double>(floatSize[1]) * (grab->offsetY / windowHeight);
+      m_grab = FloatingMoveGrab{.view = view, .offsetX = offsetX, .offsetY = offsetY};
+      view->enterDragPresentation();
+      processMove();
+      return;
+    }
+
+    auto* grab = std::get_if<FloatingMoveGrab>(&m_grab);
+    if (grab == nullptr || grab->view == nullptr || !grab->view->mapped()) {
+      return;
+    }
+    View* view = grab->view;
+
+    if (m_server->scratchpadManager() != nullptr && m_server->scratchpadManager()->contains(view)) {
+      return;
+    }
+
+    Workspace* workspace = view->workspace();
+    view->setFloating(false, false);
+    int sourceColumn = -1;
+    std::optional<DropColumnWidth> sourceWidth = std::nullopt;
+    if (workspace != nullptr) {
+      sourceColumn = workspace->layout().columnOf(view);
+      sourceWidth = captureDropColumnWidth(*workspace, view);
+      workspace->layoutDetach(view);
+    }
+    const double offsetX = m_cursor->x - view->sceneTree()->node.x;
+    const double offsetY = m_cursor->y - view->sceneTree()->node.y;
+    TiledMoveGrab tiledGrab{
+        .view = view,
+        .offsetX = offsetX,
+        .offsetY = offsetY,
+        .sourceWorkspace = workspace,
+        .sourceColumn = sourceColumn,
+        .sourceWidth = sourceWidth,
+        .drop = {.workspace = workspace, .column = std::max(0, sourceColumn)},
+        .pending = false,
+        .startX = m_cursor->x,
+        .startY = m_cursor->y,
+    };
+    m_grab = tiledGrab;
+    view->enterDragPresentation();
+    processMove();
+    updateDropTarget();
   }
 
   void Cursor::processResize() {

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -1820,7 +1820,13 @@ namespace umbriel {
 
     Workspace* workspace = view->workspace();
     if (config().input.windowDragToggle == WindowDragToggle::Pinned) {
-      view->setPinned(false, false);
+      const bool wasPinned = view->pinned();
+      view->setPinned(!wasPinned, false);
+      if (view->floating()) {
+        view->enterDragPresentation();
+        processMove();
+        return;
+      }
     } else {
       view->setFloating(false, false);
     }

--- a/src/input/cursor.h
+++ b/src/input/cursor.h
@@ -194,6 +194,7 @@ namespace umbriel {
     void updateDropTarget();
     void finishTileMove();
     void finishFloatMove();
+    void toggleFloatingDuringMove(uint32_t button);
     void processResize();
     void processResizeTile();
     [[nodiscard]] uint32_t floatResizeEdges(View* view) const;

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -610,6 +610,16 @@ namespace umbriel {
       updateShadow(width, height);
     }
     updateBlur(width, height);
+    if (m_workspace != nullptr && m_server->cursor() != nullptr && m_server->cursor()->isDraggingView(this)) {
+      const wlr_box content = {m_sceneTree->node.x, m_sceneTree->node.y, width, height};
+      const wlr_box surfaceClip = {
+          m_toplevel->base->geometry.x - m_presentation.offsetX(),
+          m_toplevel->base->geometry.y - m_presentation.offsetY(), width, height
+      };
+      setSurfaceTreeClip(&surfaceClip);
+      applyPresentedCrop(content, surfaceClip);
+      return;
+    }
     if (m_workspace != nullptr) {
       m_workspace->syncViewPresentation(this);
     }
@@ -812,7 +822,7 @@ namespace umbriel {
       }
       if (sizeAnimating()) {
         active = true;
-      } else {
+      } else if (!sizeGrabActive()) {
         finishSizeAnimation();
       }
     }
@@ -1523,6 +1533,26 @@ namespace umbriel {
   void View::resizeFloating(int width, int height) {
     syncFloatingResizePosition();
     requestFloatingSize(width, height);
+  }
+
+  void View::presentFloatingResizeSize(int width, int height) {
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+    const auto& animation = config().animation;
+    const auto& move = animation.windowsMove;
+    if (width == m_presentation.width() && height == m_presentation.height()) {
+      return;
+    }
+    if (animation.enabled && move.enabled) {
+      if (m_presentation.targeting(width, height)) {
+        return;
+      }
+      m_presentation.animateTo(width, height, move.durationMs, move.curve);
+      scheduleFrame();
+    } else {
+      m_presentation.setSize(width, height);
+    }
   }
 
   void View::finishFloatingResize() { m_floating.endResize(); }
@@ -2596,7 +2626,11 @@ namespace umbriel {
           && (m_toplevel->scheduled.width != keepWidth || m_toplevel->scheduled.height != keepHeight)) {
         requestFloatingSize(keepWidth, keepHeight);
       }
-      beginResizeAnimation(keepWidth, keepHeight);
+      if (sizeGrabActive()) {
+        presentFloatingResizeSize(keepWidth, keepHeight);
+      } else {
+        beginResizeAnimation(keepWidth, keepHeight);
+      }
       const wlr_box usable = floatingUsableArea();
       int floatX = keepX + 50;
       int floatY = keepY + 50;

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -349,6 +349,7 @@ namespace umbriel {
     void resizeFloating(int width, int height);
     void finishFloatingResize();
     void syncFloatingResizePosition();
+    void presentFloatingResizeSize(int width, int height);
     void adoptFloatingClientSize();
     void placeInUsableArea(const std::optional<WindowPosition>& position = std::nullopt);
     void setPinned(bool pinned, bool focus);


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
right click while dragging a window toggle floating or pinned according to the config, can also be disabled.
the window is moved to the cursor position if the size changes.

## Motivation

<!-- What problem does this solve? -->
I used that in niri, and got used to it.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just format`
`just test`
`just lint`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
