### PR TITLE
fix: add animations to floating windows resize

### DIFF
--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -300,8 +300,11 @@ that changes the window's pixel size on that axis: a float's size is pixels, so
 a preset that rounds to the size the window already has is skipped rather than
 applied as a step that does nothing. Resizing a maximized float leaves
 maximization behind and keeps the new size, so a later toggle maximizes rather
-than reverting to the pre-maximize box. Fullscreen owns the size outright, so
-the actions do nothing while a float is fullscreen.
+than reverting to the pre-maximize box. Both axes use the
+`animation.windows_move` transition, and a float that hangs off an edge travels
+with the resize so the same part of it stays on screen at the new size.
+Fullscreen owns the size outright, so the actions do nothing while a float is
+fullscreen.
 
 ### Maximize and fullscreen
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -997,30 +997,45 @@ namespace umbriel {
     return usable;
   }
 
-  void View::clampFloatingPosition() {
+  std::optional<FloatingPoint> View::floatingClampTarget(FloatingPoint origin, int width, int height) {
     if (m_tiled
         || !m_mapped
         || m_toplevel->scheduled.fullscreen
         || m_toplevel->scheduled.maximized
-        || sizeGrabActive()
-        || m_posX.animating()
-        || m_posY.animating()) {
-      return;
+        || sizeGrabActive()) {
+      return std::nullopt;
     }
     if (Cursor* cursor = m_server->cursor(); cursor != nullptr && cursor->isDraggingView(this)) {
-      return;
+      return std::nullopt;
     }
-
     const wlr_box usable = floatingUsableArea();
+    if (usable.width <= 0 || usable.height <= 0 || width <= 0 || height <= 0) {
+      return std::nullopt;
+    }
     const wlr_box& geo = m_toplevel->base->geometry;
-    if (usable.width <= 0 || usable.height <= 0 || geo.width <= 0 || geo.height <= 0) {
+    const wlr_box box{.x = geo.x, .y = geo.y, .width = width, .height = height};
+    const FloatingPoint clamped = clampFloatingOrigin(origin, box, usable);
+    if (clamped.x == origin.x && clamped.y == origin.y) {
+      return std::nullopt;
+    }
+    return clamped;
+  }
+
+  void View::clampFloatingPosition() {
+    if (m_posX.animating() || m_posY.animating()) {
       return;
     }
+    const wlr_box& geo = m_toplevel->base->geometry;
+    const FloatingPoint origin{.x = m_sceneTree->node.x, .y = m_sceneTree->node.y};
+    if (const auto clamped = floatingClampTarget(origin, geo.width, geo.height)) {
+      setPosition(clamped->x, clamped->y);
+    }
+  }
 
-    const FloatingPoint clamped =
-        clampFloatingOrigin({.x = m_sceneTree->node.x, .y = m_sceneTree->node.y}, geo, usable);
-    if (clamped.x != m_sceneTree->node.x || clamped.y != m_sceneTree->node.y) {
-      setPosition(clamped.x, clamped.y);
+  void View::clampFloatingPositionForSize(int width, int height) {
+    const FloatingPoint origin{.x = layoutTargetX(), .y = layoutTargetY()};
+    if (const auto clamped = floatingClampTarget(origin, width, height)) {
+      animateTo(clamped->x, clamped->y);
     }
   }
 

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -154,6 +154,9 @@ namespace umbriel {
     void setDragPosition(int x, int y);
     // Keep at least clamp(size / 4, 10, 75) pixels per axis on-screen.
     void clampFloatingPosition();
+    // The same clamp for a size that has been requested but not committed yet. The origin animates, so it settles
+    // together with the presented size.
+    void clampFloatingPositionForSize(int width, int height);
     // Send a floating size configure; the pending request is the resize-action basis until committed.
     void requestFloatingSize(int width, int height);
     // The pending compositor request, else the committed geometry.
@@ -350,6 +353,9 @@ namespace umbriel {
     void finishFloatingResize();
     void syncFloatingResizePosition();
     void adoptFloatingClientSize();
+    // Where `origin` has to move so a float of `width` by `height` keeps its on-screen margin, or nullopt when the
+    // clamp does not apply or the origin already satisfies it.
+    [[nodiscard]] std::optional<FloatingPoint> floatingClampTarget(FloatingPoint origin, int width, int height);
     void placeInUsableArea(const std::optional<WindowPosition>& position = std::nullopt);
     void setPinned(bool pinned, bool focus);
     void updateForeignIdentity();

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1067,6 +1067,7 @@ namespace umbriel {
     // box on the next toggle, discarding this size.
     view->dropMaximizedForResize();
     view->requestFloatingSize(width, height);
+    view->beginResizeAnimation(width, height);
     // Resize in place: the keep-visible clamp runs at commit, once the
     // geometry is no longer stale (adoptFloatingClientSize).
     return true;

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1068,8 +1068,9 @@ namespace umbriel {
     view->dropMaximizedForResize();
     view->requestFloatingSize(width, height);
     view->beginResizeAnimation(width, height);
-    // Resize in place: the keep-visible clamp runs at commit, once the
-    // geometry is no longer stale (adoptFloatingClientSize).
+    // Resize in place. The clamp runs on the requested size: the origin has to travel with the presented size, and a
+    // client that commits exactly what was requested never re-enters the clamp at commit.
+    view->clampFloatingPositionForSize(width, height);
     return true;
   }
 

--- a/tests/harness/checks/162_floating_resize_animation.sh
+++ b/tests/harness/checks/162_floating_resize_animation.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# harness: outputs=1
+# The floating resize verbs animate the presented size, and the keep-visible
+# clamp travels with that animation: a float hanging off the left edge shrinks
+# without its origin snapping ahead of the size it is being clamped for.
+set -euo pipefail
+
+readonly TITLE=floating-resize-animation
+readonly CLIENT="${UMBRIEL_FRACTIONAL_CLIENT:-./build-debug/fractional-client}"
+readonly CLIENT_LOG="$UMBRIEL_RUNTIME_DIR/floating-resize-animation.log"
+
+# 1000 wide at x=-900 keeps the 75px minimum on screen. Shrinking to 0.2 of the
+# 1280 output (256px) tightens that minimum to 64px, so the origin has to travel
+# to -192 and the visible sliver shrinks from 100px to 64px.
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[animation]
+duration_ms = 2000
+curve = "linear"
+
+[animation.windows_in]
+enabled = false
+
+[appearance]
+border_width = 0
+outer_border_width = 0
+corner_radius = 0
+
+[appearance.shadow]
+enabled = false
+
+[[window_rule]]
+match.title = "^floating-resize-animation$"
+default_floating = true
+default_size = [1000, 300]
+default_position = { x = -900, y = 200, anchor = "top_left" }
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+ipc_box() {
+  "$UMBRIEL" windows --json \
+    | jq -r --arg title "$TITLE" '.[] | select(.title == $title) | "\(.w)x\(.h)+\(.x)+\(.y)"'
+}
+
+wait_for_box() {
+  local expected=$1 actual=
+  for _ in $(seq 100); do
+    actual=$(ipc_box)
+    [[ $actual == "$expected" ]] && return 0
+    sleep 0.05
+  done
+  echo "expected IPC box $expected, got $actual"
+  return 1
+}
+
+capture_box() {
+  local image="$UMBRIEL_RUNTIME_DIR/$1.png"
+  local width height x y
+  grim "$image"
+  read -r width height x y < <(
+    magick "$image" -alpha off -colorspace gray -threshold 1% \
+      -bordercolor black -border 1 -trim -format '%w %h %X %Y\n' info:
+  )
+  x=${x#+}
+  y=${y#+}
+  printf '%d %d %d %d\n' "$((x - 1))" "$((y - 1))" "$width" "$height"
+}
+
+"$CLIENT" "$TITLE" 1000 300 > "$CLIENT_LOG" 2>&1 &
+wait_for_box 1000x300+-900+200
+sleep 0.2
+
+read -r before_x before_y before_w before_h < <(capture_box before)
+if (( before_x != 0 || before_y != 200 || before_w != 100 || before_h != 300 )); then
+  echo "float did not open hanging off the left edge: ${before_w}x${before_h}+${before_x}+${before_y}"
+  exit 1
+fi
+
+"$UMBRIEL" msg window-set-width:0.2 > /dev/null
+sleep 0.25
+read -r first_x first_y first_w first_h < <(capture_box shrink-250ms)
+sleep 1.00
+read -r second_x second_y second_w second_h < <(capture_box shrink-1250ms)
+
+# The sliver stays between its start and end widths at every sample. An origin
+# that ignores the requested size lets the float shrink off the output; an origin
+# that snaps to it reveals the not yet shrunk buffer and blows past 100px; a
+# snapped size lands on 64px before the animation has run.
+if ! (( first_x == 0 && second_x == 0
+    && first_y == 200 && second_y == 200
+    && first_h == 300 && second_h == 300
+    && 100 > first_w && first_w > second_w && second_w > 64 )); then
+  echo "shrink did not keep origin and size in step: first=${first_w}x${first_h}+${first_x}+${first_y}, second=${second_w}x${second_h}+${second_x}+${second_y}"
+  exit 1
+fi
+
+sleep 1.00
+wait_for_box 256x300+-192+200
+read -r after_x after_y after_w after_h < <(capture_box after)
+if (( after_x != 0 || after_y != 200 || after_w != 64 || after_h != 300 )); then
+  echo "float settled at ${after_w}x${after_h}+${after_x}+${after_y}, expected 64x300+0+200"
+  exit 1
+fi
+
+echo "floating resize animated the size with the keep-visible clamp"


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Add animations to resizing floating windows with `window-cycle-width` or `window-cycle-height`.

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Closes #98 

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
