### PR TITLE
feat(drm): add GPU exclusion policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,6 +240,18 @@ Its regressions run in their own suite:
 meson test -C build-release --suite umbrielfx
 ```
 
+On a dedicated test machine, pass the render nodes to the renderer ownership
+check. Without arguments, it reports a skip:
+
+```sh
+build-release/umbrielfx/umbrielfx-renderer-test /dev/dri/renderD128 /dev/dri/renderD129
+```
+
+Every selected node must open and initialize or the test fails. The EGL and
+scene ABI checks need no GPU access. The compositor's `backend-manager` test
+checks native startup and hotplug filtering with simulated device I/O, without
+taking control of a seat.
+
 ## Debugging
 
 - Debug and ASan builds log at debug level to stderr and to `$XDG_CACHE_HOME/umbriel/umbriel.log`

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -80,6 +80,7 @@ distribution-provided LTO and archive member pruning.
 - wayland-protocols 1.47 or newer
 - xkbcommon
 - libinput 1.23 or newer
+- libudev, required for native `[drm]` GPU exclusion support
 - pixman 0.43 or newer
 - libdrm 2.4.129 or newer
 - Cairo and PangoCairo

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The scene graph and renderer live in [`umbrielfx/`](umbrielfx/) and build as par
 
 Install a C++23 compiler, Meson, Ninja, pkg-config, wayland-scanner, and development packages for wlroots 0.20
 (0.20.1 or newer), Wayland, xkbcommon, libinput, pixman, libdrm, EGL, GLES2, GBM, lcms2, Cairo, Pango, tomlplusplus,
-and nlohmann-json. Then build Umbriel:
+and nlohmann-json. Native `[drm]` GPU exclusions also require libudev. Then build Umbriel:
 
 ```sh
 just release

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -16,6 +16,7 @@ boundaries, or regression-sensitive behavior.
 - [Xwayland input stability](xwayland-input-stability.md)
 - [Client buffer constraints](client-buffer-constraints.md)
 - [Scene helper ownership](scene-helper-ownership.md)
+- [DRM GPU exclusion](drm-device-policy.md)
 
 ## Pointer drag completion
 

--- a/docs/design/configuration-reload.md
+++ b/docs/design/configuration-reload.md
@@ -66,6 +66,7 @@ Output state and workspace inventory are independent effects.
   the overview.
 - `general.autostart` commands run only during startup, never during reload.
 - `general.xwayland` changes require a compositor restart.
+- `[drm]` changes require a restart because GPU selection happens before backend creation.
 - `[environment]` values are applied and synchronized to the systemd user
   manager only during startup. A reload does not mutate the compositor, user
   manager, or existing process environments. Traditional D-Bus activation sees

--- a/docs/design/drm-device-policy.md
+++ b/docs/design/drm-device-policy.md
@@ -1,0 +1,39 @@
+# DRM GPU exclusion
+
+`BackendManager` filters GPUs before wlroots opens their KMS nodes and gives
+`Server` the selected backend, session, and renderer factory.
+
+Without exclusions, Umbriel uses `wlr_backend_autocreate()` and
+`fx_renderer_create()`. The policy does not apply to nested Wayland, X11, or
+headless backends.
+
+## Native path
+
+For a native session with exclusions, `BackendManager`:
+
+1. Resolves the ignored GPU identities and enumerates DRM cards through udev.
+2. Opens one backend for each allowed card.
+3. Creates the renderer from the primary card through GBM.
+4. Checks open device descriptors after allocator creation and renderer recovery.
+
+Separate DRM backends and the explicit GBM constructor avoid automatic
+renderer discovery that could open excluded GPUs. Descriptor checks reject
+startup or renderer recovery if drivers open excluded DRM or proprietary
+NVIDIA devices. Unreadable descriptors and DRM descriptors without a resolvable
+GPU identity also fail the check. Descriptors closed during the scan are skipped.
+NVIDIA driver metadata is read only for open per-GPU devices that lack a PCI
+identity from udev; device numbers identify these even through aliases.
+
+Device paths resolve into `DrmDeviceIdentity` before any GPU opens. Startup
+rejects unresolved paths. Hotplug filtering uses the captured identities even
+after paths disappear or get reused. PCI selectors need no DRM node to resolve.
+
+Configuration errors that could hide exclusions stop startup. The
+[configuration reference](../user/configuration.md) covers selectors, includes,
+reloads, and compatibility limits.
+
+## Verification
+
+The [contributor guide](../../CONTRIBUTING.md#umbrielfx) describes simulated
+backend tests, EGL ABI checks, and hardware renderer checks. Physical VFIO
+transitions require testing in a dedicated native session.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -13,6 +13,10 @@ removed. Pass `umbriel -c <path>` to pin one exact path instead of using the
 lookup chain. A missing or invalid pinned path never falls back to an implicit
 candidate. Umbriel does not create or modify a user config automatically.
 
+At startup, a missing explicit `-c` path, syntax errors, unreadable files, and
+invalid include directives are fatal. Other invalid settings fall back to
+defaults unless `[drm]` is configured.
+
 ## Starting configuration
 
 The packaged starting configuration is
@@ -74,8 +78,12 @@ Files in `[include]` are applied in list order, followed by files in
 `[include.optional]`. Values in the including file override every include.
 
 `[include]` accepts `files` and the `optional` sub-table.
-`[include.optional]` accepts only `files`. Anything else is reported as an
-unknown key, in the main config and in included files alike.
+`[include.optional]` accepts only `files`. Unknown keys and invalid types reject
+both main and included configurations.
+
+If an included file defines `[drm]`, add an empty `[drm]` table to the main
+file. Umbriel then rejects a missing include instead of applying an incomplete
+exclusion list.
 
 You can split your config into multiple files for clarity:
 
@@ -118,6 +126,44 @@ honor_restored_maximize = false
 | `show_cheatsheet`         | bool         | `true`                  | Show the keybinds cheatsheet overlay on startup. If an included file is still missing, Umbriel waits for it to load before showing the overlay. Press any key or mouse button to dismiss, or toggle at runtime via `cheatsheet-toggle`. |
 | `focus_on_activate`       | bool         | `false`                 | Let unsolicited activation requests add focus and reveal their target. When false, a mapped target is only marked urgent, while an unmapped target still follows its normal `default_focused` map policy. Tokens issued by `spawn:` and client tokens validated from focused input represent user launch intent and may focus the target. Window rules override this per application. |
 | `honor_restored_maximize` | bool         | `false`                 | Honor maximized state requested by applications before their first buffer maps. The first visible configure then uses the final maximized layout target. A request sent after mapping is a normal runtime maximize request and can resize an already visible window. Later maximize requests are always honored. Applies to newly opened windows. |
+
+## DRM devices
+
+Use the optional `[drm]` section to keep GPUs unopened in a native session.
+Omit it to retain automatic GPU discovery. Changes require a restart.
+
+```toml
+[drm]
+ignored_pci_addresses = ["0000:01:00.0"]
+# Alternative using a stable DRM path:
+# ignored_devices = ["/dev/dri/by-path/pci-0000:01:00.0-card"]
+```
+
+| Key                     | Type         | Default | Description |
+| ----------------------- | ------------ | ------- | ----------- |
+| `ignored_devices`       | string array | `[]`    | Absolute DRM card or render-node paths that resolve at startup. Either node excludes the whole GPU. |
+| `ignored_pci_addresses` | string array | `[]`    | PCI addresses in `domain:bus:slot.function` form. Use this when the GPU may start bound to `vfio-pci`. |
+
+Prefer stable `/dev/dri/by-path` links over numbered `cardN` and `renderDN`
+paths. Each path resolves once at startup and pins that GPU for the session,
+even if the path disappears, changes target, or gets reused. Startup rejects
+unresolved paths with guidance to use `ignored_pci_addresses` instead.
+
+Umbriel does not bind or unbind PCI drivers. Configure libvirt with managed
+host devices, or use equivalent host tooling, for that lifecycle.
+
+### Limits
+
+- The section has no effect on nested Wayland, X11, or headless backends.
+- A native session fails to start if the build lacks the wlroots DRM backend or libudev.
+- Startup fails if no allowed GPU works. Losing the primary GPU ends the session.
+- Secondary GPUs must support the primary GPU's DMA-BUF format and modifiers.
+- `WLR_RENDERER_FORCE_SOFTWARE=1` is incompatible with exclusions.
+- Exclusions override `WLR_DRM_DEVICES` and `WLR_RENDER_DRM_DEVICE`.
+- With exclusions, `WLR_BACKENDS` supports only `drm` and optional `libinput`.
+
+See [DRM GPU exclusion](../design/drm-device-policy.md) for the backend and
+renderer design.
 
 ## Environment
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -70,9 +70,9 @@ Paths are resolved relative to the file that declares them. `~` and `~/`
 expand to the user's home directory. `$VAR` and `${VAR}` expand environment
 variables.
 
-Missing files in `[include.optional]` are silently ignored and remain watched.
-Creating one applies it without a restart. An optional file that exists must
-contain valid TOML.
+Missing files in `[include.optional]` are silently ignored and remain watched
+unless the main file declares `[drm]`. Creating a non-DRM optional file applies
+it without a restart. An optional file that exists must contain valid TOML.
 
 Files in `[include]` are applied in list order, followed by files in
 `[include.optional]`. Values in the including file override every include.
@@ -82,8 +82,8 @@ Files in `[include]` are applied in list order, followed by files in
 both main and included configurations.
 
 If an included file defines `[drm]`, add an empty `[drm]` table to the main
-file. Umbriel then rejects a missing include instead of applying an incomplete
-exclusion list.
+file. Umbriel then rejects a missing required or optional include instead of
+applying an incomplete exclusion list.
 
 You can split your config into multiple files for clarity:
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -40,6 +40,14 @@ show_cheatsheet = true                          # Show the keybind overlay on st
 focus_on_activate = false                       # Do not let unsolicited requests steal focus
 honor_restored_maximize = false                 # Honor restored maximized state
 
+# Native GPU exclusions
+# Changes require a restart. Use a PCI address if the GPU may start bound to vfio-pci.
+# Device paths must resolve at startup or Umbriel refuses to start.
+# Documentation: https://docs.noctalia.dev/umbriel/configuration/#drm-devices
+# [drm]
+# ignored_devices = ["/dev/dri/by-path/pci-0000:01:00.0-card"]
+# ignored_pci_addresses = ["0000:01:00.0"]
+
 # Session environment
 # Values apply only at session startup. Native sessions also publish them to
 # newly started systemd user services. Add or uncomment values as needed.

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,18 @@ build_tests = tests_opt.enabled() or (
   and get_option('b_sanitize') == 'none'
 )
 
+if cpp.get_define('WLR_HAS_SESSION', prefix: '#include <wlr/config.h>', dependencies: wlroots_dep) != '1'
+  error('Umbriel requires wlroots built with session support')
+endif
+wlr_has_drm_backend = cpp.get_define(
+  'WLR_HAS_DRM_BACKEND',
+  prefix: '#include <wlr/config.h>',
+  dependencies: wlroots_dep,
+) == '1'
+if cpp.get_define('WLR_HAS_LIBINPUT_BACKEND', prefix: '#include <wlr/config.h>', dependencies: wlroots_dep) != '1'
+  error('Umbriel requires wlroots built with the libinput backend')
+endif
+
 # jemalloc keeps a long-running compositor's heap compact: fewer arenas and fast page decay bound RSS. It interposes malloc only on glibc, so other libc builds
 # skip it (auto) or fail (enabled).
 jemalloc_option = get_option('jemalloc')
@@ -95,6 +107,16 @@ nlohmann_json_dep = dependency('nlohmann_json')
 cairo_dep = dependency('cairo')
 pangocairo_dep = dependency('pangocairo')
 libdrm_dep = dependency('libdrm', version: '>=2.4.129')
+libudev_dep = dependency('libudev', required: false)
+native_drm_policy_supported = wlr_has_drm_backend and libudev_dep.found()
+native_drm_policy_deps = []
+if native_drm_policy_supported
+  native_drm_policy_deps += libudev_dep
+endif
+add_project_arguments(
+  '-DUMBRIEL_HAS_NATIVE_DRM_POLICY=' + native_drm_policy_supported.to_int().to_string(),
+  language: 'cpp',
+)
 
 wayland_scanner = find_program('wayland-scanner')
 
@@ -443,6 +465,7 @@ pure_sources = files(
   'src/layout/master.cpp',
   'src/output/direction.cpp',
   'src/output/identity.cpp',
+  'src/server/drm_policy.cpp',
   'src/scene/cheatsheet_rows.cpp',
   'src/overview/shortcut_labels.cpp',
   'src/view/border_ring.cpp',
@@ -485,6 +508,7 @@ core_sources = files(
   'src/config/config_watcher.cpp',
   'src/layout/drop_target.cpp',
   'src/server/wine_color_manager.cpp',
+  'src/server/backend_manager.cpp',
   'src/server/server.cpp',
   'src/server/server_events.cpp',
   'src/server/server_keybinds.cpp',
@@ -539,6 +563,7 @@ umbriel_core_deps = [
   cairo_dep,
   pangocairo_dep,
   libdrm_dep,
+  native_drm_policy_deps,
   nlohmann_json_dep,
   layer_shell_protocol_dep,
 ]

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -10,6 +10,7 @@
   wlroots_0_20,
   libxkbcommon,
   libinput,
+  systemd,
   pixman,
   cairo,
   pango,
@@ -53,6 +54,7 @@ stdenv.mkDerivation {
     wlroots_0_20
     libxkbcommon
     libinput
+    systemd
     pixman
     tomlplusplus
     libGL

--- a/src/config/change.cpp
+++ b/src/config/change.cpp
@@ -183,6 +183,7 @@ namespace umbriel {
         .layout = true,
         .workspaces = true,
         .general = true,
+        .drm = true,
         .environment = true,
         .events = true,
         .input = true,
@@ -205,6 +206,7 @@ namespace umbriel {
         .layout = before.layout != after.layout,
         .workspaces = before.workspaces != after.workspaces,
         .general = before.general != after.general,
+        .drm = before.drm != after.drm,
         .environment = before.environment != after.environment,
         .events = before.events != after.events,
         .input = before.input != after.input,
@@ -236,6 +238,7 @@ namespace umbriel {
     add(layout, "layout");
     add(workspaces, "workspaces");
     add(general, "general");
+    add(drm, "drm");
     add(environment, "environment");
     add(events, "events");
     add(input, "input");

--- a/src/config/change.h
+++ b/src/config/change.h
@@ -17,6 +17,7 @@ namespace umbriel {
     bool layout = false;
     bool workspaces = false;
     bool general = false;
+    bool drm = false;
     bool environment = false;
     bool events = false;
     bool input = false;
@@ -36,6 +37,7 @@ namespace umbriel {
           || layout
           || workspaces
           || general
+          || drm
           || environment
           || events
           || input

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -159,6 +159,90 @@ namespace umbriel {
       emitDiag(ConfigDiagnostic::Severity::Error, &src, std::format(fmt, std::forward<A>(args)...));
     }
 
+    std::optional<std::string> normalizePciAddress(std::string_view value) {
+      constexpr std::array<size_t, 3> separators{4, 7, 10};
+      if (value.size() != 12
+          || value[separators[0]] != ':'
+          || value[separators[1]] != ':'
+          || value[separators[2]] != '.'
+          || (value[8] != '0' && value[8] != '1')
+          || value.back() < '0'
+          || value.back() > '7') {
+        return std::nullopt;
+      }
+      for (size_t index = 0; index < value.size(); ++index) {
+        if (std::ranges::find(separators, index) != separators.end()) {
+          continue;
+        }
+        if (std::isxdigit(static_cast<unsigned char>(value[index])) == 0) {
+          return std::nullopt;
+        }
+      }
+      return lowercase(value);
+    }
+
+    std::optional<std::string> readDrmPath(const toml::node& node, std::string_view context) {
+      const auto value = node.value<std::string>();
+      if (!value) {
+        errorAt(node.source(), "{} must be a string", context);
+        return std::nullopt;
+      }
+      if (value->empty()) {
+        errorAt(node.source(), "{} cannot be empty", context);
+        return std::nullopt;
+      }
+      if (value->contains('\0')) {
+        errorAt(node.source(), "{} cannot contain NUL", context);
+        return std::nullopt;
+      }
+      const std::filesystem::path path(*value);
+      if (!path.is_absolute()) {
+        errorAt(node.source(), R"({} must be an absolute path (got "{}"))", context, *value);
+        return std::nullopt;
+      }
+      // Keep the exact spelling: lexical normalization changes the meaning of
+      // `..` when an earlier path component is a symlink.
+      return value;
+    }
+
+    std::optional<std::string> readDrmPciAddress(const toml::node& node, std::string_view context) {
+      const auto value = node.value<std::string>();
+      if (!value) {
+        errorAt(node.source(), "{} entries must be strings", context);
+        return std::nullopt;
+      }
+      const auto address = normalizePciAddress(*value);
+      if (!address) {
+        errorAt(
+            node.source(), R"(invalid {} entry "{}" (expected domain:bus:slot.function, for example 0000:01:00.0))",
+            context, *value
+        );
+      }
+      return address;
+    }
+
+    template <typename Parse>
+    void readDrmSelectorList(
+        const toml::node& node, std::string_view context, std::vector<std::string>& target, Parse parse
+    ) {
+      const toml::array* values = node.as_array();
+      if (values == nullptr) {
+        errorAt(node.source(), "{} must be an array of strings", context);
+        return;
+      }
+      for (const toml::node& entry : *values) {
+        auto value = parse(entry, context);
+        if (!value) {
+          continue;
+        }
+        if (std::ranges::find(target, *value) != target.end()) {
+          warnAt(entry.source(), R"(ignoring duplicate {} entry "{}")", context, *value);
+          continue;
+        }
+        target.push_back(std::move(*value));
+      }
+    }
+
     std::filesystem::path userConfigPath() {
       if (const char* xdgConfigHome = std::getenv("XDG_CONFIG_HOME");
           xdgConfigHome != nullptr && xdgConfigHome[0] != '\0') {
@@ -170,9 +254,33 @@ namespace umbriel {
       return std::filesystem::path(".config/umbriel/config.toml");
     }
 
-    bool configPathIsRegular(const std::filesystem::path& path) {
+    enum class ConfigPathKind {
+      Missing,
+      RegularFile,
+      Unavailable,
+    };
+
+    struct ConfigPathProbe {
+      ConfigPathKind kind = ConfigPathKind::Missing;
       std::error_code error;
-      return std::filesystem::is_regular_file(path, error) && !error;
+    };
+
+    ConfigPathProbe probeConfigPath(const std::filesystem::path& path) {
+      std::error_code error;
+      const std::filesystem::file_status status = std::filesystem::status(path, error);
+      if (error) {
+        if (error == std::errc::no_such_file_or_directory || error == std::errc::not_a_directory) {
+          return {};
+        }
+        return {.kind = ConfigPathKind::Unavailable, .error = error};
+      }
+      if (status.type() == std::filesystem::file_type::not_found) {
+        return {};
+      }
+      return {
+          .kind = std::filesystem::is_regular_file(status) ? ConfigPathKind::RegularFile : ConfigPathKind::Unavailable,
+          .error = {},
+      };
     }
 
     std::vector<std::filesystem::path> defaultConfigCandidates() {
@@ -208,7 +316,7 @@ namespace umbriel {
       ConfigSelection selection{};
       selection.watchPaths = candidates;
       for (const std::filesystem::path& candidate : candidates) {
-        if (configPathIsRegular(candidate)) {
+        if (probeConfigPath(candidate).kind != ConfigPathKind::Missing) {
           selection.root = candidate;
           selection.found = true;
           return selection;
@@ -1038,6 +1146,28 @@ namespace umbriel {
             .boolean("honor_restored_maximize", loaded.general.honorRestoredMaximize)
             .strings("autostart", loaded.general.autostart);
       });
+    }
+
+    void readDrm(Section& root, Config& loaded) {
+      const toml::node* node = root.take("drm");
+      if (node == nullptr) {
+        return;
+      }
+      const toml::table* table = node->as_table();
+      if (table == nullptr) {
+        errorAt(node->source(), "drm must be a table");
+        return;
+      }
+
+      for (const auto& [key, value] : *table) {
+        if (key == "ignored_devices") {
+          readDrmSelectorList(value, "drm.ignored_devices", loaded.drm.ignoredDevices, readDrmPath);
+        } else if (key == "ignored_pci_addresses") {
+          readDrmSelectorList(value, "drm.ignored_pci_addresses", loaded.drm.ignoredPciAddresses, readDrmPciAddress);
+        } else {
+          errorAt(value.source(), "unknown key drm.{}", key.str());
+        }
+      }
     }
 
     void readEnvironment(Section& root, Config& loaded) {
@@ -1944,19 +2074,45 @@ namespace umbriel {
       }
     }
 
-    bool parseInto(
+    enum class ConfigParseOutcome : uint8_t {
+      Loaded,
+      Missing,
+      DefaultsAllowed,
+      Fatal,
+    };
+
+    bool hasRequestedDrmPolicy(const toml::table& root) {
+      const toml::node* node = root.get("drm");
+      if (node == nullptr) {
+        return false;
+      }
+      const toml::table* table = node->as_table();
+      return table == nullptr || !table->empty();
+    }
+
+    ConfigParseOutcome parseInto(
         Config& out, const std::filesystem::path& rootPath, const std::vector<std::filesystem::path>& watchPaths
     ) {
       ConfigStore& store = configStore();
       store.beginLoad(watchPaths);
 
-      std::error_code error;
-      if (!std::filesystem::is_regular_file(rootPath, error) || error) {
-        return false;
+      const ConfigPathProbe root = probeConfigPath(rootPath);
+      if (root.kind == ConfigPathKind::Missing) {
+        return ConfigParseOutcome::Missing;
+      }
+      if (root.kind == ConfigPathKind::Unavailable) {
+        const std::string reason = root.error ? root.error.message() : "not a regular file";
+        emitDiag(
+            ConfigDiagnostic::Severity::Error, nullptr,
+            std::format("cannot inspect config file {}: {}", rootPath.string(), reason)
+        );
+        return ConfigParseOutcome::Fatal;
       }
 
+      bool drmPolicyRequested = false;
       try {
         auto result = configmerge::mergeWithIncludes(rootPath);
+        drmPolicyRequested = hasRequestedDrmPolicy(result.merged);
         store.setMissingIncludes(result.missingIncludes);
         for (auto& diagnostic : result.diagnostics) {
           store.addDiagnostic(std::move(diagnostic));
@@ -1964,8 +2120,16 @@ namespace umbriel {
         for (const auto& path : result.loadedFiles) {
           store.addWatchPath(path);
         }
-        if (result.hadParseError) {
-          return false;
+        if (result.missingIncludes && result.merged.contains("drm")) {
+          emitDiag(
+              ConfigDiagnostic::Severity::Error, nullptr, "cannot safely load DRM policy while an include is missing"
+          );
+          return ConfigParseOutcome::Fatal;
+        }
+        if (result.hadError) {
+          // Invalid syntax or include directives can hide DRM policy intent.
+          // Do not silently start with defaults or a partial exclusion list.
+          return ConfigParseOutcome::Fatal;
         }
 
         Config loaded;
@@ -1978,6 +2142,7 @@ namespace umbriel {
           readHotCorners(root, loaded);
           readLayout(root, loaded);
           readGeneral(root, loaded);
+          readDrm(root, loaded);
           readEnvironment(root, loaded);
           readEvents(root, loaded);
           readWorkspaceSettings(root, loaded);
@@ -1995,17 +2160,17 @@ namespace umbriel {
           return d.severity == ConfigDiagnostic::Severity::Error;
         });
         if (hasErrors) {
-          return false;
+          return drmPolicyRequested ? ConfigParseOutcome::Fatal : ConfigParseOutcome::DefaultsAllowed;
         }
 
         out = std::move(loaded);
-        return true;
+        return ConfigParseOutcome::Loaded;
       } catch (const std::exception& exception) {
         emitDiag(ConfigDiagnostic::Severity::Error, nullptr, std::format("config load error: {}", exception.what()));
       } catch (...) {
         emitDiag(ConfigDiagnostic::Severity::Error, nullptr, "config load error: unknown error");
       }
-      return false;
+      return drmPolicyRequested ? ConfigParseOutcome::Fatal : ConfigParseOutcome::DefaultsAllowed;
     }
 
   } // namespace
@@ -2029,22 +2194,12 @@ namespace umbriel {
 
   bool configHasMissingIncludes() { return configStore().missingIncludes(); }
 
-  namespace {
-    // Whether the root config actually exists on disk right now, which is not the
-    // same as whether parsing succeeded: defaults are a valid way to run.
-    bool rootFileMissing(const std::filesystem::path& root) {
-      std::error_code ec;
-      return !std::filesystem::is_regular_file(root, ec) || static_cast<bool>(ec);
-    }
-  } // namespace
-
-  void ConfigStore::load(const char* explicitPath) {
+  bool ConfigStore::load(const char* explicitPath) {
     ConfigSelection selection;
     if (explicitPath != nullptr) {
       m_implicitCandidates.clear();
       selection.root = std::filesystem::path(explicitPath);
       selection.watchPaths.push_back(selection.root);
-      selection.found = configPathIsRegular(selection.root);
     } else {
       m_implicitCandidates = defaultConfigCandidates();
       selection = selectDefaultConfig(m_implicitCandidates);
@@ -2053,7 +2208,9 @@ namespace umbriel {
 
     Config loaded;
     loaded.keybinds = defaultKeybinds();
-    if (!parseInto(loaded, selection.root, selection.watchPaths) && rootFileMissing(selection.root)) {
+    const ConfigParseOutcome outcome = parseInto(loaded, selection.root, selection.watchPaths);
+    const bool missing = outcome == ConfigParseOutcome::Missing;
+    if (missing) {
       if (m_explicitPath) {
         emitDiag(
             ConfigDiagnostic::Severity::Error, nullptr,
@@ -2064,7 +2221,11 @@ namespace umbriel {
       }
     }
     sortDiagnostics();
-    (void)commit(std::move(loaded), selection.root, rootFileMissing(selection.root));
+    if (outcome == ConfigParseOutcome::Fatal || (missing && m_explicitPath)) {
+      return false;
+    }
+    (void)commit(std::move(loaded), selection.root, missing);
+    return true;
   }
 
   ConfigReloadResult ConfigStore::reload() {
@@ -2072,33 +2233,32 @@ namespace umbriel {
     if (m_explicitPath) {
       selection.root = m_rootPath;
       selection.watchPaths.push_back(selection.root);
-      selection.found = configPathIsRegular(selection.root);
     } else {
       selection = selectDefaultConfig(m_implicitCandidates);
     }
 
     Config loaded;
     loaded.keybinds = defaultKeybinds();
-    const bool ok = parseInto(loaded, selection.root, selection.watchPaths);
-    const bool fileMissing = rootFileMissing(selection.root);
-    if (!ok && m_explicitPath && fileMissing) {
+    const ConfigParseOutcome outcome = parseInto(loaded, selection.root, selection.watchPaths);
+    const bool missing = outcome == ConfigParseOutcome::Missing;
+    if (m_explicitPath && missing) {
       emitDiag(
           ConfigDiagnostic::Severity::Error, nullptr, std::format("config file not found: {}", selection.root.string())
       );
     }
     sortDiagnostics();
-    if (!ok) {
-      if (!m_explicitPath && !selection.found && fileMissing) {
+    if (outcome != ConfigParseOutcome::Loaded) {
+      if (!m_explicitPath && !selection.found && missing) {
         kLog.info("no config file found: {}, using defaults", selection.root.string());
         return commit(std::move(loaded), selection.root, true);
       }
       kLog.warn("config reload failed; keeping previous configuration");
       return {};
     }
-    return commit(std::move(loaded), selection.root, fileMissing);
+    return commit(std::move(loaded), selection.root, false);
   }
 
-  void loadConfig(const char* explicitPath) { configStore().load(explicitPath); }
+  bool loadConfig(const char* explicitPath) { return configStore().load(explicitPath); }
 
   ConfigReloadResult reloadConfig() { return configStore().reload(); }
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -2120,7 +2120,7 @@ namespace umbriel {
         for (const auto& path : result.loadedFiles) {
           store.addWatchPath(path);
         }
-        if (result.missingIncludes && result.merged.contains("drm")) {
+        if ((result.missingIncludes || result.missingOptionalIncludes) && result.merged.contains("drm")) {
           emitDiag(
               ConfigDiagnostic::Severity::Error, nullptr, "cannot safely load DRM policy while an include is missing"
           );

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -635,6 +635,16 @@ namespace umbriel {
       bool operator==(const General&) const = default;
     } general;
 
+    struct Drm {
+      // Absolute card or render-node paths. Either node excludes the whole GPU.
+      std::vector<std::string> ignoredDevices;
+      // Canonical PCI domain:bus:slot.function addresses.
+      std::vector<std::string> ignoredPciAddresses;
+
+      [[nodiscard]] bool configured() const { return !ignoredDevices.empty() || !ignoredPciAddresses.empty(); }
+      bool operator==(const Drm&) const = default;
+    } drm;
+
     struct Environment {
       // Ordered NAME=value pairs exported to the compositor and the native session's systemd user manager.
       std::vector<std::pair<std::string, std::string>> variables;
@@ -770,7 +780,7 @@ namespace umbriel {
   };
 
   [[nodiscard]] const Config& config();
-  void loadConfig(const char* explicitPath);
+  [[nodiscard]] bool loadConfig(const char* explicitPath);
   [[nodiscard]] ConfigReloadResult reloadConfig();
   [[nodiscard]] const std::vector<std::filesystem::path>& configWatchPaths();
   [[nodiscard]] const std::vector<ConfigDiagnostic>& configDiagnostics();

--- a/src/config/config_merge.cpp
+++ b/src/config/config_merge.cpp
@@ -1,7 +1,6 @@
 #include "config/config_merge.h"
 
 #include "config/config_diag.h"
-#include "config/section.h"
 #include "core/log.h"
 
 #include <algorithm>
@@ -35,6 +34,7 @@ namespace umbriel::configmerge {
       }
       const std::string loc = diag.location();
       if (severity == ConfigDiagnostic::Severity::Error) {
+        result.hadError = true;
         kLog.error("{}{}", loc.empty() ? "" : loc + ": ", msg);
       } else {
         kLog.warn("{}{}", loc.empty() ? "" : loc + ": ", msg);
@@ -203,22 +203,29 @@ namespace umbriel::configmerge {
       const auto* files = node->as_array();
       if (files == nullptr) {
         emit(
-            result, ConfigDiagnostic::Severity::Warning, &node->source(),
-            std::format("ignoring {} (expected array of strings)", name)
+            result, ConfigDiagnostic::Severity::Error, &node->source(),
+            std::format("{} must be an array of strings", name)
         );
         return;
       }
       for (const auto& entry : *files) {
-        if (!entry.is_string()) {
+        const auto path = entry.value<std::string>();
+        if (!path) {
           emit(
-              result, ConfigDiagnostic::Severity::Warning, &entry.source(),
-              std::format("ignoring {} (expected array of strings)", name)
+              result, ConfigDiagnostic::Severity::Error, &entry.source(),
+              std::format("{} entries must be strings", name)
           );
-          entries.clear();
-          return;
+          continue;
+        }
+        if (path->contains('\0')) {
+          emit(
+              result, ConfigDiagnostic::Severity::Error, &entry.source(),
+              std::format("{} entries cannot contain NUL", name)
+          );
+          continue;
         }
         entries.push_back({
-            .path = *entry.value<std::string>(),
+            .path = *path,
             .source = entry.source(),
         });
       }
@@ -232,16 +239,37 @@ namespace umbriel::configmerge {
       }
       const auto* include = node->as_table();
       if (include == nullptr) {
-        emit(result, ConfigDiagnostic::Severity::Warning, &node->source(), "ignoring include (expected table)");
+        emit(result, ConfigDiagnostic::Severity::Error, &node->source(), "include must be a table");
         return directive;
       }
-      // `include` is erased from the table before the config readers run, so the root section never sees it and never
-      // reports its unknown keys. This reader owns that report for the section's fixed vocabulary.
-      Section keys(*include, "include", result.diagnostics);
-      readIncludeFiles(keys.take("files"), "include.files", directive.files, result);
-      keys.sub("optional", [&](Section& optional) {
-        readIncludeFiles(optional.take("files"), "include.optional.files", directive.optionalFiles, result);
-      });
+      // A malformed directive can hide the only file containing DRM exclusions.
+      // Reject it even when the successfully loaded files have no [drm] section.
+      for (const auto& [key, value] : *include) {
+        if (key.str() != "files" && key.str() != "optional") {
+          emit(
+              result, ConfigDiagnostic::Severity::Error, &value.source(),
+              std::format("unknown key include.{}", key.str())
+          );
+        }
+      }
+      readIncludeFiles(include->get("files"), "include.files", directive.files, result);
+      const toml::node* optionalNode = include->get("optional");
+      if (optionalNode != nullptr) {
+        const auto* optional = optionalNode->as_table();
+        if (optional == nullptr) {
+          emit(result, ConfigDiagnostic::Severity::Error, &optionalNode->source(), "include.optional must be a table");
+        } else {
+          for (const auto& [key, value] : *optional) {
+            if (key.str() != "files") {
+              emit(
+                  result, ConfigDiagnostic::Severity::Error, &value.source(),
+                  std::format("unknown key include.optional.{}", key.str())
+              );
+            }
+          }
+          readIncludeFiles(optional->get("files"), "include.optional.files", directive.optionalFiles, result);
+        }
+      }
       return directive;
     }
 
@@ -277,18 +305,31 @@ namespace umbriel::configmerge {
         for (const auto& entry : entries) {
           const auto target = expandPath(entry.path, path.parent_path());
           std::error_code error;
-          if (std::filesystem::is_regular_file(target, error) && !error) {
+          const std::filesystem::file_status status = std::filesystem::status(target, error);
+          if (!error && std::filesystem::is_regular_file(status)) {
             deepMerge(base, loadAndExpand(target, visited, result));
             continue;
           }
           result.loadedFiles.push_back(canonicalKey(target));
-          if (optional) {
+          const bool missing = error == std::errc::no_such_file_or_directory
+              || error == std::errc::not_a_directory
+              || (!error && status.type() == std::filesystem::file_type::not_found);
+          if (missing) {
+            if (optional) {
+              continue;
+            }
+            result.missingIncludes = true;
+            emit(
+                result, ConfigDiagnostic::Severity::Warning, &entry.source,
+                std::format("include not found: {} (from {})", target.string(), path.string())
+            );
             continue;
           }
-          result.missingIncludes = true;
+
+          const std::string reason = error ? error.message() : "not a regular file";
           emit(
-              result, ConfigDiagnostic::Severity::Warning, &entry.source,
-              std::format("include not found: {} (from {})", target.string(), path.string())
+              result, ConfigDiagnostic::Severity::Error, &entry.source,
+              std::format("cannot inspect included config file {}: {}", target.string(), reason)
           );
         }
       };
@@ -304,7 +345,6 @@ namespace umbriel::configmerge {
       try {
         parsed = toml::parse_file(path.string());
       } catch (const toml::parse_error& error) {
-        result.hadParseError = true;
         const auto key = canonicalKey(path);
         if (std::ranges::find(result.loadedFiles, key) == result.loadedFiles.end()) {
           result.loadedFiles.push_back(key);

--- a/src/config/config_merge.cpp
+++ b/src/config/config_merge.cpp
@@ -316,6 +316,7 @@ namespace umbriel::configmerge {
               || (!error && status.type() == std::filesystem::file_type::not_found);
           if (missing) {
             if (optional) {
+              result.missingOptionalIncludes = true;
               continue;
             }
             result.missingIncludes = true;

--- a/src/config/config_merge.h
+++ b/src/config/config_merge.h
@@ -13,7 +13,7 @@ namespace umbriel::configmerge {
     toml::table merged;
     std::vector<std::filesystem::path> loadedFiles;
     std::vector<ConfigDiagnostic> diagnostics;
-    bool hadParseError = false;
+    bool hadError = false;
     bool missingIncludes = false;
   };
 

--- a/src/config/config_merge.h
+++ b/src/config/config_merge.h
@@ -15,6 +15,7 @@ namespace umbriel::configmerge {
     std::vector<ConfigDiagnostic> diagnostics;
     bool hadError = false;
     bool missingIncludes = false;
+    bool missingOptionalIncludes = false;
   };
 
   [[nodiscard]] MergeResult mergeWithIncludes(const std::filesystem::path& rootFile);

--- a/src/config/store.h
+++ b/src/config/store.h
@@ -18,9 +18,10 @@ namespace umbriel {
   // which is cheaper and less error-prone than every consumer being individually re-notified from Server::applyConfig.
   class ConfigStore {
   public:
-    // Resolve the user, system, or packaged config and load it. Falls back to
-    // built-in defaults when no file exists.
-    void load(const char* explicitPath);
+    // Resolve the user, system, or packaged config and load it. Missing explicit
+    // paths, invalid includes, syntax errors, and DRM policy errors fail closed;
+    // other parsed errors retain the compatibility fallback to defaults.
+    [[nodiscard]] bool load(const char* explicitPath);
     // Re-parse. On failure the previous configuration is kept and the generation
     // does not move: a config with a syntax error must not take the session down.
     [[nodiscard]] ConfigReloadResult reload();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ namespace {
       }
     }
 
-    umbriel::loadConfig(configPath);
+    (void)umbriel::loadConfig(configPath);
     const auto& diags = umbriel::configDiagnostics();
     if (diags.empty()) {
       std::println("config: ok ({})", umbriel::configRootPath().string());
@@ -323,7 +323,10 @@ int main(int argc, char** argv) {
 
   try {
     kLog.info("starting umbriel version={} commit={}", umbriel::build_info::version(), umbriel::build_info::revision());
-    umbriel::loadConfig(configPath);
+    if (!umbriel::loadConfig(configPath)) {
+      kLog.error("initial configuration is invalid; refusing to start");
+      return EXIT_FAILURE;
+    }
     umbriel::Server server;
 
     // SIGINT and SIGTERM are handled on the event loop by the server itself. SIG_IGN for SIGCHLD reaps spawned children

--- a/src/server/backend_manager.cpp
+++ b/src/server/backend_manager.cpp
@@ -1,0 +1,867 @@
+#include "server/backend_manager.h"
+
+#include "core/log.h"
+#include "server/drm_policy.h"
+#include "wlr.h"
+
+#include <cstdlib>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
+
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <libudev.h>
+#include <string>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <vector>
+#include <xf86drm.h>
+#include <xf86drmMode.h>
+#endif
+
+namespace umbriel {
+
+  namespace {
+
+    constexpr Logger kLog("drm");
+
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+    constexpr auto kDeviceWaitTimeout = std::chrono::seconds(10);
+    // Linux reserves this character-device major for DRM, including removed nodes.
+    constexpr unsigned int kDrmDeviceMajor = 226;
+    // NVIDIA reserves minors 0-247 for GPUs; 254 and 255 are shared devices.
+    constexpr unsigned int kNvidiaDeviceMajor = 195;
+    constexpr unsigned int kNvidiaGpuMinorMax = 247;
+
+    struct UdevDeviceDeleter {
+      void operator()(udev_device* device) const { udev_device_unref(device); }
+    };
+    struct UdevEnumerateDeleter {
+      void operator()(udev_enumerate* enumerate) const { udev_enumerate_unref(enumerate); }
+    };
+    using UdevDevice = std::unique_ptr<udev_device, UdevDeviceDeleter>;
+    using UdevEnumerate = std::unique_ptr<udev_enumerate, UdevEnumerateDeleter>;
+
+    bool hasNumericSuffix(std::string_view value, std::string_view prefix) {
+      if (!value.starts_with(prefix) || value.size() == prefix.size()) {
+        return false;
+      }
+      return std::ranges::all_of(value.substr(prefix.size()), [](char character) {
+        return character >= '0' && character <= '9';
+      });
+    }
+
+    bool isDrmNode(udev_device* device) {
+      const char* subsystem = udev_device_get_subsystem(device);
+      const char* sysname = udev_device_get_sysname(device);
+      return subsystem != nullptr
+          && std::string_view(subsystem) == "drm"
+          && sysname != nullptr
+          && (hasNumericSuffix(sysname, "card") || hasNumericSuffix(sysname, "renderD"));
+    }
+
+    std::string physicalDevicePath(udev_device* device) {
+      for (udev_device* parent = udev_device_get_parent(device); parent != nullptr;
+           parent = udev_device_get_parent(parent)) {
+        const char* subsystem = udev_device_get_subsystem(parent);
+        if (subsystem != nullptr && std::string_view(subsystem) == "drm") {
+          continue;
+        }
+        if (const char* syspath = udev_device_get_syspath(parent)) {
+          return syspath;
+        }
+      }
+      return {};
+    }
+
+    std::optional<std::string> pciAddress(udev_device* device) {
+      udev_device* pci = udev_device_get_parent_with_subsystem_devtype(device, "pci", nullptr);
+      if (pci == nullptr) {
+        return std::nullopt;
+      }
+      const char* sysname = udev_device_get_sysname(pci);
+      return sysname == nullptr ? std::nullopt : std::optional<std::string>(sysname);
+    }
+
+    DrmDeviceIdentity physicalIdentityFromUdev(udev_device* device, dev_t number, std::string_view fallbackNode = {}) {
+      DrmDeviceIdentity identity;
+      identity.node = fallbackNode;
+      identity.device = number;
+      if (device != nullptr) {
+        if (const char* node = udev_device_get_devnode(device)) {
+          identity.node = node;
+        }
+        identity.physicalDevice = physicalDevicePath(device);
+        identity.pciAddress = pciAddress(device);
+      }
+      return identity;
+    }
+
+    std::optional<DrmDeviceIdentity> identityFromDevnum(udev* context, dev_t device, std::string_view node = {}) {
+      UdevDevice udevDevice(udev_device_new_from_devnum(context, 'c', device));
+      if (!udevDevice || !isDrmNode(udevDevice.get())) {
+        return std::nullopt;
+      }
+      return physicalIdentityFromUdev(udevDevice.get(), udev_device_get_devnum(udevDevice.get()), node);
+    }
+
+    std::optional<unsigned int> nvidiaDeviceMinor(const std::filesystem::path& informationPath) {
+      std::ifstream information(informationPath);
+      std::string line;
+      while (std::getline(information, line)) {
+        if (const auto minorNumber = parseNvidiaDeviceMinor(line)) {
+          return minorNumber;
+        }
+      }
+      return std::nullopt;
+    }
+
+    // Some NVIDIA nodes lack a udev parent; driver metadata supplies their PCI addresses.
+    std::optional<std::vector<std::pair<dev_t, std::string>>> nvidiaPciDevices() {
+      std::error_code error;
+      std::filesystem::directory_iterator gpu("/proc/driver/nvidia/gpus", error);
+      if (error) {
+        if (error == std::errc::no_such_file_or_directory) {
+          return std::vector<std::pair<dev_t, std::string>>{};
+        }
+        kLog.error("cannot inspect proprietary NVIDIA GPU metadata: {}", error.message());
+        return std::nullopt;
+      }
+
+      std::vector<std::pair<dev_t, std::string>> devices;
+      const std::filesystem::directory_iterator end;
+      while (gpu != end) {
+        // Missing records only matter if an open GPU needs their PCI identity.
+        if (const auto minorNumber = nvidiaDeviceMinor(gpu->path() / "information")) {
+          const std::filesystem::path node = "/dev" / std::filesystem::path("nvidia" + std::to_string(*minorNumber));
+          struct stat statBuffer{};
+          if (stat(node.c_str(), &statBuffer) == 0 && S_ISCHR(statBuffer.st_mode)) {
+            devices.emplace_back(statBuffer.st_rdev, gpu->path().filename().string());
+          }
+        }
+        gpu.increment(error);
+        if (error) {
+          kLog.error("cannot continue inspecting proprietary NVIDIA GPU metadata: {}", error.message());
+          return std::nullopt;
+        }
+      }
+      return devices;
+    }
+
+    std::expected<DrmDeviceIdentity, std::string> resolveDrmPath(udev* context, const std::string& path) {
+      struct stat statBuffer{};
+      if (stat(path.c_str(), &statBuffer) != 0) {
+        return std::unexpected(std::string("stat failed: ") + std::strerror(errno));
+      }
+      if (!S_ISCHR(statBuffer.st_mode)) {
+        return std::unexpected("not a character device");
+      }
+      auto identity = identityFromDevnum(context, statBuffer.st_rdev, path);
+      if (!identity) {
+        return std::unexpected("not a DRM card or render node");
+      }
+      return std::move(*identity);
+    }
+
+    bool environmentFlagEnabled(const char* name) {
+      const char* value = std::getenv(name);
+      return value != nullptr && std::string_view(value) == "1";
+    }
+
+    const char* exclusionMatchName(DrmExclusionMatch match) {
+      switch (match) {
+      case DrmExclusionMatch::DeviceNumber:
+        return "device number";
+      case DrmExclusionMatch::PhysicalDevice:
+        return "physical GPU";
+      case DrmExclusionMatch::PciAddress:
+        return "PCI address";
+      case DrmExclusionMatch::None:
+        return "none";
+      }
+      return "unknown";
+    }
+
+    void disconnectListener(wl_listener& listener) {
+      if (listener.notify == nullptr) {
+        return;
+      }
+      wl_list_remove(&listener.link);
+      listener.notify = nullptr;
+    }
+
+#endif
+
+  } // namespace
+
+  class BackendManager::Impl {
+  public:
+    Impl(wl_display* display, Config::Drm config) : m_display(display), m_config(std::move(config)) {}
+
+    ~Impl() {
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+      m_destroying = true;
+      disconnectSessionListeners();
+#endif
+      if (m_backend != nullptr) {
+        wlr_backend_destroy(m_backend);
+      }
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+      if (m_policyActive && m_session != nullptr) {
+        wlr_session_destroy(m_session);
+      }
+#endif
+    }
+
+    [[nodiscard]] bool initialize() {
+      const char* configuredBackends = std::getenv("WLR_BACKENDS");
+      const DrmBackendEnvironment environment = resolveDrmBackendEnvironment(
+          configuredBackends == nullptr ? std::nullopt : std::optional<std::string_view>(configuredBackends),
+          std::getenv("WAYLAND_DISPLAY") != nullptr, std::getenv("WAYLAND_SOCKET") != nullptr,
+          std::getenv("DISPLAY") != nullptr
+      );
+      m_policyActive = m_config.configured() && environment.native;
+      if (m_config.configured() && !environment.native) {
+        kLog.info("configuration is inactive because the selected backend is nested or headless");
+      }
+
+      if (!m_policyActive) {
+        m_backend = wlr_backend_autocreate(wl_display_get_event_loop(m_display), &m_session);
+        return m_backend != nullptr;
+      }
+
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+      if (!environment.exclusionsSupported) {
+        kLog.error(
+            "DRM exclusion supports one drm backend and at most one libinput backend; mixed native backends cannot be "
+            "filtered safely"
+        );
+        return false;
+      }
+      return initializeFiltered(environment);
+#else
+      kLog.error("DRM policy requires wlroots DRM backend and libudev support in this build");
+      return false;
+#endif
+    }
+
+    [[nodiscard]] wlr_backend* backend() const { return m_backend; }
+    [[nodiscard]] wlr_session* session() const { return m_session; }
+
+    [[nodiscard]] wlr_renderer* createRenderer() {
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+      if (m_policyActive) {
+        const bool forceSoftware = environmentFlagEnabled("WLR_RENDERER_FORCE_SOFTWARE");
+        if (forceSoftware) {
+          kLog.error(
+              "WLR_RENDERER_FORCE_SOFTWARE=1 cannot guarantee DRM exclusions; refusing to enumerate EGL devices"
+          );
+          return nullptr;
+        }
+        return createPrimaryRenderer();
+      }
+#endif
+      return fx_renderer_create(m_backend);
+    }
+
+    [[nodiscard]] bool verifyOpenDevices([[maybe_unused]] std::string_view context) {
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+      return !m_policyActive || verifyNoExcludedDeviceIsOpen(context);
+#else
+      return true;
+#endif
+    }
+
+    void markStarted() {
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+      m_started = true;
+#endif
+    }
+
+  private:
+    wl_display* m_display = nullptr;
+    Config::Drm m_config;
+    bool m_policyActive = false;
+    wlr_backend* m_backend = nullptr;
+    wlr_session* m_session = nullptr;
+
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+    struct DrmBackendRecord {
+      Impl* owner = nullptr;
+      wlr_backend* backend = nullptr;
+      DrmDeviceIdentity identity;
+      wl_listener destroy{};
+    };
+
+    [[nodiscard]] bool initializeFiltered(const DrmBackendEnvironment& environment) {
+      logEnvironmentPrecedence();
+      wl_event_loop* loop = wl_display_get_event_loop(m_display);
+      m_backend = wlr_multi_backend_create(loop);
+      if (m_backend == nullptr) {
+        kLog.error("failed to create the filtered multi-backend");
+        return false;
+      }
+
+      m_session = wlr_session_create(loop);
+      if (m_session == nullptr) {
+        kLog.error("failed to create a native session");
+        return false;
+      }
+      connectSessionListeners();
+      if (!waitForActiveSession()) {
+        return false;
+      }
+      if (!resolveIgnoredDevices()) {
+        return false;
+      }
+      if (environment.createLibinput
+          && environment.libinputBeforeDrm
+          && !createLibinputBackend(environment.allowMissingLibinput)) {
+        return false;
+      }
+
+      auto candidates = enumerateDrmCards();
+      if (!candidates) {
+        return false;
+      }
+      if (candidates->empty()) {
+        kLog.info("waiting up to 10 seconds for a DRM card");
+        if (!waitForDrmCard()) {
+          return false;
+        }
+        candidates = enumerateDrmCards();
+        if (!candidates) {
+          return false;
+        }
+      }
+      if (candidates->empty()) {
+        kLog.error("no DRM cards were found for seat {}", m_session->seat);
+        return false;
+      }
+
+      for (unsigned int attempt = 0; attempt < 2 && m_primary == nullptr; ++attempt) {
+        bool anyAllowed = false;
+        for (const DrmDeviceIdentity& candidate : *candidates) {
+          const DrmExclusionMatch match = drmExclusionMatch(candidate, m_ignoredDevices, m_config.ignoredPciAddresses);
+          if (match != DrmExclusionMatch::None) {
+            kLog.info("excluding {} before open (matched {})", candidate.node, exclusionMatchName(match));
+            continue;
+          }
+          anyAllowed = true;
+          openCandidate(candidate);
+        }
+        if (!anyAllowed) {
+          kLog.error("all DRM cards on seat {} are excluded", m_session->seat);
+          return false;
+        }
+
+        if (m_primary == nullptr && attempt == 0) {
+          kLog.warn("no allowed DRM card initialized; retrying once from a fresh udev enumeration");
+          candidates = enumerateDrmCards();
+          if (!candidates || candidates->empty()) {
+            break;
+          }
+        }
+      }
+      if (m_primary == nullptr) {
+        kLog.error("could not create a backend on any allowed DRM card");
+        return false;
+      }
+      if (environment.createLibinput
+          && !environment.libinputBeforeDrm
+          && !createLibinputBackend(environment.allowMissingLibinput)) {
+        return false;
+      }
+
+      m_initializing = false;
+      for (const std::string& path : std::exchange(m_pendingDrmCards, {})) {
+        handleAddedDrmCard(path);
+      }
+      return true;
+    }
+
+    void logEnvironmentPrecedence() const {
+      if (std::getenv("WLR_DRM_DEVICES") != nullptr) {
+        kLog.warn("ignoring inherited WLR_DRM_DEVICES because DRM exclusions are configured");
+      }
+      if (std::getenv("WLR_RENDER_DRM_DEVICE") != nullptr) {
+        kLog.warn("ignoring inherited WLR_RENDER_DRM_DEVICE because [drm] is configured");
+      }
+    }
+
+    [[nodiscard]] bool waitForActiveSession() {
+      if (m_session->active) {
+        return true;
+      }
+      kLog.info("waiting up to 10 seconds for the native session to become active");
+      const auto deadline = std::chrono::steady_clock::now() + kDeviceWaitTimeout;
+      while (m_session != nullptr && !m_session->active) {
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+        if (remaining.count() <= 0) {
+          break;
+        }
+        if (wl_event_loop_dispatch(wl_display_get_event_loop(m_display), static_cast<int>(remaining.count())) < 0) {
+          kLog.error("failed while waiting for the session: {}", std::strerror(errno));
+          return false;
+        }
+      }
+      if (m_session == nullptr || !m_session->active) {
+        kLog.error("timed out waiting for the native session");
+        return false;
+      }
+      return true;
+    }
+
+    [[nodiscard]] bool waitForDrmCard() {
+      m_addSeen = false;
+      const auto deadline = std::chrono::steady_clock::now() + kDeviceWaitTimeout;
+      while (m_session != nullptr && !m_addSeen) {
+        const auto remaining =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+        if (remaining.count() <= 0) {
+          break;
+        }
+        if (wl_event_loop_dispatch(wl_display_get_event_loop(m_display), static_cast<int>(remaining.count())) < 0) {
+          kLog.error("failed while waiting for a DRM card: {}", std::strerror(errno));
+          return false;
+        }
+      }
+      return m_session != nullptr;
+    }
+
+    [[nodiscard]] bool createLibinputBackend(bool allowMissing) {
+      wlr_backend* backend = wlr_libinput_backend_create(m_session);
+      if (backend == nullptr) {
+        if (allowMissing && environmentFlagEnabled("WLR_LIBINPUT_NO_DEVICES")) {
+          kLog.info("starting without libinput because WLR_LIBINPUT_NO_DEVICES=1");
+          return true;
+        }
+        kLog.error("failed to create the libinput backend");
+        return false;
+      }
+      if (!wlr_multi_backend_add(m_backend, backend)) {
+        kLog.error("failed to add libinput to the multi-backend");
+        wlr_backend_destroy(backend);
+        return false;
+      }
+      return true;
+    }
+
+    [[nodiscard]] std::optional<std::vector<DrmDeviceIdentity>> enumerateDrmCards() const {
+      UdevEnumerate enumerate(udev_enumerate_new(m_session->udev));
+      if (!enumerate) {
+        kLog.error("failed to allocate a udev DRM enumeration");
+        return std::nullopt;
+      }
+      udev_enumerate_add_match_subsystem(enumerate.get(), "drm");
+      udev_enumerate_add_match_sysname(enumerate.get(), "card[0-9]*");
+      if (udev_enumerate_scan_devices(enumerate.get()) != 0) {
+        kLog.error("failed to enumerate DRM cards through udev");
+        return std::nullopt;
+      }
+
+      std::vector<DrmDeviceIdentity> candidates;
+      for (udev_list_entry* entry = udev_enumerate_get_list_entry(enumerate.get()); entry != nullptr;
+           entry = udev_list_entry_get_next(entry)) {
+        const char* syspath = udev_list_entry_get_name(entry);
+        if (syspath == nullptr) {
+          continue;
+        }
+        UdevDevice device(udev_device_new_from_syspath(m_session->udev, syspath));
+        if (!device || !isDrmNode(device.get())) {
+          continue;
+        }
+        const char* seat = udev_device_get_property_value(device.get(), "ID_SEAT");
+        seat = seat == nullptr ? "seat0" : seat;
+        if (m_session->seat[0] != '\0' && std::string_view(m_session->seat) != seat) {
+          continue;
+        }
+        auto identity = physicalIdentityFromUdev(device.get(), udev_device_get_devnum(device.get()));
+        if (identity.node.empty()) {
+          continue;
+        }
+        bool bootDisplay = false;
+        if (const char* value = udev_device_get_sysattr_value(device.get(), "boot_display")) {
+          bootDisplay = std::string_view(value) == "1";
+        }
+        if (!bootDisplay) {
+          udev_device* pci = udev_device_get_parent_with_subsystem_devtype(device.get(), "pci", nullptr);
+          if (pci != nullptr) {
+            if (const char* value = udev_device_get_sysattr_value(pci, "boot_vga")) {
+              bootDisplay = std::string_view(value) == "1";
+            }
+          }
+        }
+        candidates.push_back(std::move(identity));
+        if (bootDisplay) {
+          // Match wlr_session_find_gpus(): retain udev enumeration order, but
+          // move the boot display to the first slot.
+          std::swap(candidates.front(), candidates.back());
+        }
+      }
+      return candidates;
+    }
+
+    // Resolve all configured paths before opening any GPU. Runtime filtering
+    // uses these physical identities even after paths disappear or get reused.
+    [[nodiscard]] bool resolveIgnoredDevices() {
+      m_ignoredDevices.reserve(m_config.ignoredDevices.size());
+      for (const std::string& path : m_config.ignoredDevices) {
+        auto identity = resolveDrmPath(m_session->udev, path);
+        if (!identity) {
+          kLog.error(
+              "cannot resolve ignored DRM selector {}: {}. Use ignored_pci_addresses for a GPU that is absent or "
+              "bound to vfio-pci at startup",
+              path, identity.error()
+          );
+          return false;
+        }
+        if (!identity->pciAddress && identity->physicalDevice.empty()) {
+          kLog.error("ignored DRM selector {} has no stable GPU identity; use ignored_pci_addresses instead", path);
+          return false;
+        }
+        m_ignoredDevices.push_back(std::move(*identity));
+        kLog.info("resolved ignored DRM selector {}", path);
+      }
+      return true;
+    }
+
+    void openCandidate(const DrmDeviceIdentity& candidate) {
+      struct stat preOpenStat{};
+      if (stat(candidate.node.c_str(), &preOpenStat) != 0 || !S_ISCHR(preOpenStat.st_mode)) {
+        kLog.warn("allowed DRM card {} disappeared before open", candidate.node);
+        return;
+      }
+      if (preOpenStat.st_rdev != candidate.device) {
+        kLog.warn("allowed DRM card {} was re-enumerated before open; deferring it", candidate.node);
+        return;
+      }
+      auto identity = identityFromDevnum(m_session->udev, preOpenStat.st_rdev, candidate.node);
+      if (!identity) {
+        kLog.warn("allowed DRM card {} no longer has a valid udev identity", candidate.node);
+        return;
+      }
+      const DrmExclusionMatch preOpenMatch =
+          drmExclusionMatch(*identity, m_ignoredDevices, m_config.ignoredPciAddresses);
+      if (preOpenMatch != DrmExclusionMatch::None) {
+        kLog.info(
+            "excluding {} at the final pre-open check (matched {})", candidate.node, exclusionMatchName(preOpenMatch)
+        );
+        return;
+      }
+
+      wlr_device* device = wlr_session_open_file(m_session, identity->node.c_str());
+      if (device == nullptr) {
+        kLog.warn("failed to open allowed DRM card {}", identity->node);
+        return;
+      }
+      if (device->dev != identity->device) {
+        kLog.warn("DRM card {} changed identity while opening; deferring it", identity->node);
+        wlr_session_close_file(m_session, device);
+        return;
+      }
+      auto openedIdentity = identityFromDevnum(m_session->udev, device->dev, identity->node);
+      if (!openedIdentity
+          || drmExclusionMatch(*openedIdentity, m_ignoredDevices, m_config.ignoredPciAddresses)
+              != DrmExclusionMatch::None) {
+        kLog.error("DRM card {} became excluded while opening; closing it without creating a backend", identity->node);
+        wlr_session_close_file(m_session, device);
+        return;
+      }
+      if (drmIsKMS(device->fd) == 0) {
+        kLog.warn("allowed DRM node {} is not KMS-capable", identity->node);
+        wlr_session_close_file(m_session, device);
+        return;
+      }
+
+      const bool primary = m_primary == nullptr;
+      // A parent makes wlroots create an internal multi-GPU renderer through
+      // EGL device enumeration. Independent backends keep exclusions strict;
+      // secondary outputs import the compositor's DMA-BUFs directly instead.
+      wlr_backend* drm = wlr_drm_backend_create(m_session, device, nullptr);
+      if (drm == nullptr) {
+        closeDeviceIfOwned(device);
+        kLog.warn("failed to create a DRM backend for {}", identity->node);
+        return;
+      }
+      if (!wlr_multi_backend_add(m_backend, drm)) {
+        kLog.warn("failed to add {} to the multi-backend", identity->node);
+        wlr_backend_destroy(drm);
+        return;
+      }
+
+      auto record = std::make_unique<DrmBackendRecord>();
+      record->owner = this;
+      record->backend = drm;
+      record->identity = std::move(*openedIdentity);
+      record->destroy.notify = onDrmBackendDestroy;
+      wl_signal_add(&drm->events.destroy, &record->destroy);
+      if (primary) {
+        m_primary = drm;
+        kLog.info("selected {} as the primary DRM card", identity->node);
+      } else {
+        kLog.info("added allowed secondary DRM card {}", identity->node);
+      }
+      m_drmBackends.push_back(std::move(record));
+
+      if (m_started && !wlr_backend_start(drm)) {
+        kLog.warn("failed to start hotplugged DRM card {}", identity->node);
+        wlr_multi_backend_remove(m_backend, drm);
+        wlr_backend_destroy(drm);
+      }
+    }
+
+    void closeDeviceIfOwned(wlr_device* candidate) const {
+      wlr_device* device = nullptr;
+      wl_list_for_each(device, &m_session->devices, link) {
+        if (device == candidate) {
+          wlr_session_close_file(m_session, device);
+          return;
+        }
+      }
+    }
+
+    void handleAddedDrmCard(const std::string& path) {
+      if (m_session == nullptr) {
+        return;
+      }
+
+      auto identity = resolveDrmPath(m_session->udev, path);
+      if (!identity) {
+        kLog.warn("ignoring DRM add event for {}: {}", path, identity.error());
+        return;
+      }
+      const bool alreadyActive = std::ranges::any_of(m_drmBackends, [&](const auto& record) {
+        return sameDrmPhysicalDevice(record->identity, *identity);
+      });
+      if (alreadyActive) {
+        return;
+      }
+
+      const DrmExclusionMatch match = drmExclusionMatch(*identity, m_ignoredDevices, m_config.ignoredPciAddresses);
+      if (match != DrmExclusionMatch::None) {
+        kLog.info("keeping reattached DRM card {} excluded (matched {})", path, exclusionMatchName(match));
+        return;
+      }
+      openCandidate(*identity);
+    }
+
+    [[nodiscard]] wlr_renderer* createPrimaryRenderer() {
+      if (m_primary == nullptr) {
+        kLog.error("cannot create an exclusion-safe renderer without a primary DRM backend");
+        return nullptr;
+      }
+      const int fd = wlr_backend_get_drm_fd(m_primary);
+      if (fd < 0) {
+        kLog.error("the primary DRM backend did not expose a renderer device");
+        return nullptr;
+      }
+      wlr_renderer* renderer = fx_renderer_create_with_drm_fd_gbm(fd);
+      if (renderer == nullptr) {
+        return nullptr;
+      }
+
+      const auto primary =
+          std::ranges::find_if(m_drmBackends, [&](const auto& record) { return record->backend == m_primary; });
+      auto rendererDevice = rendererIdentity(renderer);
+      if (primary == m_drmBackends.end()
+          || !rendererDevice
+          || !sameDrmPhysicalDevice((*primary)->identity, *rendererDevice)) {
+        kLog.error("renderer did not initialize on the primary DRM device");
+        wlr_renderer_destroy(renderer);
+        return nullptr;
+      }
+      return renderer;
+    }
+
+    [[nodiscard]] bool verifyNoExcludedDeviceIsOpen(std::string_view context) const {
+      if (m_session == nullptr) {
+        kLog.error("native session is unavailable {}", context);
+        return false;
+      }
+      std::error_code error;
+      std::filesystem::directory_iterator descriptor("/proc/self/fd", error);
+      if (error) {
+        kLog.error("cannot inspect open devices {}: {}", context, error.message());
+        return false;
+      }
+
+      std::optional<std::vector<std::pair<dev_t, std::string>>> nvidiaPciByDevice;
+      const std::filesystem::directory_iterator end;
+      while (descriptor != end) {
+        struct stat statBuffer{};
+        if (stat(descriptor->path().c_str(), &statBuffer) != 0) {
+          const int statError = errno;
+          if (statError != ENOENT) {
+            kLog.error(
+                "cannot inspect descriptor {} {}: {}", descriptor->path().string(), context, std::strerror(statError)
+            );
+            return false;
+          }
+        } else if (S_ISCHR(statBuffer.st_mode)) {
+          std::error_code targetError;
+          const std::filesystem::path target = std::filesystem::read_symlink(descriptor->path(), targetError);
+          const std::string fallbackNode = targetError ? descriptor->path().string() : target.string();
+          UdevDevice device(udev_device_new_from_devnum(m_session->udev, 'c', statBuffer.st_rdev));
+          auto identity = physicalIdentityFromUdev(device.get(), statBuffer.st_rdev, fallbackNode);
+          if (major(statBuffer.st_rdev) == kDrmDeviceMajor && !identity.pciAddress && identity.physicalDevice.empty()) {
+            kLog.error(
+                "cannot attribute open DRM device {} {} because its GPU identity is unavailable", identity.node, context
+            );
+            return false;
+          }
+          const bool nvidiaGpu =
+              (major(statBuffer.st_rdev) == kNvidiaDeviceMajor && minor(statBuffer.st_rdev) <= kNvidiaGpuMinorMax)
+              || isNvidiaGpuDeviceNode(identity.node);
+          if (!identity.pciAddress && nvidiaGpu) {
+            if (!nvidiaPciByDevice) {
+              nvidiaPciByDevice = nvidiaPciDevices();
+              if (!nvidiaPciByDevice) {
+                return false;
+              }
+            }
+            const auto nvidia = std::ranges::find_if(*nvidiaPciByDevice, [&](const auto& gpu) {
+              return gpu.first == statBuffer.st_rdev;
+            });
+            if (nvidia == nvidiaPciByDevice->end()) {
+              kLog.error(
+                  "cannot attribute open NVIDIA GPU device {} {} because its PCI metadata is unavailable",
+                  identity.node, context
+              );
+              return false;
+            }
+            identity.pciAddress = nvidia->second;
+          }
+          const DrmExclusionMatch match = drmExclusionMatch(identity, m_ignoredDevices, m_config.ignoredPciAddresses);
+          if (match != DrmExclusionMatch::None) {
+            kLog.error("excluded device {} is open {} (matched {})", identity.node, context, exclusionMatchName(match));
+            return false;
+          }
+        }
+        descriptor.increment(error);
+        if (error) {
+          kLog.error("cannot continue inspecting open devices {}: {}", context, error.message());
+          return false;
+        }
+      }
+      return true;
+    }
+
+    [[nodiscard]] std::optional<DrmDeviceIdentity> rendererIdentity(wlr_renderer* renderer) const {
+      if (m_session == nullptr) {
+        return std::nullopt;
+      }
+      const int fd = wlr_renderer_get_drm_fd(renderer);
+      if (fd < 0) {
+        return std::nullopt;
+      }
+      struct stat statBuffer{};
+      if (fstat(fd, &statBuffer) != 0 || !S_ISCHR(statBuffer.st_mode)) {
+        return std::nullopt;
+      }
+      return identityFromDevnum(m_session->udev, statBuffer.st_rdev);
+    }
+
+    void connectSessionListeners() {
+      m_sessionAdd.notify = onSessionAdd;
+      wl_signal_add(&m_session->events.add_drm_card, &m_sessionAdd);
+      m_sessionDestroy.notify = onSessionDestroy;
+      wl_signal_add(&m_session->events.destroy, &m_sessionDestroy);
+    }
+
+    void disconnectSessionListeners() {
+      disconnectListener(m_sessionAdd);
+      disconnectListener(m_sessionDestroy);
+    }
+
+    static void onSessionAdd(wl_listener* listener, void* data) {
+      Impl* self;
+      self = wl_container_of(listener, self, m_sessionAdd);
+      self->m_addSeen = true;
+      const auto* event = static_cast<const wlr_session_add_event*>(data);
+      if (event == nullptr || event->path == nullptr) {
+        return;
+      }
+      if (self->m_initializing) {
+        self->m_pendingDrmCards.emplace_back(event->path);
+      } else {
+        self->handleAddedDrmCard(event->path);
+      }
+    }
+
+    static void onSessionDestroy(wl_listener* listener, void* /*data*/) {
+      Impl* self;
+      self = wl_container_of(listener, self, m_sessionDestroy);
+      self->disconnectSessionListeners();
+      self->m_session = nullptr;
+      if (!self->m_destroying) {
+        kLog.error("native session was lost; terminating Umbriel");
+        wl_display_terminate(self->m_display);
+      }
+    }
+
+    static void onDrmBackendDestroy(wl_listener* listener, void* /*data*/) {
+      DrmBackendRecord* record;
+      record = wl_container_of(listener, record, destroy);
+      Impl* self = record->owner;
+      const bool primary = record->backend == self->m_primary;
+      disconnectListener(record->destroy);
+      if (primary) {
+        self->m_primary = nullptr;
+      }
+      const auto position =
+          std::ranges::find_if(self->m_drmBackends, [&](const auto& candidate) { return candidate.get() == record; });
+      if (position != self->m_drmBackends.end()) {
+        self->m_drmBackends.erase(position);
+      }
+      if (primary && !self->m_destroying) {
+        kLog.error("primary DRM backend was lost; terminating Umbriel");
+        wl_display_terminate(self->m_display);
+      } else if (!primary && !self->m_destroying) {
+        kLog.info("secondary DRM backend was removed");
+      }
+    }
+
+    bool m_initializing = true;
+    bool m_started = false;
+    bool m_destroying = false;
+    bool m_addSeen = false;
+    wlr_backend* m_primary = nullptr;
+    std::vector<DrmDeviceIdentity> m_ignoredDevices;
+    std::vector<std::unique_ptr<DrmBackendRecord>> m_drmBackends;
+    std::vector<std::string> m_pendingDrmCards;
+    wl_listener m_sessionAdd{};
+    wl_listener m_sessionDestroy{};
+#endif
+  };
+
+  std::unique_ptr<BackendManager> BackendManager::create(wl_display* display, const Config::Drm& config) {
+    if (display == nullptr) {
+      return nullptr;
+    }
+    auto impl = std::make_unique<Impl>(display, config);
+    if (!impl->initialize()) {
+      return nullptr;
+    }
+    return std::unique_ptr<BackendManager>(new BackendManager(std::move(impl)));
+  }
+
+  BackendManager::BackendManager(std::unique_ptr<Impl> impl) : m_impl(std::move(impl)) {}
+  BackendManager::~BackendManager() = default;
+
+  wlr_backend* BackendManager::backend() const { return m_impl->backend(); }
+  wlr_session* BackendManager::session() const { return m_impl->session(); }
+  wlr_renderer* BackendManager::createRenderer() { return m_impl->createRenderer(); }
+  bool BackendManager::verifyOpenDevices(std::string_view context) { return m_impl->verifyOpenDevices(context); }
+  void BackendManager::markStarted() { m_impl->markStarted(); }
+
+} // namespace umbriel

--- a/src/server/backend_manager.h
+++ b/src/server/backend_manager.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "config/config.h"
+
+#include <memory>
+#include <string_view>
+
+struct wl_display;
+struct wlr_backend;
+struct wlr_renderer;
+struct wlr_session;
+
+namespace umbriel {
+
+  // Owns backend selection, hotplug handling, and the GPU exclusions fixed at startup.
+  class BackendManager {
+  public:
+    [[nodiscard]] static std::unique_ptr<BackendManager> create(wl_display* display, const Config::Drm& config);
+    ~BackendManager();
+
+    BackendManager(const BackendManager&) = delete;
+    BackendManager& operator=(const BackendManager&) = delete;
+
+    [[nodiscard]] wlr_backend* backend() const;
+    [[nodiscard]] wlr_session* session() const;
+    [[nodiscard]] wlr_renderer* createRenderer();
+    [[nodiscard]] bool verifyOpenDevices(std::string_view context);
+    void markStarted();
+
+  private:
+    class Impl;
+    explicit BackendManager(std::unique_ptr<Impl> impl);
+
+    std::unique_ptr<Impl> m_impl;
+  };
+
+} // namespace umbriel

--- a/src/server/drm_policy.cpp
+++ b/src/server/drm_policy.cpp
@@ -1,0 +1,121 @@
+#include "server/drm_policy.h"
+
+#include <algorithm>
+#include <charconv>
+#include <ranges>
+
+namespace umbriel {
+
+  bool sameDrmPhysicalDevice(const DrmDeviceIdentity& first, const DrmDeviceIdentity& second) {
+    if (first.pciAddress && second.pciAddress) {
+      return first.pciAddress == second.pciAddress;
+    }
+    if (!first.physicalDevice.empty() && !second.physicalDevice.empty()) {
+      return first.physicalDevice == second.physicalDevice;
+    }
+    return first.device == second.device;
+  }
+
+  DrmBackendEnvironment resolveDrmBackendEnvironment(
+      std::optional<std::string_view> wlrBackends, bool waylandDisplaySet, bool waylandSocketSet, bool x11DisplaySet
+  ) {
+    if (!wlrBackends) {
+      return {
+          .native = !waylandDisplaySet && !waylandSocketSet && !x11DisplaySet,
+          .exclusionsSupported = true,
+          .createLibinput = true,
+          .libinputBeforeDrm = true,
+          .allowMissingLibinput = true,
+      };
+    }
+
+    bool drmSeen = false;
+    bool libinputSeen = false;
+    bool libinputBeforeDrm = false;
+    bool supported = true;
+    for (const auto token : *wlrBackends | std::views::split(',')) {
+      const std::string_view name(token.begin(), token.end());
+      if (name.empty()) {
+        continue;
+      }
+      if (name == "drm" && !drmSeen) {
+        drmSeen = true;
+      } else if (name == "libinput" && !libinputSeen) {
+        libinputSeen = true;
+        libinputBeforeDrm = !drmSeen;
+      } else {
+        supported = false;
+      }
+    }
+    return {
+        .native = drmSeen,
+        .exclusionsSupported = drmSeen && supported,
+        .createLibinput = libinputSeen,
+        .libinputBeforeDrm = libinputBeforeDrm,
+        .allowMissingLibinput = false,
+    };
+  }
+
+  DrmExclusionMatch drmExclusionMatch(
+      const DrmDeviceIdentity& device, std::span<const DrmDeviceIdentity> ignoredDevices,
+      std::span<const std::string> pciAddresses
+  ) {
+    if (device.pciAddress && std::ranges::find(pciAddresses, *device.pciAddress) != pciAddresses.end()) {
+      return DrmExclusionMatch::PciAddress;
+    }
+
+    for (const DrmDeviceIdentity& ignored : ignoredDevices) {
+      if (sameDrmPhysicalDevice(device, ignored)) {
+        if (device.pciAddress && ignored.pciAddress) {
+          return DrmExclusionMatch::PciAddress;
+        }
+        return !device.physicalDevice.empty() && !ignored.physicalDevice.empty() ? DrmExclusionMatch::PhysicalDevice
+                                                                                 : DrmExclusionMatch::DeviceNumber;
+      }
+    }
+    return DrmExclusionMatch::None;
+  }
+
+  std::optional<unsigned int> parseNvidiaDeviceMinor(std::string_view line) {
+    constexpr std::string_view prefix = "Device Minor:";
+    const size_t first = line.find_first_not_of(" \t");
+    if (first == std::string_view::npos) {
+      return std::nullopt;
+    }
+    line.remove_prefix(first);
+    if (!line.starts_with(prefix)) {
+      return std::nullopt;
+    }
+    line.remove_prefix(prefix.size());
+    const size_t numberStart = line.find_first_not_of(" \t");
+    if (numberStart == std::string_view::npos) {
+      return std::nullopt;
+    }
+    line.remove_prefix(numberStart);
+    line = line.substr(0, line.find_last_not_of(" \t\r") + 1);
+
+    unsigned int minorNumber = 0;
+    const auto [end, error] = std::from_chars(line.data(), line.data() + line.size(), minorNumber);
+    if (error != std::errc{} || end != line.data() + line.size()) {
+      return std::nullopt;
+    }
+    return minorNumber;
+  }
+
+  bool isNvidiaGpuDeviceNode(std::string_view node) {
+    constexpr std::string_view deletedSuffix = " (deleted)";
+    if (node.ends_with(deletedSuffix)) {
+      node.remove_suffix(deletedSuffix.size());
+    }
+    const size_t separator = node.find_last_of('/');
+    const std::string_view name = node.substr(separator == std::string_view::npos ? 0 : separator + 1);
+    constexpr std::string_view prefix = "nvidia";
+    if (!name.starts_with(prefix) || name.size() == prefix.size()) {
+      return false;
+    }
+    return std::ranges::all_of(name.substr(prefix.size()), [](char character) {
+      return character >= '0' && character <= '9';
+    });
+  }
+
+} // namespace umbriel

--- a/src/server/drm_policy.h
+++ b/src/server/drm_policy.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+
+namespace umbriel {
+
+  // Identity shared by a GPU's card and render nodes. physicalDevice is the
+  // parent sysfs device, so selecting either node applies to the whole GPU.
+  struct DrmDeviceIdentity {
+    std::string node;
+    dev_t device = 0;
+    std::string physicalDevice;
+    std::optional<std::string> pciAddress;
+  };
+
+  enum class DrmExclusionMatch {
+    None,
+    DeviceNumber,
+    PhysicalDevice,
+    PciAddress,
+  };
+
+  struct DrmBackendEnvironment {
+    bool native = false;
+    bool exclusionsSupported = false;
+    bool createLibinput = false;
+    bool libinputBeforeDrm = false;
+    bool allowMissingLibinput = false;
+    bool operator==(const DrmBackendEnvironment&) const = default;
+  };
+
+  // Card and render nodes have different device numbers but share a physical
+  // GPU. Prefer stable PCI and sysfs identities before the node number.
+  [[nodiscard]] bool sameDrmPhysicalDevice(const DrmDeviceIdentity& first, const DrmDeviceIdentity& second);
+
+  // Mirrors wlroots' WLR_BACKENDS precedence and comma tokenization without
+  // touching process state. Presence of a display variable matters even when
+  // its value is empty, matching wlr_backend_autocreate().
+  [[nodiscard]] DrmBackendEnvironment resolveDrmBackendEnvironment(
+      std::optional<std::string_view> wlrBackends, bool waylandDisplaySet, bool waylandSocketSet, bool x11DisplaySet
+  );
+
+  [[nodiscard]] DrmExclusionMatch drmExclusionMatch(
+      const DrmDeviceIdentity& device, std::span<const DrmDeviceIdentity> ignoredDevices,
+      std::span<const std::string> pciAddresses
+  );
+
+  // Parses one "Device Minor:" line from proprietary NVIDIA GPU metadata.
+  [[nodiscard]] std::optional<unsigned int> parseNvidiaDeviceMinor(std::string_view line);
+
+  // True only for proprietary NVIDIA per-GPU character devices. Shared nodes
+  // such as nvidiactl and nvidia-modeset do not identify one physical GPU.
+  [[nodiscard]] bool isNvidiaGpuDeviceNode(std::string_view node);
+
+} // namespace umbriel

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -21,6 +21,7 @@
 #include "scene/config_banner.h"
 #include "scene/hint_rect.h"
 #include "scene/quit_confirm.h"
+#include "server/backend_manager.h"
 #include "server/ipc.h"
 #include "server/wine_color_manager.h"
 #include "view/view.h"
@@ -264,12 +265,14 @@ namespace umbriel {
     m_clientCreated.notify = onClientCreated;
     wl_display_add_client_created_listener(m_display, &m_clientCreated);
 
-    m_backend = wlr_backend_autocreate(wl_display_get_event_loop(m_display), &m_session);
-    if (m_backend == nullptr) {
+    m_backendManager = BackendManager::create(m_display, config().drm);
+    if (m_backendManager == nullptr) {
       throw std::runtime_error("failed to create wlr_backend");
     }
+    m_backend = m_backendManager->backend();
+    m_session = m_backendManager->session();
 
-    m_renderer = fx_renderer_create(m_backend);
+    m_renderer = m_backendManager->createRenderer();
     if (m_renderer == nullptr) {
       throw std::runtime_error("failed to create fx_renderer");
     }
@@ -302,6 +305,9 @@ namespace umbriel {
     m_allocator = wlr_allocator_autocreate(m_backend, m_renderer);
     if (m_allocator == nullptr) {
       throw std::runtime_error("failed to create wlr_allocator");
+    }
+    if (!m_backendManager->verifyOpenDevices("after allocator creation")) {
+      throw std::runtime_error("renderer or allocator opened an excluded GPU");
     }
 
     prepareAnimationShaders(m_renderer);
@@ -604,7 +610,9 @@ namespace umbriel {
     wlr_allocator_destroy(m_allocator);
     clearAnimationShaderCache();
     wlr_renderer_destroy(m_renderer);
-    wlr_backend_destroy(m_backend);
+    m_backendManager.reset();
+    m_backend = nullptr;
+    m_session = nullptr;
     wl_display_destroy(m_display);
   }
 
@@ -667,6 +675,7 @@ namespace umbriel {
       wlr_log(WLR_ERROR, "failed to start backend");
       return false;
     }
+    m_backendManager->markStarted();
 
     // These are delivered through the event loop, not a signal handler, so the shutdown path is ordinary code. Note the
     // side effect: wl_event_loop_add_signal blocks the signal process-wide, and a blocked mask survives fork and exec,

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -94,6 +94,7 @@ namespace umbriel {
   struct Keybind;
 
   class Cursor;
+  class BackendManager;
   class FocusManager;
   class XwaylandSupervisor;
   class ConfigWatcher;
@@ -488,6 +489,7 @@ namespace umbriel {
     };
 
     wl_display* m_display = nullptr;
+    std::unique_ptr<BackendManager> m_backendManager;
     wlr_backend* m_backend = nullptr;
     wlr_session* m_session = nullptr;
     wlr_renderer* m_renderer = nullptr;

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -15,6 +15,7 @@
 #include "scene/cheatsheet.h"
 #include "scene/hint_rect.h"
 #include "scene/quit_confirm.h"
+#include "server/backend_manager.h"
 #include "server/ipc.h"
 #include "server/server.h"
 #include "view/popup.h"
@@ -468,6 +469,9 @@ namespace umbriel {
     cancelModifierTap();
     const ConfigReloadResult result = reloadConfig();
     if (result.success) {
+      if (result.change.drm) {
+        kLog.warn("DRM configuration changed; restart Umbriel to apply it");
+      }
       if (result.change.keybinds) {
         m_bindCooldowns.clear();
       }
@@ -544,7 +548,7 @@ namespace umbriel {
     wlr_renderer* oldRenderer = m_renderer;
     wlr_allocator* oldAllocator = m_allocator;
 
-    wlr_renderer* newRenderer = fx_renderer_create(m_backend);
+    wlr_renderer* newRenderer = m_backendManager->createRenderer();
     if (newRenderer == nullptr) {
       kLog.error("could not recreate fx_renderer after GPU reset, terminating");
       stop();
@@ -554,6 +558,13 @@ namespace umbriel {
     if (newAllocator == nullptr) {
       kLog.error("could not recreate allocator after GPU reset, terminating");
       wlr_renderer_destroy(newRenderer);
+      stop();
+      return;
+    }
+    if (!m_backendManager->verifyOpenDevices("after renderer recovery")) {
+      wlr_allocator_destroy(newAllocator);
+      wlr_renderer_destroy(newRenderer);
+      kLog.error("renderer recovery opened an excluded GPU, terminating");
       stop();
       return;
     }

--- a/src/wlr.h
+++ b/src/wlr.h
@@ -6,6 +6,9 @@ extern "C" {
 #include <umbrielfx/render/fx_renderer/fx_renderer.h>
 #include <umbrielfx/types/wlr_scene.h>
 #include <wlr/backend.h>
+#if UMBRIEL_HAS_NATIVE_DRM_POLICY
+#include <wlr/backend/drm.h>
+#endif
 #include <wlr/backend/headless.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/multi.h>

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -31,7 +31,13 @@ unit_tests = [
   ['deferred-unfullscreen', ['unit/deferred_unfullscreen.cpp'], []],
   ['config-section', ['unit/config_section.cpp'], []],
   ['config-change', ['unit/config_change.cpp'], []],
-  ['config-load', ['unit/config_load.cpp'], [umbriel_core_dep]],
+  [
+    'config-load',
+    ['unit/config_load.cpp'],
+    [umbriel_core_dep],
+    ['-DUMBRIEL_EXAMPLE_CONFIG="' + meson.project_source_root() / 'examples/config.toml' + '"'],
+  ],
+  ['drm-policy', ['unit/drm_policy.cpp'], []],
   ['config-watcher', ['unit/config_watcher.cpp'], [umbriel_core_dep]],
   ['action-registry', ['unit/action_registry.cpp'], [umbriel_core_dep]],
   ['ipc-commands', ['unit/ipc_commands.cpp'], [umbriel_core_dep]],
@@ -46,16 +52,26 @@ unit_tests = [
   ],
 ]
 
+if native_drm_policy_supported
+  # Meson enables 64-bit file offsets; glibc redirects stat to stat64.
+  stat_symbol = is_glibc ? 'stat64' : 'stat'
+  unit_tests += [
+    ['backend-manager', ['unit/backend_manager.cpp'], [umbriel_core_dep], [], ['-Wl,--wrap=' + stat_symbol]],
+  ]
+endif
+
 unit_test_targets = []
 foreach unit_test : unit_tests
-  # Optional fourth element: compile args for tests that need a path or flag baked in.
+  # Optional compile and link args for tests needing paths, flags, or device I/O wrappers.
   unit_test_args = unit_test.length() > 3 ? unit_test[3] : []
+  unit_test_link_args = unit_test.length() > 4 ? unit_test[4] : []
   test_exe = executable(
     unit_test[0] + '-test',
     unit_test[1],
     include_directories: include_directories('unit'),
     dependencies: [umbriel_pure_dep] + unit_test[2],
     cpp_args: unit_test_args,
+    link_args: unit_test_link_args,
   )
   unit_test_targets += test_exe
   # Config-load also validates the packaged example, including out-of-tree builds.

--- a/tests/unit/backend_manager.cpp
+++ b/tests/unit/backend_manager.cpp
@@ -1,0 +1,484 @@
+#include "server/backend_manager.h"
+
+#include "check.h"
+#include "wlr.h"
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <vector>
+
+extern "C" {
+#include <libudev.h>
+#include <wlr/backend/interface.h>
+#include <xf86drmMode.h>
+}
+
+// Run the real BackendManager and wlroots multi-backend against a simulated
+// udev inventory and session. Only device I/O is substituted: no seat, DRM FD,
+// or graphics driver is opened. Every privileged open attempt is observable.
+struct udev_list_entry {
+  std::string name;
+  udev_list_entry* next = nullptr;
+};
+struct udev_device {
+  std::string subsystem;
+  std::string sysname;
+  std::string syspath;
+  std::string node;
+  dev_t device = 0;
+  udev_device* parent = nullptr;
+  std::vector<std::string> links;
+  bool present = true;
+};
+struct udev {};
+struct udev_enumerate {
+  std::vector<udev_list_entry> entries;
+};
+
+namespace {
+  udev_list_entry* linkEntries(std::vector<udev_list_entry>& entries) {
+    for (size_t i = 0; i < entries.size(); ++i) {
+      entries[i].next = i + 1 < entries.size() ? &entries[i + 1] : nullptr;
+    }
+    return entries.empty() ? nullptr : &entries.front();
+  }
+
+  struct TestDevices {
+    udev context;
+    std::list<udev_device> inventory;
+    std::vector<std::string> openedPci;
+    std::vector<std::string> startedPci;
+    int automaticCalls = 0;
+    int nextFd = 1000;
+    std::string auditPath;
+    dev_t auditDevice = 0;
+    int auditError = 0;
+
+    udev_device& addGpu(unsigned int card, const std::string& pci) {
+      auto& parent = inventory.emplace_back();
+      parent.subsystem = "pci";
+      parent.sysname = pci;
+      parent.syspath = "/sys/devices/" + pci;
+      auto& device = inventory.emplace_back();
+      device.subsystem = "drm";
+      device.parent = &parent;
+      renumber(device, card);
+      device.links.push_back("/dev/dri/by-path/pci-" + pci + "-card");
+      return device;
+    }
+
+    udev_device& addRenderNode(udev_device& card, unsigned int minor) {
+      auto& render = inventory.emplace_back();
+      render.subsystem = "drm";
+      render.parent = card.parent;
+      render.sysname = "renderD" + std::to_string(minor);
+      render.node = "/dev/dri/" + render.sysname;
+      render.syspath = render.parent->syspath + "/drm/" + render.sysname;
+      render.device = makedev(226, minor);
+      render.links.push_back("/dev/dri/by-path/pci-" + render.parent->sysname + "-render");
+      return render;
+    }
+
+    void renumber(udev_device& device, unsigned int card) {
+      device.sysname = "card" + std::to_string(card);
+      device.node = "/dev/dri/" + device.sysname;
+      device.syspath = device.parent->syspath + "/drm/" + device.sysname;
+      device.device = makedev(226, card);
+      device.present = true;
+    }
+
+    udev_device* findNode(std::string_view path) {
+      for (auto& device : inventory) {
+        if (device.present && (device.node == path || std::ranges::contains(device.links, path))) {
+          return &device;
+        }
+      }
+      return nullptr;
+    }
+  };
+
+  TestDevices* devices = nullptr;
+
+  struct DrmBackend {
+    wlr_backend base{};
+    wlr_session* session = nullptr;
+    wlr_device* device = nullptr;
+    std::string pci;
+    wl_listener remove{};
+  };
+
+  bool startDrm(wlr_backend* base) {
+    DrmBackend* drm;
+    drm = wl_container_of(base, drm, base);
+    devices->startedPci.push_back(drm->pci);
+    return true;
+  }
+
+  void destroyDrm(wlr_backend* base) {
+    DrmBackend* drm;
+    drm = wl_container_of(base, drm, base);
+    wl_list_remove(&drm->remove.link);
+    wlr_backend_finish(base);
+    wlr_session_close_file(drm->session, drm->device);
+    delete drm;
+  }
+
+  void removeDrm(wl_listener* listener, void*) {
+    DrmBackend* drm;
+    drm = wl_container_of(listener, drm, remove);
+    wlr_backend_destroy(&drm->base);
+  }
+
+  const wlr_backend_impl kDrmImpl{
+      .start = startDrm,
+      .destroy = destroyDrm,
+      .get_drm_fd = nullptr,
+      .test = nullptr,
+      .commit = nullptr,
+  };
+
+  class Fixture {
+  public:
+    Fixture() {
+      if (const char* value = std::getenv("WLR_BACKENDS")) {
+        m_backends = value;
+      }
+      setenv("WLR_BACKENDS", "drm", 1);
+      devices = &inventory;
+      display = wl_display_create();
+    }
+    ~Fixture() {
+      manager.reset();
+      wl_display_destroy(display);
+      devices = nullptr;
+      if (m_backends) {
+        setenv("WLR_BACKENDS", m_backends->c_str(), 1);
+      } else {
+        unsetenv("WLR_BACKENDS");
+      }
+    }
+
+    void start(const umbriel::Config::Drm& config) {
+      manager = umbriel::BackendManager::create(display, config);
+      CHECK(manager != nullptr);
+      if (manager) {
+        CHECK(wlr_backend_start(manager->backend()));
+        manager->markStarted();
+      }
+    }
+
+    void add(udev_device& device) {
+      device.present = true;
+      wlr_session_add_event event{.path = device.node.c_str()};
+      wl_signal_emit_mutable(&manager->session()->events.add_drm_card, &event);
+    }
+
+    void remove(udev_device& node) {
+      node.present = false;
+      wlr_device* device = nullptr;
+      wl_list_for_each(device, &manager->session()->devices, link) {
+        if (device->dev == node.device) {
+          wl_signal_emit_mutable(&device->events.remove, nullptr);
+          break;
+        }
+      }
+    }
+
+    bool verifyOpenDevice(dev_t device) {
+      std::FILE* file = std::tmpfile();
+      CHECK(file != nullptr);
+      if (file == nullptr) {
+        return false;
+      }
+      inventory.auditPath = "/proc/self/fd/" + std::to_string(fileno(file));
+      inventory.auditDevice = device;
+      const bool accepted = manager->verifyOpenDevices("during descriptor audit");
+      inventory.auditPath.clear();
+      std::fclose(file);
+      return accepted;
+    }
+
+    TestDevices inventory;
+    wl_display* display = nullptr;
+    std::unique_ptr<umbriel::BackendManager> manager;
+
+  private:
+    std::optional<std::string> m_backends;
+  };
+} // namespace
+
+extern "C" {
+// --wrap=stat limits this substitution to calls in this executable. Other paths
+// retain libc behavior, including invalid selectors such as /dev/null.
+#if defined(__GLIBC__) && _FILE_OFFSET_BITS == 64
+#define __real_stat __real_stat64
+#define __wrap_stat __wrap_stat64
+#endif
+int __real_stat(const char* path, struct stat* result);
+int __wrap_stat(const char* path, struct stat* result) {
+  // Substitute one real descriptor so the audit can outlive its udev entry.
+  if (devices->auditPath == path) {
+    if (devices->auditError != 0) {
+      errno = devices->auditError;
+      return -1;
+    }
+    *result = {};
+    result->st_mode = S_IFCHR | 0600;
+    result->st_rdev = devices->auditDevice;
+    return 0;
+  }
+  if (!std::string_view(path).starts_with("/dev/dri/")) {
+    return __real_stat(path, result);
+  }
+  const udev_device* device = devices->findNode(path);
+  if (device == nullptr) {
+    errno = ENOENT;
+    return -1;
+  }
+  *result = {};
+  result->st_mode = S_IFCHR | 0600;
+  result->st_rdev = device->device;
+  return 0;
+}
+
+udev_enumerate* udev_enumerate_new(udev*) { return new udev_enumerate; }
+udev_enumerate* udev_enumerate_unref(udev_enumerate* enumerate) {
+  delete enumerate;
+  return nullptr;
+}
+int udev_enumerate_add_match_subsystem(udev_enumerate*, const char*) { return 0; }
+int udev_enumerate_add_match_sysname(udev_enumerate*, const char*) { return 0; }
+int udev_enumerate_scan_devices(udev_enumerate* enumerate) {
+  for (const auto& device : devices->inventory) {
+    if (device.present && device.subsystem == "drm" && device.sysname.starts_with("card")) {
+      enumerate->entries.push_back({.name = device.syspath});
+    }
+  }
+  return 0;
+}
+udev_list_entry* udev_enumerate_get_list_entry(udev_enumerate* enumerate) { return linkEntries(enumerate->entries); }
+udev_list_entry* udev_list_entry_get_next(udev_list_entry* entry) { return entry->next; }
+const char* udev_list_entry_get_name(udev_list_entry* entry) { return entry->name.c_str(); }
+udev_device* udev_device_new_from_syspath(udev*, const char* path) {
+  const auto found = std::ranges::find(devices->inventory, path, &udev_device::syspath);
+  return found == devices->inventory.end() || !found->present ? nullptr : &*found;
+}
+udev_device* udev_device_new_from_devnum(udev*, char, dev_t number) {
+  const auto found = std::ranges::find_if(devices->inventory, [&](const auto& device) {
+    return device.present && device.device == number && device.subsystem == "drm";
+  });
+  return found == devices->inventory.end() ? nullptr : &*found;
+}
+udev_device* udev_device_unref(udev_device*) { return nullptr; }
+udev_device* udev_device_get_parent(udev_device* device) { return device->parent; }
+udev_device* udev_device_get_parent_with_subsystem_devtype(udev_device* device, const char* subsystem, const char*) {
+  for (auto* parent = device->parent; parent != nullptr; parent = parent->parent) {
+    if (parent->subsystem == subsystem) {
+      return parent;
+    }
+  }
+  return nullptr;
+}
+const char* udev_device_get_subsystem(udev_device* device) { return device->subsystem.c_str(); }
+const char* udev_device_get_sysname(udev_device* device) { return device->sysname.c_str(); }
+const char* udev_device_get_syspath(udev_device* device) { return device->syspath.c_str(); }
+const char* udev_device_get_devnode(udev_device* device) { return device->node.c_str(); }
+dev_t udev_device_get_devnum(udev_device* device) { return device->device; }
+const char* udev_device_get_property_value(udev_device*, const char*) { return nullptr; }
+const char* udev_device_get_sysattr_value(udev_device*, const char*) { return nullptr; }
+
+wlr_session* wlr_session_create(wl_event_loop* loop) {
+  auto* session = new wlr_session{};
+  session->active = true;
+  std::strcpy(session->seat, "seat0");
+  session->udev = &devices->context;
+  session->event_loop = loop;
+  wl_list_init(&session->devices);
+  wl_signal_init(&session->events.active);
+  wl_signal_init(&session->events.add_drm_card);
+  wl_signal_init(&session->events.destroy);
+  return session;
+}
+void wlr_session_destroy(wlr_session* session) {
+  wl_signal_emit_mutable(&session->events.destroy, session);
+  CHECK(wl_list_empty(&session->devices));
+  CHECK(wl_list_empty(&session->events.add_drm_card.listener_list));
+  delete session;
+}
+wlr_device* wlr_session_open_file(wlr_session* session, const char* path) {
+  const auto* node = devices->findNode(path);
+  CHECK(node != nullptr);
+  if (node == nullptr) {
+    return nullptr;
+  }
+  devices->openedPci.push_back(node->parent->sysname);
+  auto* device = new wlr_device{};
+  device->fd = devices->nextFd++;
+  device->dev = node->device;
+  wl_list_insert(&session->devices, &device->link);
+  wl_signal_init(&device->events.change);
+  wl_signal_init(&device->events.remove);
+  return device;
+}
+void wlr_session_close_file(wlr_session*, wlr_device* device) {
+  wl_list_remove(&device->link);
+  delete device;
+}
+int drmIsKMS(int fd) {
+  CHECK(fd >= 1000);
+  return 1;
+}
+wlr_backend* wlr_drm_backend_create(wlr_session* session, wlr_device* device, wlr_backend* parent) {
+  CHECK(parent == nullptr);
+  auto* drm = new DrmBackend{};
+  wlr_backend_init(&drm->base, &kDrmImpl);
+  drm->session = session;
+  drm->device = device;
+  drm->pci = devices->openedPci.back();
+  drm->remove.notify = removeDrm;
+  wl_signal_add(&device->events.remove, &drm->remove);
+  return &drm->base;
+}
+wlr_backend* wlr_backend_autocreate(wl_event_loop* loop, wlr_session** session) {
+  ++devices->automaticCalls;
+  *session = nullptr;
+  return wlr_multi_backend_create(loop);
+}
+} // extern "C"
+
+UMBRIEL_TEST(excludedGpuRemainsUnopenedAfterNodeReuseAndReattachment) {
+  Fixture fixture;
+  fixture.inventory.addGpu(0, "0000:00:02.0");
+  auto& ignored = fixture.inventory.addGpu(1, "0000:01:00.0");
+  fixture.start({.ignoredDevices = {ignored.node}, .ignoredPciAddresses = {}});
+  CHECK_EQ(fixture.inventory.openedPci, (std::vector<std::string>{"0000:00:02.0"}));
+
+  fixture.remove(ignored);
+  auto& replacement = fixture.inventory.addGpu(1, "0000:03:00.0");
+  fixture.add(replacement);
+  fixture.inventory.renumber(ignored, 7);
+  fixture.add(ignored);
+  CHECK_EQ(fixture.inventory.openedPci, (std::vector<std::string>{"0000:00:02.0", "0000:03:00.0"}));
+  CHECK_EQ(fixture.inventory.startedPci, fixture.inventory.openedPci);
+
+  fixture.remove(replacement);
+  fixture.inventory.renumber(replacement, 4);
+  fixture.add(replacement);
+  CHECK_EQ(fixture.inventory.openedPci, (std::vector<std::string>{"0000:00:02.0", "0000:03:00.0", "0000:03:00.0"}));
+}
+
+UMBRIEL_TEST(pciExclusionCoversGpuThatStartsBoundToVfio) {
+  Fixture fixture;
+  fixture.inventory.addGpu(0, "0000:00:02.0");
+  fixture.start({.ignoredDevices = {}, .ignoredPciAddresses = {"0000:01:00.0"}});
+  auto& ignored = fixture.inventory.addGpu(5, "0000:01:00.0");
+  fixture.add(ignored);
+  CHECK_EQ(fixture.inventory.openedPci, (std::vector<std::string>{"0000:00:02.0"}));
+}
+
+UMBRIEL_TEST(renderSelectorKeepsItsGpuWhenTheLinkIsRetargeted) {
+  Fixture fixture;
+  fixture.inventory.addGpu(0, "0000:00:02.0");
+  auto& ignored = fixture.inventory.addGpu(1, "0000:01:00.0");
+  auto& render = fixture.inventory.addRenderNode(ignored, 129);
+  const std::string selector = render.links.front();
+  fixture.start({.ignoredDevices = {selector}, .ignoredPciAddresses = {}});
+  CHECK_EQ(fixture.inventory.openedPci, (std::vector<std::string>{"0000:00:02.0"}));
+
+  fixture.remove(ignored);
+  render.present = false;
+  auto& replacement = fixture.inventory.addGpu(1, "0000:03:00.0");
+  auto& replacementRender = fixture.inventory.addRenderNode(replacement, 129);
+  replacementRender.links.push_back(selector);
+  fixture.add(replacement);
+  fixture.inventory.renumber(ignored, 7);
+  fixture.add(ignored);
+  CHECK_EQ(fixture.inventory.openedPci, (std::vector<std::string>{"0000:00:02.0", "0000:03:00.0"}));
+}
+
+UMBRIEL_TEST(unresolvedRenderSelectorFailsBeforeOpeningAnyGpu) {
+  Fixture fixture;
+  fixture.inventory.addGpu(0, "0000:00:02.0");
+  // The card is visible before its render-node link. Accepting the unresolved
+  // selector here would open the GPU that the user intended to exclude.
+  fixture.inventory.addGpu(5, "0000:01:00.0");
+  auto manager = umbriel::BackendManager::create(
+      fixture.display, {.ignoredDevices = {"/dev/dri/by-path/pci-0000:01:00.0-render"}, .ignoredPciAddresses = {}}
+  );
+  CHECK(manager == nullptr);
+  CHECK(fixture.inventory.openedPci.empty());
+}
+
+UMBRIEL_TEST(allExcludedAndInvalidSelectorsFailWithoutOpeningAnyGpu) {
+  Fixture fixture;
+  auto& gpu = fixture.inventory.addGpu(0, "0000:00:02.0");
+  CHECK(
+      umbriel::BackendManager::create(fixture.display, {.ignoredDevices = {gpu.node}, .ignoredPciAddresses = {}})
+      == nullptr
+  );
+  CHECK(
+      umbriel::BackendManager::create(fixture.display, {.ignoredDevices = {"/dev/null"}, .ignoredPciAddresses = {}})
+      == nullptr
+  );
+  CHECK(fixture.inventory.openedPci.empty());
+}
+
+UMBRIEL_TEST(descriptorAuditRejectsExcludedGpuWhenUdevMetadataDisappears) {
+  for (const bool usePciSelector : {false, true}) {
+    Fixture fixture;
+    auto& allowed = fixture.inventory.addGpu(0, "0000:00:02.0");
+    auto& ignored = fixture.inventory.addGpu(1, "0000:01:00.0");
+    auto& render = fixture.inventory.addRenderNode(ignored, 129);
+    fixture.start(
+        usePciSelector ? umbriel::Config::Drm{.ignoredDevices = {}, .ignoredPciAddresses = {"0000:01:00.0"}}
+                       : umbriel::Config::Drm{.ignoredDevices = {ignored.node}, .ignoredPciAddresses = {}}
+    );
+
+    CHECK(fixture.verifyOpenDevice(allowed.device));
+    CHECK(!fixture.verifyOpenDevice(ignored.device));
+    CHECK(!fixture.verifyOpenDevice(render.device));
+    render.present = false;
+    CHECK(!fixture.verifyOpenDevice(render.device));
+    ignored.present = false;
+    CHECK(!fixture.verifyOpenDevice(ignored.device));
+
+    allowed.parent->subsystem = "platform";
+    CHECK(fixture.verifyOpenDevice(allowed.device));
+    allowed.parent = nullptr;
+    CHECK(!fixture.verifyOpenDevice(allowed.device));
+    CHECK(fixture.verifyOpenDevice(makedev(1, 3)));
+  }
+}
+
+UMBRIEL_TEST(automaticAndHeadlessPathsKeepWlrootsDiscovery) {
+  Fixture fixture;
+  fixture.start({});
+  CHECK_EQ(fixture.inventory.automaticCalls, 1);
+  fixture.manager.reset();
+  setenv("WLR_BACKENDS", "headless", 1);
+  fixture.start({.ignoredDevices = {"/dev/dri/missing-render-node"}, .ignoredPciAddresses = {"0000:01:00.0"}});
+  CHECK_EQ(fixture.inventory.automaticCalls, 2);
+  CHECK(fixture.inventory.openedPci.empty());
+}
+
+UMBRIEL_TEST(descriptorAuditRejectsUnreadableDescriptorsButAllowsClosedOnes) {
+  Fixture fixture;
+  fixture.inventory.addGpu(0, "0000:00:02.0");
+  auto& ignored = fixture.inventory.addGpu(1, "0000:01:00.0");
+  fixture.start({.ignoredDevices = {}, .ignoredPciAddresses = {"0000:01:00.0"}});
+  fixture.inventory.auditError = EACCES;
+  CHECK(!fixture.verifyOpenDevice(ignored.device));
+  fixture.inventory.auditError = ENOENT;
+  CHECK(fixture.verifyOpenDevice(ignored.device));
+}
+
+int main() { return RUN_TESTS(); }

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -28,6 +28,7 @@ UMBRIEL_TEST(aFirstLoadReportsEverything) {
   CHECK(change.appearance);
   CHECK(change.animation);
   CHECK(change.colors);
+  CHECK(change.drm);
   CHECK(change.events);
   CHECK(change.input);
   CHECK(change.outputs);
@@ -35,6 +36,15 @@ UMBRIEL_TEST(aFirstLoadReportsEverything) {
 
 UMBRIEL_TEST(eachSectionIsReportedOnItsOwn) {
   const Config before;
+
+  {
+    Config after;
+    after.drm.ignoredPciAddresses.emplace_back("0000:01:00.0");
+    const ConfigChange change = ConfigChange::between(before, after);
+    CHECK(change.drm);
+    CHECK(!ConfigEffects::between(before, after).any());
+    CHECK_EQ(change.summary(), std::string("drm"));
+  }
 
   {
     Config after;

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -122,14 +122,14 @@ UMBRIEL_TEST(defaultConfigLookupPrefersUserThenSystem) {
   const ScopedEnvironment configDirs("XDG_CONFIG_DIRS", systemDir.string());
 
   ConfigStore& store = umbriel::configStore();
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
 
   CHECK_EQ(store.rootPath(), systemConfig);
   CHECK_EQ(store.config().layout.gap, 17);
   CHECK(!store.fileMissing());
 
   tree.write("user/umbriel/config.toml", "[layout]\ngap = 19\n");
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
 
   CHECK_EQ(store.rootPath(), userConfig);
   CHECK_EQ(store.config().layout.gap, 19);
@@ -147,7 +147,7 @@ UMBRIEL_TEST(implicitConfigReloadAdoptsAndReleasesHigherPriorityUserPath) {
   const ScopedEnvironment configDirs("XDG_CONFIG_DIRS", systemDir.string());
 
   ConfigStore& store = umbriel::configStore();
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
 
   CHECK_EQ(store.rootPath(), systemConfig);
   CHECK_EQ(store.config().layout.gap, 17);
@@ -178,7 +178,7 @@ UMBRIEL_TEST(malformedNewUserConfigKeepsActiveSystemConfigAndRetriesAfterCorrect
   const ScopedEnvironment configDirs("XDG_CONFIG_DIRS", systemDir.string());
 
   ConfigStore& store = umbriel::configStore();
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
   const uint64_t generation = store.generation();
 
   tree.write("user/umbriel/config.toml", "[layout\n");
@@ -212,7 +212,7 @@ UMBRIEL_TEST(implicitConfigReloadKeepsCandidatesCapturedAtInitialLoad) {
   const ScopedEnvironment configDirs("XDG_CONFIG_DIRS", systemDir.string());
 
   ConfigStore& store = umbriel::configStore();
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
   const std::vector<std::filesystem::path> initialWatchPaths = store.watchPaths();
 
   tree.write("changed-user/umbriel/config.toml", "[layout]\ngap = 29\n");
@@ -238,7 +238,7 @@ UMBRIEL_TEST(explicitConfigReloadStaysPinnedWhenUserConfigAppears) {
 
   ConfigStore& store = umbriel::configStore();
   const std::string explicitPath = explicitConfig.string();
-  store.load(explicitPath.c_str());
+  CHECK(store.load(explicitPath.c_str()));
 
   CHECK_EQ(store.rootPath(), explicitConfig);
   CHECK_EQ(store.config().layout.gap, 23);
@@ -1274,7 +1274,7 @@ UMBRIEL_TEST(missingIncludesRemainPendingUntilTheyLoad) {
   CHECK_EQ(store.config().colors.accentPrimary[0], 18.0F / 255.0F);
 }
 
-UMBRIEL_TEST(unknownIncludeKeysAreReported) {
+UMBRIEL_TEST(unknownIncludeKeysRejectReload) {
   // The merge erases `include` before the config readers run, so the merge is the only place that can report a typo in
   // this section. Every file's own `include` table is checked, not just the root's.
   const TempConfig file;
@@ -1283,9 +1283,13 @@ UMBRIEL_TEST(unknownIncludeKeysAreReported) {
 
   ConfigStore& store = umbriel::configStore();
   store.setRootPath(file.path(), true);
+  const umbriel::Config previous = store.config();
+  const uint64_t generation = store.generation();
   const umbriel::ConfigReloadResult loaded = store.reload();
 
-  CHECK(loaded.success);
+  CHECK(!loaded.success);
+  CHECK(store.config() == previous);
+  CHECK_EQ(store.generation(), generation);
   CHECK(containsDiagnostic(store, "unknown key include.dirs"));
   CHECK(containsDiagnostic(store, "unknown key include.paths"));
   CHECK(!containsDiagnostic(store, "unknown key include.files"));
@@ -1884,6 +1888,8 @@ _PRIVATE = "kept"
 "HAS-HYPHEN" = "ignored"
 NOT_A_STRING = 1
 WAYLAND_DISPLAY = "wrong"
+WLR_DRM_DEVICES = "/dev/dri/card0"
+WLR_RENDER_DRM_DEVICE = "/dev/dri/renderD128"
 )");
 
   ConfigStore& store = umbriel::configStore();
@@ -1891,7 +1897,7 @@ WAYLAND_DISPLAY = "wrong"
   const umbriel::ConfigReloadResult result = store.reload();
 
   CHECK(result.success);
-  CHECK_EQ(store.config().environment.variables.size(), size_t{2});
+  CHECK_EQ(store.config().environment.variables.size(), size_t{4});
   CHECK(
       std::ranges::find(store.config().environment.variables, std::pair{std::string{"DXVK_HDR"}, std::string{"1"}})
       != store.config().environment.variables.end()
@@ -1900,12 +1906,328 @@ WAYLAND_DISPLAY = "wrong"
       std::ranges::find(store.config().environment.variables, std::pair{std::string{"_PRIVATE"}, std::string{"kept"}})
       != store.config().environment.variables.end()
   );
+  CHECK(
+      std::ranges::find(
+          store.config().environment.variables, std::pair{std::string{"WLR_DRM_DEVICES"}, std::string{"/dev/dri/card0"}}
+      )
+      != store.config().environment.variables.end()
+  );
+  CHECK(
+      std::ranges::find(
+          store.config().environment.variables,
+          std::pair{std::string{"WLR_RENDER_DRM_DEVICE"}, std::string{"/dev/dri/renderD128"}}
+      )
+      != store.config().environment.variables.end()
+  );
   CHECK(containsDiagnostic(store, R"(ignoring environment key "9INVALID" (expected [A-Za-z_][A-Za-z0-9_]*))"));
   CHECK(containsDiagnostic(store, R"(ignoring environment key "HAS-HYPHEN" (expected [A-Za-z_][A-Za-z0-9_]*))"));
   CHECK(containsDiagnostic(store, "ignoring environment.NOT_A_STRING (expected string)"));
   CHECK(containsDiagnostic(store, "ignoring environment.WAYLAND_DISPLAY (reserved by Umbriel)"));
   CHECK(!containsDiagnostic(store, "unknown key environment.DXVK_HDR"));
   CHECK(!containsDiagnostic(store, "unknown key environment._PRIVATE"));
+}
+
+UMBRIEL_TEST(drmConfigurationLoadsAndNormalizesSelectors) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+ignored_devices = [
+  "/dev/dri/by-path/pci-0000:01:00.0-card",
+  "/dev/dri/by-path/pci-0000:01:00.0-card",
+]
+ignored_pci_addresses = ["0000:01:00.0", "0000:01:00.0"]
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+  const umbriel::ConfigReloadResult result = store.reload();
+
+  CHECK(result.success);
+  CHECK(store.config().drm.configured());
+  CHECK_EQ(store.config().drm.ignoredDevices.size(), size_t{1});
+  CHECK_EQ(store.config().drm.ignoredPciAddresses, std::vector<std::string>{"0000:01:00.0"});
+  CHECK(containsDiagnostic(store, "ignoring duplicate drm.ignored_devices"));
+  CHECK(containsDiagnostic(store, "ignoring duplicate drm.ignored_pci_addresses"));
+
+  file.write(R"(
+[drm]
+ignored_pci_addresses = ["0000:AB:0C.7"]
+)");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().drm.ignoredPciAddresses, std::vector<std::string>{"0000:ab:0c.7"});
+}
+
+UMBRIEL_TEST(emptyDrmTableKeepsTheCompatibilityPath) {
+  const TempConfig file;
+  file.write("[drm]\n");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  CHECK(store.reload().success);
+  CHECK(!store.config().drm.configured());
+}
+
+UMBRIEL_TEST(drmPathsPreserveSymlinkSensitiveComponents) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+ignored_devices = ["/dev/dri/excluded/../card0"]
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().drm.ignoredDevices, std::vector<std::string>{"/dev/dri/excluded/../card0"});
+}
+
+UMBRIEL_TEST(drmConfigurationRejectsUnsafeSelectors) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+ignored_pci_addresses = ["0000:01:00.0"]
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+  CHECK(store.reload().success);
+  const umbriel::Config previous = store.config();
+
+  file.write(R"(
+[drm]
+ignored_devices = [1, "relative-card"]
+ignored_pci_addresses = ["01:00.0", "0000:01:00.8", "0000:01:20.0"]
+render_device = "/dev/dri/renderD128"
+surprise = true
+)");
+
+  const umbriel::ConfigReloadResult result = store.reload();
+
+  CHECK(!result.success);
+  CHECK(store.config() == previous);
+  CHECK(containsDiagnostic(store, "drm.ignored_devices must be a string"));
+  CHECK(containsDiagnostic(store, "drm.ignored_devices must be an absolute path"));
+  CHECK(containsDiagnostic(store, "invalid drm.ignored_pci_addresses entry"));
+  CHECK(containsDiagnostic(store, "unknown key drm.render_device"));
+  CHECK(containsDiagnostic(store, "unknown key drm.surprise"));
+}
+
+UMBRIEL_TEST(initialConfigErrorsDoNotCommitDefaults) {
+  const TempConfig file;
+  file.write("[drm]\nignored_pci_addresses = [\"invalid\"]\n");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+  const umbriel::Config previous = store.config();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(store.config() == previous);
+  CHECK(containsDiagnostic(store, "invalid drm.ignored_pci_addresses entry"));
+}
+
+UMBRIEL_TEST(initialNonDrmErrorsKeepCompatibilityDefaults) {
+  const TempConfig file;
+  file.write("workspace = \"invalid\"\n");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation + 1);
+  CHECK(!store.config().drm.configured());
+  CHECK(containsDiagnostic(store, "workspace must be a [[workspace]] array of tables"));
+}
+
+UMBRIEL_TEST(initialSyntaxErrorsFailClosedEvenWithoutRecognizableDrmPolicy) {
+  const TempConfig file;
+  file.write("workspace =\n");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+}
+
+UMBRIEL_TEST(initialErrorsCannotDiscardRequestedDrmPolicy) {
+  const TempConfig file;
+  file.write(R"(
+workspace = "invalid"
+
+[drm]
+ignored_pci_addresses = ["0000:01:00.0"]
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "workspace must be a [[workspace]] array of tables"));
+}
+
+UMBRIEL_TEST(initialSyntaxErrorsCannotDiscardRequestedDrmPolicy) {
+  const TempConfig file;
+  file.write(R"(
+[drm]
+ignored_devices = ["/dev/dri/card0"
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "Error while parsing array"));
+}
+
+UMBRIEL_TEST(initialIncludedSyntaxErrorsCannotDiscardRequestedDrmPolicy) {
+  const TempConfig file;
+  file.write("[include]\nfiles = [\"" + file.includeName() + "\"]\n");
+  file.writeInclude(R"(
+[drm]
+ignored_pci_addresses = ["0000:01:00.0"
+)");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "Error while parsing array"));
+}
+
+UMBRIEL_TEST(invalidIncludeDirectivesCannotDiscardDrmPolicy) {
+  const TempConfigTree tree;
+  const std::filesystem::path root = tree.path("config.toml");
+  tree.write("hardware.toml", "[drm]\nignored_pci_addresses = [\"0000:01:00.0\"]\n");
+  tree.write("config.toml", "[include]\nfiles = [\"hardware.toml\"]\n");
+
+  ConfigStore& store = umbriel::configStore();
+  CHECK(store.load(root.c_str()));
+  const umbriel::Config previous = store.config();
+  const uint64_t generation = store.generation();
+
+  constexpr std::array invalidIncludes{
+      "include = [\"hardware.toml\"]\n",
+      "[include]\nfiles = \"hardware.toml\"\n",
+      "[include]\nfiles = [\"hardware.toml\", 42]\n",
+      "[include]\nfile = [\"hardware.toml\"]\n",
+      "[include]\nfiles = [\"hardware.toml\\u0000missing\"]\n",
+  };
+  for (const char* include : invalidIncludes) {
+    tree.write("config.toml", include);
+
+    CHECK(!store.load(root.c_str()));
+    CHECK_EQ(store.generation(), generation);
+    CHECK(store.config() == previous);
+    CHECK(std::ranges::any_of(store.diagnostics(), [](const ConfigDiagnostic& diagnostic) {
+      return diagnostic.severity == ConfigDiagnostic::Severity::Error;
+    }));
+    CHECK(!store.reload().success);
+    CHECK_EQ(store.generation(), generation);
+    CHECK(store.config() == previous);
+  }
+}
+
+UMBRIEL_TEST(initialUnreadableConfigCannotSilentlyDiscardDrmPolicy) {
+  const TempConfig file;
+  file.write("[drm]\nignored_devices = [\"/dev/dri/card0\"]\n");
+  std::filesystem::permissions(file.path(), std::filesystem::perms::none);
+  CHECK(access(file.path().c_str(), R_OK) != 0);
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "File could not be opened for reading"));
+}
+
+UMBRIEL_TEST(initialInaccessibleConfigCannotSilentlyDiscardDrmPolicy) {
+  const TempConfigTree tree;
+  tree.write("restricted/config.toml", "[drm]\nignored_devices = [\"/dev/dri/card0\"]\n");
+  const std::filesystem::path restricted = tree.path("restricted");
+  const std::filesystem::path configPath = restricted / "config.toml";
+  std::filesystem::permissions(restricted, std::filesystem::perms::none);
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+  const bool loaded = store.load(configPath.c_str());
+  std::filesystem::permissions(restricted, std::filesystem::perms::owner_all);
+
+  CHECK(!loaded);
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "cannot inspect config file"));
+}
+
+UMBRIEL_TEST(defaultConfigLookupDoesNotSkipInaccessibleUserPolicy) {
+  const TempConfigTree tree;
+  const std::filesystem::path userHome = tree.path("user");
+  const std::filesystem::path userConfig = userHome / "umbriel/config.toml";
+  const std::filesystem::path systemDir = tree.path("system");
+  tree.write("user/umbriel/config.toml", "[drm]\nignored_devices = [\"/dev/dri/card0\"]\n");
+  tree.write("system/umbriel/config.toml", "[layout]\ngap = 17\n");
+  const ScopedEnvironment configHome("XDG_CONFIG_HOME", userHome.string());
+  const ScopedEnvironment configDirs("XDG_CONFIG_DIRS", systemDir.string());
+  std::filesystem::permissions(userConfig.parent_path(), std::filesystem::perms::none);
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+  const bool loaded = store.load(nullptr);
+  std::filesystem::permissions(userConfig.parent_path(), std::filesystem::perms::owner_all);
+
+  CHECK(!loaded);
+  CHECK_EQ(store.rootPath(), userConfig);
+  CHECK_EQ(store.generation(), generation);
+  CHECK(containsDiagnostic(store, "cannot inspect config file"));
+}
+
+UMBRIEL_TEST(missingPolicyIncludeRequiresRootDrmIntentMarker) {
+  const TempConfig file;
+  file.write("[include]\nfiles = [\"" + file.includeName() + "\"]\n\n[drm]\n");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(store.missingIncludes());
+  CHECK(containsDiagnostic(store, "cannot safely load DRM policy while an include is missing"));
+}
+
+UMBRIEL_TEST(inaccessibleIncludeCannotBeTreatedAsMissing) {
+  const TempConfigTree tree;
+  tree.write("config.toml", "[include]\nfiles = [\"restricted/hardware.toml\"]\n");
+  tree.write("restricted/hardware.toml", "[drm]\nignored_devices = [\"/dev/dri/card0\"]\n");
+  const std::filesystem::path restricted = tree.path("restricted");
+  std::filesystem::permissions(restricted, std::filesystem::perms::none);
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+  const bool loaded = store.load(tree.path("config.toml").c_str());
+  std::filesystem::permissions(restricted, std::filesystem::perms::owner_all);
+
+  CHECK(!loaded);
+  CHECK_EQ(store.generation(), generation);
+  CHECK(!store.missingIncludes());
+  CHECK(containsDiagnostic(store, "cannot inspect included config file"));
+}
+
+UMBRIEL_TEST(initialMissingExplicitConfigFailsWithoutCommittingDefaults) {
+  const TempConfig file;
+  std::filesystem::remove(file.path());
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+  const umbriel::Config previous = store.config();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(store.config() == previous);
+  CHECK(containsDiagnostic(store, "config file not found"));
 }
 
 UMBRIEL_TEST(eventsLoadCanonicalLidCommands) {
@@ -1927,18 +2249,8 @@ lid_open = "notify-send awake"
 }
 
 UMBRIEL_TEST(packagedAnimationDefaultsMatchCompiledDefaults) {
-  std::filesystem::path root = std::filesystem::current_path();
-  while (!std::filesystem::exists(root / "examples/config.toml")) {
-    const std::filesystem::path parent = root.parent_path();
-    if (parent == root) {
-      CHECK(false);
-      return;
-    }
-    root = parent;
-  }
-
   ConfigStore& store = umbriel::configStore();
-  store.setRootPath(root / "examples/config.toml", true);
+  store.setRootPath(UMBRIEL_EXAMPLE_CONFIG, true);
   const umbriel::ConfigReloadResult result = store.reload();
 
   CHECK(result.success);

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -2198,6 +2198,19 @@ UMBRIEL_TEST(missingPolicyIncludeRequiresRootDrmIntentMarker) {
   CHECK(containsDiagnostic(store, "cannot safely load DRM policy while an include is missing"));
 }
 
+UMBRIEL_TEST(missingOptionalPolicyIncludeRequiresRootDrmIntentMarker) {
+  const TempConfig file;
+  file.write("[include.optional]\nfiles = [\"" + file.includeName() + "\"]\n\n[drm]\n");
+
+  ConfigStore& store = umbriel::configStore();
+  const uint64_t generation = store.generation();
+
+  CHECK(!store.load(file.path().c_str()));
+  CHECK_EQ(store.generation(), generation);
+  CHECK(!store.missingIncludes());
+  CHECK(containsDiagnostic(store, "cannot safely load DRM policy while an include is missing"));
+}
+
 UMBRIEL_TEST(inaccessibleIncludeCannotBeTreatedAsMissing) {
   const TempConfigTree tree;
   tree.write("config.toml", "[include]\nfiles = [\"restricted/hardware.toml\"]\n");

--- a/tests/unit/config_watcher.cpp
+++ b/tests/unit/config_watcher.cpp
@@ -143,7 +143,7 @@ UMBRIEL_TEST(anIncludedFileReloadsThroughASymlinkedConfigDirectory) {
   const SymlinkedConfigTree tree;
   const std::string root = tree.root().string();
   ConfigStore& store = umbriel::configStore();
-  store.load(root.c_str());
+  CHECK(store.load(root.c_str()));
 
   CHECK_EQ(store.config().layout.gap, 5);
   CHECK_EQ(store.config().appearance.borderWidth, 2);
@@ -181,7 +181,7 @@ UMBRIEL_TEST(aRetargetedSymlinkedConfigDirectoryReloadsFromTheNewTarget) {
   const SymlinkedConfigTree tree;
   const std::string root = tree.root().string();
   ConfigStore& store = umbriel::configStore();
-  store.load(root.c_str());
+  CHECK(store.load(root.c_str()));
 
   CHECK_EQ(store.config().layout.gap, 5);
 
@@ -219,7 +219,7 @@ UMBRIEL_TEST(aNewHigherPriorityUserConfigIsAdoptedWithoutRestart) {
   const ScopedEnvironment configDirs("XDG_CONFIG_DIRS", tree.systemDir().string());
 
   ConfigStore& store = umbriel::configStore();
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
 
   CHECK_EQ(store.rootPath(), tree.systemConfig());
   CHECK_EQ(store.config().layout.gap, 17);
@@ -255,7 +255,7 @@ UMBRIEL_TEST(aDeletedSymlinkTargetIsRewatchedWhenItReappears) {
   const ScopedEnvironment configDirs("XDG_CONFIG_DIRS", tree.systemDir().string());
 
   ConfigStore& store = umbriel::configStore();
-  store.load(nullptr);
+  CHECK(store.load(nullptr));
 
   CHECK_EQ(store.rootPath(), tree.userConfig());
   CHECK_EQ(store.config().layout.gap, 19);

--- a/tests/unit/drm_policy.cpp
+++ b/tests/unit/drm_policy.cpp
@@ -1,0 +1,144 @@
+#include "server/drm_policy.h"
+
+#include "check.h"
+
+#include <sys/sysmacros.h>
+#include <vector>
+
+using umbriel::DrmDeviceIdentity;
+using umbriel::DrmExclusionMatch;
+using umbriel::drmExclusionMatch;
+using umbriel::isNvidiaGpuDeviceNode;
+using umbriel::parseNvidiaDeviceMinor;
+using umbriel::resolveDrmBackendEnvironment;
+using umbriel::sameDrmPhysicalDevice;
+
+namespace {
+  const DrmDeviceIdentity kIntegrated{
+      .node = "/dev/dri/card0",
+      .device = makedev(226, 0),
+      .physicalDevice = "/sys/devices/pci0000:00/0000:00:02.0",
+      .pciAddress = "0000:00:02.0",
+  };
+  const DrmDeviceIdentity kDiscrete{
+      .node = "/dev/dri/card1",
+      .device = makedev(226, 1),
+      .physicalDevice = "/sys/devices/pci0000:00/0000:01:00.0",
+      .pciAddress = "0000:01:00.0",
+  };
+} // namespace
+
+UMBRIEL_TEST(renderNodeIdentityExcludesTheWholePhysicalGpu) {
+  const std::vector<DrmDeviceIdentity> ignored{{
+      .node = "/dev/dri/renderD129",
+      .device = makedev(226, 129),
+      .physicalDevice = kDiscrete.physicalDevice,
+      .pciAddress = kDiscrete.pciAddress,
+  }};
+
+  CHECK(drmExclusionMatch(kDiscrete, ignored, {}) == DrmExclusionMatch::PciAddress);
+  CHECK(drmExclusionMatch(kIntegrated, ignored, {}) == DrmExclusionMatch::None);
+}
+
+UMBRIEL_TEST(cardAndRenderNodesCompareAsOnePhysicalGpu) {
+  DrmDeviceIdentity renderNode = kDiscrete;
+  renderNode.node = "/dev/dri/renderD129";
+  renderNode.device = makedev(226, 129);
+
+  CHECK(sameDrmPhysicalDevice(kDiscrete, renderNode));
+
+  renderNode.pciAddress = "0000:02:00.0";
+  CHECK(!sameDrmPhysicalDevice(kDiscrete, renderNode));
+
+  DrmDeviceIdentity platformDevice = kDiscrete;
+  platformDevice.pciAddress.reset();
+  renderNode = platformDevice;
+  renderNode.node = "/dev/dri/renderD129";
+  renderNode.device = makedev(226, 129);
+  CHECK(sameDrmPhysicalDevice(platformDevice, renderNode));
+  CHECK(drmExclusionMatch(renderNode, std::span{&platformDevice, size_t{1}}, {}) == DrmExclusionMatch::PhysicalDevice);
+}
+
+UMBRIEL_TEST(resolvedIdentityDoesNotFollowAReusedDeviceNode) {
+  const std::vector<DrmDeviceIdentity> ignored{kDiscrete};
+  DrmDeviceIdentity replacement = kIntegrated;
+  replacement.node = kDiscrete.node;
+  replacement.device = kDiscrete.device;
+
+  CHECK(drmExclusionMatch(replacement, ignored, {}) == DrmExclusionMatch::None);
+}
+
+UMBRIEL_TEST(resolvedIdentitySurvivesNodeRenumbering) {
+  const std::vector<DrmDeviceIdentity> ignored{kDiscrete};
+  DrmDeviceIdentity reattached = kDiscrete;
+  reattached.node = "/dev/dri/card7";
+  reattached.device = makedev(226, 7);
+  CHECK(drmExclusionMatch(reattached, ignored, {}) == DrmExclusionMatch::PciAddress);
+}
+
+UMBRIEL_TEST(pciAddressKeepsAReattachedGpuExcluded) {
+  const std::vector<std::string> pciAddresses{"0000:01:00.0"};
+  DrmDeviceIdentity reenumerated = kDiscrete;
+  reenumerated.node = "/dev/dri/card7";
+  reenumerated.device = makedev(226, 7);
+
+  CHECK(drmExclusionMatch(reenumerated, {}, pciAddresses) == DrmExclusionMatch::PciAddress);
+}
+
+UMBRIEL_TEST(backendEnvironmentMatchesWlrootsPrecedence) {
+  CHECK_EQ(
+      resolveDrmBackendEnvironment(std::nullopt, false, false, false),
+      (umbriel::DrmBackendEnvironment{
+          .native = true,
+          .exclusionsSupported = true,
+          .createLibinput = true,
+          .libinputBeforeDrm = true,
+          .allowMissingLibinput = true,
+      })
+  );
+  CHECK(!resolveDrmBackendEnvironment(std::nullopt, true, false, false).native);
+  CHECK(!resolveDrmBackendEnvironment(std::nullopt, false, true, false).native);
+  CHECK(!resolveDrmBackendEnvironment(std::nullopt, false, false, true).native);
+  CHECK(!resolveDrmBackendEnvironment(std::string_view{}, false, false, false).native);
+}
+
+UMBRIEL_TEST(filteredBackendSupportsOnlyOneDrmAndOptionalLibinput) {
+  const auto drmOnly = resolveDrmBackendEnvironment("drm", true, true, true);
+  CHECK(drmOnly.native);
+  CHECK(drmOnly.exclusionsSupported);
+  CHECK(!drmOnly.createLibinput);
+
+  const auto native = resolveDrmBackendEnvironment(",drm,,libinput,", true, false, false);
+  CHECK(native.native);
+  CHECK(native.exclusionsSupported);
+  CHECK(native.createLibinput);
+  CHECK(!native.libinputBeforeDrm);
+
+  const auto inputFirst = resolveDrmBackendEnvironment("libinput,drm", false, false, false);
+  CHECK(inputFirst.exclusionsSupported);
+  CHECK(inputFirst.libinputBeforeDrm);
+
+  CHECK(!resolveDrmBackendEnvironment("drm,headless", false, false, false).exclusionsSupported);
+  CHECK(!resolveDrmBackendEnvironment("drm,drm", false, false, false).exclusionsSupported);
+  CHECK(!resolveDrmBackendEnvironment("drm, libinput", false, false, false).exclusionsSupported);
+}
+
+UMBRIEL_TEST(nvidiaDeviceMinorParsesDriverLine) {
+  CHECK_EQ(parseNvidiaDeviceMinor("Device Minor: \t 0"), std::optional<unsigned int>{0});
+  CHECK_EQ(parseNvidiaDeviceMinor("  Device Minor: 17\r"), std::optional<unsigned int>{17});
+  CHECK(!parseNvidiaDeviceMinor("Device Minor: none"));
+  CHECK(!parseNvidiaDeviceMinor("Device Minor: 3 trailing"));
+  CHECK(!parseNvidiaDeviceMinor("Model: no minor"));
+}
+
+UMBRIEL_TEST(nvidiaGpuDeviceNodeExcludesOnlyPerGpuNodes) {
+  CHECK(isNvidiaGpuDeviceNode("/dev/nvidia0"));
+  CHECK(isNvidiaGpuDeviceNode("/dev/nvidia17"));
+  CHECK(isNvidiaGpuDeviceNode("/dev/nvidia17 (deleted)"));
+  CHECK(!isNvidiaGpuDeviceNode("/dev/nvidia"));
+  CHECK(!isNvidiaGpuDeviceNode("/dev/nvidiactl"));
+  CHECK(!isNvidiaGpuDeviceNode("/dev/nvidia-modeset"));
+  CHECK(!isNvidiaGpuDeviceNode("/dev/nvidia0-extra"));
+}
+
+int main() { return RUN_TESTS(); }

--- a/umbrielfx/include/umbrielfx/render/fx_renderer/fx_renderer.h
+++ b/umbrielfx/include/umbrielfx/render/fx_renderer/fx_renderer.h
@@ -12,6 +12,8 @@ struct fx_renderer;
 struct wlr_output;
 
 struct wlr_renderer *fx_renderer_create_with_drm_fd(int drm_fd);
+/* Creates through GBM without enumerating EGL devices. */
+struct wlr_renderer *fx_renderer_create_with_drm_fd_gbm(int drm_fd);
 struct wlr_renderer *fx_renderer_create(struct wlr_backend *backend);
 
 struct fx_renderer *fx_get_renderer(struct wlr_renderer *wlr_renderer);

--- a/umbrielfx/internal/render/egl.h
+++ b/umbrielfx/internal/render/egl.h
@@ -3,6 +3,11 @@
 
 #include <wlr/render/egl.h>
 
+enum wlr_egl_drm_fd_strategy {
+	WLR_EGL_DRM_FD_EGL_DEVICE_FIRST,
+	WLR_EGL_DRM_FD_GBM_EXACT,
+};
+
 struct wlr_egl {
 	EGLDisplay display;
 	EGLContext context;
@@ -47,6 +52,9 @@ struct wlr_egl {
 	bool has_modifiers;
 	struct wlr_drm_format_set dmabuf_texture_formats;
 	struct wlr_drm_format_set dmabuf_render_formats;
+
+	// Keep additions after the fields read by wlroots' GLES2 renderer.
+	enum wlr_egl_drm_fd_strategy drm_fd_strategy;
 };
 
 struct wlr_egl_context {
@@ -62,6 +70,12 @@ struct wlr_egl_context {
  * Will attempt to load all possibly required API functions.
  */
 struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd);
+
+/**
+ * Initializes an EGL context for the given DRM FD through GBM without
+ * enumerating EGL devices.
+ */
+struct wlr_egl *wlr_egl_create_with_drm_fd_gbm(int drm_fd);
 
 /**
  * Frees all related EGL resources, makes the context not-current and

--- a/umbrielfx/meson.build
+++ b/umbrielfx/meson.build
@@ -232,6 +232,34 @@ if build_tests
     suite: 'umbrielfx',
   )
 
+  umbrielfx_renderer_test = executable(
+    'umbrielfx-renderer-test',
+    'tests/renderer.c',
+    c_args: umbrielfx_c_args,
+    dependencies: umbrielfx_deps,
+    include_directories: [umbrielfx_inc, umbrielfx_internal_inc],
+    link_with: umbrielfx_lib,
+    build_by_default: false,
+  )
+
+  test(
+    'umbrielfx-renderer-gbm-device',
+    umbrielfx_renderer_test,
+    suite: 'umbrielfx',
+  )
+
+  if cc.get_define('WLR_HAS_GLES2_RENDERER', prefix: '#include <wlr/config.h>', dependencies: wlroots_dep) == '1'
+    umbrielfx_egl_abi_test = executable(
+      'umbrielfx-egl-abi-test',
+      'tests/egl_abi.c',
+      c_args: umbrielfx_c_args,
+      dependencies: umbrielfx_deps,
+      include_directories: umbrielfx_internal_inc,
+      export_dynamic: true,
+      build_by_default: false,
+    )
+    test('umbrielfx-egl-abi', umbrielfx_egl_abi_test, suite: 'umbrielfx')
+  endif
   # The compositor calls scene helpers umbrielfx does not reimplement, so they
   # resolve to libwlroots and read umbrielfx's structs at wlroots' field offsets.
   # One source, built against each header, proves the offsets still agree.

--- a/umbrielfx/render/egl.c
+++ b/umbrielfx/render/egl.c
@@ -214,6 +214,7 @@ static struct wlr_egl *egl_create(void) {
 		wlr_log_errno(WLR_ERROR, "Allocation failed");
 		return NULL;
 	}
+	egl->drm_fd_strategy = WLR_EGL_DRM_FD_EGL_DEVICE_FIRST;
 
 	load_egl_proc(&egl->procs.eglGetPlatformDisplayEXT,
 		"eglGetPlatformDisplayEXT");
@@ -383,6 +384,9 @@ static bool egl_init_display(struct wlr_egl *egl, EGLDisplay display,
 
 static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 		void *remote_display, bool allow_software) {
+	// A GBM display is private to this wlr_egl because umbrielfx created the GBM
+	// device. It can always be terminated, even without reference tracking.
+	bool owns_display = platform == EGL_PLATFORM_GBM_KHR;
 	EGLint display_attribs[3] = {0};
 	size_t display_attribs_len = 0;
 
@@ -402,7 +406,7 @@ static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 	}
 
 	if (!egl_init_display(egl, display, allow_software)) {
-		if (egl->exts.KHR_display_reference) {
+		if (owns_display || egl->exts.KHR_display_reference) {
 			eglTerminate(display);
 		}
 		return false;
@@ -439,6 +443,11 @@ static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 		wlr_log(WLR_DEBUG, "Created EGL context using OpenGL ES 2.0");
 	} else {
 		wlr_log(WLR_ERROR, "Failed to create EGL context using OpenGL ES 2.0");
+		wlr_drm_format_set_finish(&egl->dmabuf_render_formats);
+		wlr_drm_format_set_finish(&egl->dmabuf_texture_formats);
+		if (owns_display || egl->exts.KHR_display_reference) {
+			eglTerminate(display);
+		}
 		return false;
 	}
 
@@ -558,6 +567,38 @@ static int open_render_node(int drm_fd) {
 	return render_fd;
 }
 
+static bool egl_init_with_gbm(struct wlr_egl *egl, int drm_fd,
+		bool allow_software) {
+	if (!egl->exts.KHR_platform_gbm) {
+		wlr_log(WLR_DEBUG, "KHR_platform_gbm not supported");
+		return false;
+	}
+
+	int gbm_fd = open_render_node(drm_fd);
+	if (gbm_fd < 0) {
+		wlr_log(WLR_ERROR, "Failed to open DRM render node");
+		return false;
+	}
+
+	egl->gbm_device = gbm_create_device(gbm_fd);
+	if (!egl->gbm_device) {
+		close(gbm_fd);
+		wlr_log(WLR_ERROR, "Failed to create GBM device");
+		return false;
+	}
+
+	if (egl_init(egl, EGL_PLATFORM_GBM_KHR, egl->gbm_device,
+			allow_software)) {
+		wlr_log(WLR_DEBUG, "Using EGL_PLATFORM_GBM_KHR");
+		return true;
+	}
+
+	gbm_device_destroy(egl->gbm_device);
+	egl->gbm_device = NULL;
+	close(gbm_fd);
+	return false;
+}
+
 struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd) {
 	bool allow_software = drm_fd < 0;
 
@@ -585,33 +626,32 @@ struct wlr_egl *wlr_egl_create_with_drm_fd(int drm_fd) {
 		wlr_log(WLR_DEBUG, "EXT_platform_device not supported");
 	}
 
-	if (egl->exts.KHR_platform_gbm && drm_fd >= 0) {
-		int gbm_fd = open_render_node(drm_fd);
-		if (gbm_fd < 0) {
-			wlr_log(WLR_ERROR, "Failed to open DRM render node");
-			goto error;
-		}
-
-		egl->gbm_device = gbm_create_device(gbm_fd);
-		if (!egl->gbm_device) {
-			close(gbm_fd);
-			wlr_log(WLR_ERROR, "Failed to create GBM device");
-			goto error;
-		}
-
-		if (egl_init(egl, EGL_PLATFORM_GBM_KHR, egl->gbm_device, allow_software)) {
-			wlr_log(WLR_DEBUG, "Using EGL_PLATFORM_GBM_KHR");
-			return egl;
-		}
-
-		gbm_device_destroy(egl->gbm_device);
-		close(gbm_fd);
-	} else {
-		wlr_log(WLR_DEBUG, "KHR_platform_gbm not supported");
+	if (drm_fd >= 0 && egl_init_with_gbm(egl, drm_fd, allow_software)) {
+		return egl;
 	}
 
 error:
 	wlr_log(WLR_ERROR, "Failed to initialize EGL context");
+	free(egl);
+	eglReleaseThread();
+	return NULL;
+}
+
+struct wlr_egl *wlr_egl_create_with_drm_fd_gbm(int drm_fd) {
+	assert(drm_fd >= 0);
+
+	struct wlr_egl *egl = egl_create();
+	if (egl == NULL) {
+		wlr_log(WLR_ERROR, "Failed to create EGL context");
+		return NULL;
+	}
+	egl->drm_fd_strategy = WLR_EGL_DRM_FD_GBM_EXACT;
+
+	if (egl_init_with_gbm(egl, drm_fd, false)) {
+		return egl;
+	}
+
+	wlr_log(WLR_ERROR, "Failed to initialize EGL context through GBM");
 	free(egl);
 	eglReleaseThread();
 	return NULL;
@@ -659,7 +699,7 @@ void wlr_egl_destroy(struct wlr_egl *egl) {
 	eglMakeCurrent(egl->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 	eglDestroyContext(egl->display, egl->context);
 
-	if (egl->exts.KHR_display_reference) {
+	if (egl->gbm_device != NULL || egl->exts.KHR_display_reference) {
 		eglTerminate(egl->display);
 	}
 
@@ -1040,22 +1080,27 @@ static int dup_egl_device_drm_fd(struct wlr_egl *egl) {
 	return render_fd;
 }
 
-int wlr_egl_dup_drm_fd(struct wlr_egl *egl) {
-	int fd = dup_egl_device_drm_fd(egl);
-	if (fd >= 0) {
-		return fd;
-	}
-
-	// Fallback to GBM's FD if we can't use EGLDevice
+static int dup_gbm_drm_fd(struct wlr_egl *egl) {
 	if (egl->gbm_device == NULL) {
 		return -1;
 	}
 
-	fd = fcntl(gbm_device_get_fd(egl->gbm_device), F_DUPFD_CLOEXEC, 0);
+	int fd = fcntl(gbm_device_get_fd(egl->gbm_device), F_DUPFD_CLOEXEC, 0);
 	if (fd < 0) {
 		wlr_log_errno(WLR_ERROR, "Failed to dup GBM FD");
 	}
 	return fd;
+}
+
+int wlr_egl_dup_drm_fd(struct wlr_egl *egl) {
+	// GBM-exact renderers must keep the exact device they initialized.
+	// All other renderers retain wlroots' EGL-device-first compatibility path.
+	if (egl->drm_fd_strategy == WLR_EGL_DRM_FD_GBM_EXACT) {
+		return dup_gbm_drm_fd(egl);
+	}
+
+	int fd = dup_egl_device_drm_fd(egl);
+	return fd >= 0 ? fd : dup_gbm_drm_fd(egl);
 }
 
 EGLSyncKHR wlr_egl_create_sync(struct wlr_egl *egl, int fence_fd) {

--- a/umbrielfx/render/fx_renderer/fx_renderer.c
+++ b/umbrielfx/render/fx_renderer/fx_renderer.c
@@ -384,14 +384,20 @@ static void fx_log(GLenum src, GLenum type, GLuint id, GLenum severity,
 	_wlr_log(fx_log_importance_to_wlr(type), "[GLES2] %s", msg);
 }
 
-static struct wlr_renderer *renderer_autocreate(struct wlr_backend *backend, int drm_fd) {
+static struct wlr_renderer *renderer_autocreate(struct wlr_backend *backend,
+		int drm_fd, bool gbm_only) {
 	bool own_drm_fd = false;
 	if (!open_preferred_drm_fd(backend, &drm_fd, &own_drm_fd)) {
 		wlr_log(WLR_ERROR, "Cannot create GLES2 renderer: no DRM FD available");
 		return NULL;
 	}
 
-	struct wlr_egl *egl = wlr_egl_create_with_drm_fd(drm_fd);
+	struct wlr_egl *egl = gbm_only
+		? wlr_egl_create_with_drm_fd_gbm(drm_fd)
+		: wlr_egl_create_with_drm_fd(drm_fd);
+	if (own_drm_fd && drm_fd >= 0) {
+		close(drm_fd);
+	}
 	if (egl == NULL) {
 		wlr_log(WLR_ERROR, "Could not initialize EGL");
 		return NULL;
@@ -404,21 +410,23 @@ static struct wlr_renderer *renderer_autocreate(struct wlr_backend *backend, int
 		return NULL;
 	}
 
-	if (own_drm_fd && drm_fd >= 0) {
-		close(drm_fd);
-	}
-
 	return renderer;
 }
 
 struct wlr_renderer *fx_renderer_create_with_drm_fd(int drm_fd) {
 	assert(drm_fd >= 0);
 
-	return renderer_autocreate(NULL, drm_fd);
+	return renderer_autocreate(NULL, drm_fd, false);
+}
+
+struct wlr_renderer *fx_renderer_create_with_drm_fd_gbm(int drm_fd) {
+	assert(drm_fd >= 0);
+
+	return renderer_autocreate(NULL, drm_fd, true);
 }
 
 struct wlr_renderer *fx_renderer_create(struct wlr_backend *backend) {
-	return renderer_autocreate(backend, -1);
+	return renderer_autocreate(backend, -1, false);
 }
 
 static bool link_shaders(struct fx_renderer *renderer) {

--- a/umbrielfx/tests/egl_abi.c
+++ b/umbrielfx/tests/egl_abi.c
@@ -1,0 +1,62 @@
+// wlroots' multi-GPU renderer reads umbrielfx's EGL objects directly. Exercise
+// that shared layout through the linked library without opening a GPU. Missing
+// BGRA support deliberately stops initialization after its EGL import check.
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wlr/render/gles2.h>
+#include <wlr/util/log.h>
+
+#include "render/egl.h"
+
+static bool import_rejected;
+static bool bgra_rejected;
+
+static void capture_log(enum wlr_log_importance importance,
+		const char *format, va_list args) {
+	if (importance != WLR_ERROR) {
+		return;
+	}
+	char message[512];
+	vsnprintf(message, sizeof(message), format, args);
+	import_rejected |= strstr(message,
+		"EGL_EXT_image_dma_buf_import not supported") != NULL;
+	bgra_rejected |= strstr(message,
+		"BGRA8888 format not supported by GLES2") != NULL;
+}
+
+bool wlr_egl_make_current(struct wlr_egl *egl,
+		struct wlr_egl_context *save_context) {
+	(void)egl;
+	(void)save_context;
+	return true;
+}
+
+const GLubyte *glGetString(GLenum name) {
+	(void)name;
+	return (const GLubyte *)"";
+}
+
+static bool check_import_flag(bool supported) {
+	struct wlr_egl egl = {0};
+	egl.exts.EXT_image_dma_buf_import = supported;
+	import_rejected = false;
+	bgra_rejected = false;
+	struct wlr_renderer *renderer = wlr_gles2_renderer_create(&egl);
+	if (renderer != NULL || import_rejected == supported ||
+			bgra_rejected != supported) {
+		fprintf(stderr, "FAIL: linked wlroots misread EGL import flag %d "
+			"(import rejected: %d, BGRA rejected: %d)\n",
+			supported, import_rejected, bgra_rejected);
+		return false;
+	}
+	return true;
+}
+
+int main(void) {
+	wlr_log_init(WLR_ERROR, capture_log);
+	return check_import_flag(false) && check_import_flag(true)
+		? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/umbrielfx/tests/renderer.c
+++ b/umbrielfx/tests/renderer.c
@@ -1,0 +1,210 @@
+#include <dirent.h>
+#include <drm_fourcc.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/render/wlr_texture.h>
+#include <xf86drm.h>
+
+#include "umbrielfx/render/fx_renderer/fx_renderer.h"
+
+#define CREATE_CYCLES 8
+
+static bool same_drm_device(int first_fd, int second_fd) {
+	drmDevice *first = NULL;
+	drmDevice *second = NULL;
+	bool same = drmGetDevice2(first_fd, 0, &first) == 0 &&
+		drmGetDevice2(second_fd, 0, &second) == 0 &&
+		drmDevicesEqual(first, second);
+	drmFreeDevice(&first);
+	drmFreeDevice(&second);
+	return same;
+}
+
+static int count_open_fds(void) {
+	DIR *directory = opendir("/proc/self/fd");
+	if (directory == NULL) {
+		return -1;
+	}
+
+	int count = 0;
+	struct dirent *entry;
+	while ((entry = readdir(directory)) != NULL) {
+		if (strcmp(entry->d_name, ".") != 0 &&
+				strcmp(entry->d_name, "..") != 0) {
+			count++;
+		}
+	}
+	closedir(directory);
+	return count;
+}
+
+static void print_open_fds(void) {
+	DIR *directory = opendir("/proc/self/fd");
+	if (directory == NULL) {
+		return;
+	}
+	struct dirent *entry;
+	while ((entry = readdir(directory)) != NULL) {
+		if (entry->d_name[0] == '.') {
+			continue;
+		}
+		char target[256];
+		ssize_t length = readlinkat(dirfd(directory), entry->d_name,
+			target, sizeof(target) - 1);
+		if (length >= 0) {
+			target[length] = '\0';
+			fprintf(stderr, "  fd %s: %s\n", entry->d_name, target);
+		}
+	}
+	closedir(directory);
+}
+
+static struct wlr_renderer *create_owned_renderer(int drm_fd) {
+	(void)drm_fd;
+	return fx_renderer_create(NULL);
+}
+
+static bool renderer_matches(struct wlr_renderer *renderer, int drm_fd) {
+	int renderer_fd = wlr_renderer_get_drm_fd(renderer);
+	return renderer_fd >= 0 && same_drm_device(drm_fd, renderer_fd);
+}
+
+static bool renderer_is_usable(struct wlr_renderer *renderer) {
+	const uint32_t input = 0xFF224466;
+	uint32_t output = 0;
+	struct wlr_texture *texture = wlr_texture_from_pixels(renderer,
+		DRM_FORMAT_ARGB8888, sizeof(input), 1, 1, &input);
+	if (texture == NULL) {
+		return false;
+	}
+	bool ok = wlr_texture_read_pixels(texture,
+		&(struct wlr_texture_read_pixels_options) {
+			.data = &output,
+			.format = DRM_FORMAT_ARGB8888,
+			.stride = sizeof(output),
+		});
+	wlr_texture_destroy(texture);
+	return ok && output == input;
+}
+
+static bool replacement_survives_old_renderer_destroy(int drm_fd) {
+	struct wlr_renderer *old_renderer =
+		fx_renderer_create_with_drm_fd_gbm(drm_fd);
+	struct wlr_renderer *replacement =
+		fx_renderer_create_with_drm_fd_gbm(drm_fd);
+	if (old_renderer == NULL || replacement == NULL) {
+		if (old_renderer != NULL) {
+			wlr_renderer_destroy(old_renderer);
+		}
+		if (replacement != NULL) {
+			wlr_renderer_destroy(replacement);
+		}
+		return false;
+	}
+
+	wlr_renderer_destroy(old_renderer);
+	bool ok = renderer_matches(replacement, drm_fd) &&
+		renderer_is_usable(replacement);
+	wlr_renderer_destroy(replacement);
+	return ok;
+}
+
+static bool descriptors_are_stable(
+		int drm_fd, struct wlr_renderer *(*create_renderer)(int)) {
+	struct wlr_renderer *renderer = create_renderer(drm_fd);
+	if (renderer == NULL) {
+		fprintf(stderr, "FAIL: renderer creation failed\n");
+		return false;
+	}
+	if (!renderer_matches(renderer, drm_fd)) {
+		fprintf(stderr, "FAIL: renderer used a different DRM device\n");
+		wlr_renderer_destroy(renderer);
+		return false;
+	}
+	if (!renderer_is_usable(renderer)) {
+		fprintf(stderr, "FAIL: renderer could not upload and read back a texture\n");
+		wlr_renderer_destroy(renderer);
+		return false;
+	}
+	wlr_renderer_destroy(renderer);
+
+	int before = count_open_fds();
+	if (before < 0) {
+		fprintf(stderr, "FAIL: could not inspect /proc/self/fd\n");
+		return false;
+	}
+	for (int i = 0; i < CREATE_CYCLES; i++) {
+		renderer = create_renderer(drm_fd);
+		if (renderer == NULL) {
+			fprintf(stderr, "FAIL: renderer creation failed in cycle %d\n", i + 1);
+			return false;
+		}
+		if (!renderer_matches(renderer, drm_fd)) {
+			fprintf(stderr, "FAIL: renderer changed DRM device in cycle %d\n", i + 1);
+			wlr_renderer_destroy(renderer);
+			return false;
+		}
+		wlr_renderer_destroy(renderer);
+	}
+	int after = count_open_fds();
+	if (after != before) {
+		fprintf(stderr, "FAIL: open descriptor count changed from %d to %d\n",
+			before, after);
+		print_open_fds();
+		return false;
+	}
+	return true;
+}
+
+static bool test_device(const char *path) {
+	fprintf(stderr, "Testing DRM render node %s\n", path);
+	int drm_fd = open(path, O_RDWR | O_CLOEXEC);
+	if (drm_fd < 0) {
+		perror("FAIL: could not open selected DRM render node");
+		return false;
+	}
+	if (drmGetNodeTypeFromFd(drm_fd) != DRM_NODE_RENDER) {
+		fprintf(stderr, "FAIL: %s is not a DRM render node\n", path);
+		close(drm_fd);
+		return false;
+	}
+	if (setenv("WLR_RENDER_DRM_DEVICE", path, 1) != 0) {
+		perror("FAIL: could not select renderer device");
+		close(drm_fd);
+		return false;
+	}
+
+	bool passed = false;
+	if (!replacement_survives_old_renderer_destroy(drm_fd)) {
+		fprintf(stderr,
+			"FAIL: replacement renderer could not be created or did not "
+			"survive old renderer teardown\n");
+	} else if (descriptors_are_stable(drm_fd,
+			fx_renderer_create_with_drm_fd_gbm)) {
+		passed = descriptors_are_stable(drm_fd, create_owned_renderer);
+	}
+	close(drm_fd);
+	return passed;
+}
+
+int main(int argc, char **argv) {
+	// GPU access is opt-in. Pass every render node to check as a separate
+	// argument; a selected node that cannot initialize is a failure, not a skip.
+	if (argc == 1) {
+		fprintf(stderr, "SKIP: pass DRM render-node paths as arguments\n");
+		return 77;
+	}
+
+	bool passed = true;
+	for (int i = 1; i < argc; i++) {
+		if (!test_device(argv[i])) {
+			passed = false;
+		}
+	}
+	return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

Adds optional native GPU exclusions by DRM path or PCI address. Paths resolve once before any GPU opens; PCI selectors work while a GPU is absent or bound to `vfio-pci`.

`BackendManager` filters startup and hotplug, gives allowed GPUs independent backends, and uses an explicit GBM renderer constructor. Descriptor checks reject excluded devices, unidentified DRM descriptors, and unexpected inspection errors. NVIDIA metadata is needed only for open per-GPU devices without a PCI identity from udev. Configuration errors that could hide exclusions stop startup. Automatic discovery remains unchanged without exclusions and in nested or headless sessions. Policy changes require a restart.

See the [configuration reference](https://github.com/Gustav0ar/umbriel/blob/feat/drm-device-policy/docs/user/configuration.md#drm-devices) for selectors and limits.

## Motivation

Keep a guest GPU available for VFIO while Umbriel uses the remaining GPUs. Host tooling manages PCI driver binding.

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Refactoring
- [x] Documentation

## Testing

- Isolated build against wlroots 0.20.2; all 37 compositor test executables and both EGL/scene ABI checks passed.
- Native tests cover startup rejection, path retargeting, node reuse, reattachment, and descriptor audits after udev metadata disappears, using simulated device I/O.
- The build without native DRM policy support passed automatic/headless startup and native-policy rejection checks.
- Refactored parsers matched the previous implementation in differential checks. Descriptor-audit failure tests failed before the fixes and passed afterward. Temporary NVIDIA metadata fixtures verified aliases, shared nodes, and missing records.
- `just format`, `git diff --check`, clang-tidy, documentation links, and validation of `examples/config.toml` passed.

Three existing color-config test warnings remain. Physical VFIO transitions and multi-GPU display behavior were not tested.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

