### PR TITLE
fix(layout): resize past neighbor minimum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ result
 result-*
 /TODO.md
 /pr-*.md
+/.github/workflows/scripts/__pycache__

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -1020,8 +1020,9 @@ namespace umbriel {
             if (requestedPrev < minimumPrev && minimumPrev == minPrev) {
               newCur = std::min(m_startPrimaryPx - static_cast<int>(std::lround(dPrimary)), maxCur);
               layout.setScroll(
-                  m_startScroll + static_cast<double>(layout.columnX(m_column, viewportPrimary) - m_startColumnX)
-                  + static_cast<double>(newCur - m_startPrimaryPx),
+                  m_startScroll
+                      + static_cast<double>(layout.columnX(m_column, viewportPrimary) - m_startColumnX)
+                      + static_cast<double>(newCur - m_startPrimaryPx),
                   true
               );
             }

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -1012,11 +1012,14 @@ namespace umbriel {
             const int minCur = columnMinPrimary(m_column);
             const int maxPrev = columnMaxPrimary(m_column - 1);
             const int maxCur = columnMaxPrimary(m_column);
-            const int newPrev = std::clamp(
-                m_startPrevPrimaryPx + static_cast<int>(std::lround(dPrimary)), std::max(minPrev, pair - gap - maxCur),
-                std::min(maxPrev, pair - gap - minCur)
-            );
-            const int newCur = pair - gap - newPrev;
+            const int requestedPrev = m_startPrevPrimaryPx + static_cast<int>(std::lround(dPrimary));
+            const int minimumPrev = std::max(minPrev, pair - gap - maxCur);
+            const int maximumPrev = std::min(maxPrev, pair - gap - minCur);
+            const int newPrev = std::clamp(requestedPrev, minimumPrev, maximumPrev);
+            int newCur = pair - gap - newPrev;
+            if (requestedPrev < minimumPrev && minimumPrev == minPrev) {
+              newCur = std::min(m_startPrimaryPx - static_cast<int>(std::lround(dPrimary)), maxCur);
+            }
             setColumnPrimaryPx(m_column - 1, newPrev);
             setColumnPrimaryPx(m_column, newCur);
           } else {

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -1019,6 +1019,11 @@ namespace umbriel {
             int newCur = pair - gap - newPrev;
             if (requestedPrev < minimumPrev && minimumPrev == minPrev) {
               newCur = std::min(m_startPrimaryPx - static_cast<int>(std::lround(dPrimary)), maxCur);
+              layout.setScroll(
+                  m_startScroll + static_cast<double>(layout.columnX(m_column, viewportPrimary) - m_startColumnX)
+                  + static_cast<double>(newCur - m_startPrimaryPx),
+                  true
+              );
             }
             setColumnPrimaryPx(m_column - 1, newPrev);
             setColumnPrimaryPx(m_column, newCur);

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -1017,8 +1017,13 @@ namespace umbriel {
             const int maximumPrev = std::min(maxPrev, pair - gap - minCur);
             const int newPrev = std::clamp(requestedPrev, minimumPrev, maximumPrev);
             int newCur = pair - gap - newPrev;
-            if (requestedPrev < minimumPrev && minimumPrev == minPrev) {
+            const bool growsPastPreviousMinimum = requestedPrev < minimumPrev && minimumPrev == minPrev;
+            if (growsPastPreviousMinimum) {
               newCur = std::min(m_startPrimaryPx - static_cast<int>(std::lround(dPrimary)), maxCur);
+            }
+            setColumnPrimaryPx(m_column - 1, newPrev);
+            setColumnPrimaryPx(m_column, newCur);
+            if (growsPastPreviousMinimum) {
               layout.setScroll(
                   m_startScroll
                       + static_cast<double>(layout.columnX(m_column, viewportPrimary) - m_startColumnX)
@@ -1026,8 +1031,6 @@ namespace umbriel {
                   true
               );
             }
-            setColumnPrimaryPx(m_column - 1, newPrev);
-            setColumnPrimaryPx(m_column, newCur);
           } else {
             const double extentDelta = centerUnderfullStrip ? centeredPrimaryDelta(-dPrimary) : -dPrimary;
             const int newExtent = std::clamp(

--- a/tests/harness/checks/516_resize_past_neighbor_minimum.sh
+++ b/tests/harness/checks/516_resize_past_neighbor_minimum.sh
@@ -31,8 +31,8 @@ wait_for_window() {
 }
 
 foot --title=resize-min-a sh -c 'sleep 120' > /dev/null 2>&1 &
-foot --title=resize-min-b sh -c 'sleep 120' > /dev/null 2>&1 &
 wait_for_window resize-min-a
+foot --title=resize-min-b sh -c 'sleep 120' > /dev/null 2>&1 &
 wait_for_window resize-min-b
 
 a=$(window resize-min-a)
@@ -56,11 +56,15 @@ pointer move "$(jq -r '.x + 20 | floor' <<< "$b_before")" "$(jq -r '.y + .h / 2 
 for _ in $(seq 60); do
   a=$(window resize-min-a)
   b_after=$(window resize-min-b)
-  [[ $(jq -r '.w' <<< "$a") -eq 189 && $(jq -r '.w' <<< "$b_after") -gt $(jq -r '.w' <<< "$b_before") ]] && break
+  [[ $(jq -r '.w' <<< "$a") -eq 189 \
+    && $(jq -r '.x' <<< "$b_after") -lt $(jq -r '.x' <<< "$b_before") \
+    && $(jq -r '.x + .w' <<< "$b_after") -le $(jq -r '.x + .w' <<< "$b_before") ]] && break
   sleep 0.1
 done
 
-if [[ $(jq -r '.w' <<< "$a") -ne 189 || $(jq -r '.w' <<< "$b_after") -le $(jq -r '.w' <<< "$b_before") ]]; then
+if [[ $(jq -r '.w' <<< "$a") -ne 189 \
+  || $(jq -r '.x' <<< "$b_after") -ge $(jq -r '.x' <<< "$b_before") \
+  || $(jq -r '.x + .w' <<< "$b_after") -gt $(jq -r '.x + .w' <<< "$b_before") ]]; then
   echo "leftward resize did not grow B after A reached minimum: before=$b_before after=$b_after windows=$($UMBRIEL windows --json)"
   exit 1
 fi

--- a/tests/harness/checks/516_resize_past_neighbor_minimum.sh
+++ b/tests/harness/checks/516_resize_past_neighbor_minimum.sh
@@ -58,13 +58,13 @@ for _ in $(seq 60); do
   b_after=$(window resize-min-b)
   [[ $(jq -r '.w' <<< "$a") -eq 189 \
     && $(jq -r '.x' <<< "$b_after") -lt $(jq -r '.x' <<< "$b_before") \
-    && $(jq -r '.x + .w' <<< "$b_after") -le $(jq -r '.x + .w' <<< "$b_before") ]] && break
+    && $(jq -r '.x + .w' <<< "$b_after") -eq $(jq -r '.x + .w' <<< "$b_before") ]] && break
   sleep 0.1
 done
 
 if [[ $(jq -r '.w' <<< "$a") -ne 189 \
   || $(jq -r '.x' <<< "$b_after") -ge $(jq -r '.x' <<< "$b_before") \
-  || $(jq -r '.x + .w' <<< "$b_after") -gt $(jq -r '.x + .w' <<< "$b_before") ]]; then
+  || $(jq -r '.x + .w' <<< "$b_after") -ne $(jq -r '.x + .w' <<< "$b_before") ]]; then
   echo "leftward resize did not grow B after A reached minimum: before=$b_before after=$b_after windows=$($UMBRIEL windows --json)"
   exit 1
 fi

--- a/tests/harness/checks/516_resize_past_neighbor_minimum.sh
+++ b/tests/harness/checks/516_resize_past_neighbor_minimum.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly BTN_RIGHT=273
+readonly OUTPUT_W=1280
+readonly OUTPUT_H=720
+readonly POINTER="${UMBRIEL_POINTER_CLIENT:-./build-debug/pointer-client}"
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+[layout.scrolling]
+default_width_fraction = 0.25
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+pointer() {
+  "$POINTER" "$OUTPUT_W" "$OUTPUT_H" "$@"
+}
+
+window() {
+  "$UMBRIEL" windows --json | jq -c --arg title "$1" '.[] | select(.title == $title)'
+}
+
+wait_for_window() {
+  local title=$1
+  for _ in $(seq 60); do
+    [[ -n $(window "$title") ]] && return 0
+    sleep 0.1
+  done
+  echo "timed out waiting for $title"
+  return 1
+}
+
+foot --title=resize-min-a sh -c 'sleep 120' > /dev/null 2>&1 &
+foot --title=resize-min-b sh -c 'sleep 120' > /dev/null 2>&1 &
+wait_for_window resize-min-a
+wait_for_window resize-min-b
+
+a=$(window resize-min-a)
+pointer move "$(jq -r '.x + .w - 20 | floor' <<< "$a")" "$(jq -r '.y + .h / 2 | floor' <<< "$a")" \
+  mod logo press "$BTN_RIGHT" move 200 360 release "$BTN_RIGHT" mod none
+
+for _ in $(seq 60); do
+  a=$(window resize-min-a)
+  [[ $(jq -r '.w' <<< "$a") -eq 189 ]] && break
+  sleep 0.1
+done
+if [[ $(jq -r '.w' <<< "$a") -ne 189 ]]; then
+  echo "left window did not reach its 189px resize minimum: $a"
+  exit 1
+fi
+
+b_before=$(window resize-min-b)
+pointer move "$(jq -r '.x + 20 | floor' <<< "$b_before")" "$(jq -r '.y + .h / 2 | floor' <<< "$b_before")" \
+  mod logo press "$BTN_RIGHT" move "$(jq -r '.x - 80 | floor' <<< "$b_before")" 360 release "$BTN_RIGHT" mod none
+
+for _ in $(seq 60); do
+  a=$(window resize-min-a)
+  b_after=$(window resize-min-b)
+  [[ $(jq -r '.w' <<< "$a") -eq 189 && $(jq -r '.w' <<< "$b_after") -gt $(jq -r '.w' <<< "$b_before") ]] && break
+  sleep 0.1
+done
+
+if [[ $(jq -r '.w' <<< "$a") -ne 189 || $(jq -r '.w' <<< "$b_after") -le $(jq -r '.w' <<< "$b_before") ]]; then
+  echo "leftward resize did not grow B after A reached minimum: before=$b_before after=$b_after windows=$($UMBRIEL windows --json)"
+  exit 1
+fi
+
+echo "leftward Mod+Right-drag grows B after A reaches its minimum width"

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -417,6 +417,30 @@ UMBRIEL_TEST(horizontalResizeRecentersAnUnderfullStripImmediately) {
   );
 }
 
+UMBRIEL_TEST(leftwardResizeGrowsCurrentColumnAfterPreviousHitsMinimumWidth) {
+  Fixture fixture;
+  fixture.addColumns(2);
+  fixture.layout.setConstraints([](const View* view) {
+    return LayoutConstraints{.minWidth = view == stub(0) ? 900 : 1};
+  });
+  fixture.layout.arrange(kUsable);
+
+  const wlr_box previousBefore = fixture.layout.targetBox(stub(0));
+  const wlr_box currentBefore = fixture.layout.targetBox(stub(1));
+  CHECK_EQ(previousBefore.width, 900);
+
+  auto resize = fixture.layout.beginResize(stub(1), WLR_EDGE_LEFT, kUsable);
+  CHECK(resize != nullptr);
+  resize->applyDelta(-100.0, 0.0, kUsable);
+  fixture.layout.arrange(kUsable);
+
+  const wlr_box previousAfter = fixture.layout.targetBox(stub(0));
+  const wlr_box currentAfter = fixture.layout.targetBox(stub(1));
+  CHECK_EQ(previousAfter.width, previousBefore.width);
+  CHECK_EQ(currentAfter.x, currentBefore.x);
+  CHECK(currentAfter.width > currentBefore.width);
+}
+
 UMBRIEL_TEST(middleOfPartiallyOffscreenColumnGrabsNothing) {
   Fixture fixture;
   fixture.addColumns(2);

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -427,6 +427,7 @@ UMBRIEL_TEST(leftwardResizeGrowsCurrentColumnAfterPreviousHitsMinimumWidth) {
 
   const wlr_box previousBefore = fixture.layout.targetBox(stub(0));
   const wlr_box currentBefore = fixture.layout.targetBox(stub(1));
+  const int currentRightBefore = currentBefore.x + currentBefore.width;
   CHECK_EQ(previousBefore.width, 900);
 
   auto resize = fixture.layout.beginResize(stub(1), WLR_EDGE_LEFT, kUsable);
@@ -437,7 +438,8 @@ UMBRIEL_TEST(leftwardResizeGrowsCurrentColumnAfterPreviousHitsMinimumWidth) {
   const wlr_box previousAfter = fixture.layout.targetBox(stub(0));
   const wlr_box currentAfter = fixture.layout.targetBox(stub(1));
   CHECK_EQ(previousAfter.width, previousBefore.width);
-  CHECK_EQ(currentAfter.x, currentBefore.x);
+  CHECK(currentAfter.x < currentBefore.x);
+  CHECK_EQ(currentAfter.x + currentAfter.width, currentRightBefore);
   CHECK(currentAfter.width > currentBefore.width);
 }
 

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -443,6 +443,33 @@ UMBRIEL_TEST(leftwardResizeGrowsCurrentColumnAfterPreviousHitsMinimumWidth) {
   CHECK(currentAfter.width > currentBefore.width);
 }
 
+UMBRIEL_TEST(centeredUnderfullLeftwardResizeKeepsCurrentRightEdgeFixed) {
+  Fixture fixture;
+  fixture.addColumns(2);
+  fixture.layout.setConstraints([](const View* view) {
+    return LayoutConstraints{.minWidth = view == stub(0) ? 189 : 1};
+  });
+  CHECK(fixture.layout.setWidthFraction(0, 0.15));
+  CHECK(fixture.layout.setWidthFraction(1, 0.25));
+  fixture.layout.arrange(kUsable);
+
+  const wlr_box previousBefore = fixture.layout.targetBox(stub(0));
+  const wlr_box currentBefore = fixture.layout.targetBox(stub(1));
+  const int currentRightBefore = currentBefore.x + currentBefore.width;
+  CHECK_EQ(previousBefore.width, 189);
+
+  auto resize = fixture.layout.beginResize(stub(1), WLR_EDGE_LEFT, kUsable);
+  CHECK(resize != nullptr);
+  resize->applyDelta(-80.0, 0.0, kUsable);
+  fixture.layout.arrange(kUsable);
+
+  const wlr_box previousAfter = fixture.layout.targetBox(stub(0));
+  const wlr_box currentAfter = fixture.layout.targetBox(stub(1));
+  CHECK_EQ(previousAfter.width, previousBefore.width);
+  CHECK_EQ(currentAfter.x + currentAfter.width, currentRightBefore);
+  CHECK_EQ(currentAfter.width, currentBefore.width + 80);
+}
+
 UMBRIEL_TEST(middleOfPartiallyOffscreenColumnGrabsNothing) {
   Fixture fixture;
   fixture.addColumns(2);


### PR DESCRIPTION
## Summary

Without this fix, when dragging Window B to resize it leftward, if Window A is at its minimum width, Window B will refuse to resize itself. This branch fixes that behavior, allowing Window B to be resized regardless of Window A's width. Note that this new behavior mimics what happens when you drag rightward to resize.

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Testing

 Commands run:
```
  meson setup build-debug -Dbuildtype=debug
  meson compile -C build-debug umbriel pointer-client scrolling-layout-test
  ./build-debug/scrolling-layout-test
  meson test -C build-debug --print-errorlogs scrolling-layout
  bash -n tests/harness/checks/516_resize_past_neighbor_minimum.sh
  tests/harness/verify.sh ./build-debug/umbriel 516_resize_past_neighbor_minimum
  git diff --check
```

 Manual/integration testing:
- Ran the new headless compositor harness check 516_resize_past_neighbor_minimum.
- It opens two real foot windows, uses the virtual pointer with Mod+Right-drag to shrink A to its minimum, then drags B’s left edge left.
- It verifies A remains at minimum, B’s left edge moves left, and B’s right edge does not advance.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested in a nested Umbriel session
- [X] Tested in a native Umbriel session
- [X] Tested with multiple monitors
- [X] Tested with a scaled output
- [X] Tested with native Wayland applications
- [X] Tested with X11 applications through xwayland-satellite
- [X] Tested with the scrolling layout
- [X] Tested with the dwindle layout

## Screenshots / Videos

[video example](https://github.com/user-attachments/assets/112125bc-825a-4ff5-a4df-12535780ec46)


## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format`, or this PR has no C++ changes.
- [X] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [X] I functionally verified compositor behavior where automated checks are insufficient.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [X] I used canonical names for config keys, IPC actions, paths, and identifiers.
