### PR TITLE
fix(view): uniform rounding rule for main surface and subsurfaces

### DIFF
--- a/docs/design/border-rendering.md
+++ b/docs/design/border-rendering.md
@@ -97,6 +97,30 @@ clamping inside every texture fetch caused constant full-session flicker and
 tearing on NVIDIA (595.71.05, open modules), so an empty `sample_box` must keep
 the fetch byte-identical to a build without the clamp.
 
+## Surface rounding
+
+The content edge is a shader contour, so the client surfaces inside the hole
+have to follow the same arc or their square corners cover it. Each scene buffer
+carries `corner_box`, the rounded rectangle its radii describe, in node-relative
+coordinates. Umbriel gives every buffer under a toplevel's surface tree the same
+box, the window's content box, and the fragment shader clips to it and rounds
+its corners.
+
+Nothing in that rule inspects a buffer's own destination quad, which is what
+makes it hold in every state a window reaches:
+
+- a main surface inset inside the content box, because the window geometry
+  origin lies at a subsurface above or left of it, keeps its own corners square;
+- a full-window subsurface rounds the window's corners;
+- an interior subsurface, such as an embedded video, never touches the arc;
+- an animated or interactively resized presented size rounds where the window is
+  drawn now, including while the client's committed buffer still lags it.
+
+An empty `corner_box` falls back to rounding the buffer's own quad, which is
+what the overview badge and other standalone buffers use. Overview cards apply
+the window rule against the card's content box, so a thumbnail rounds wherever
+the live window does.
+
 ## Scene lifecycle
 
 View decorations, overview cards, and their close-animation snapshots all copy
@@ -116,6 +140,11 @@ a second scene node or draw order.
   carries a transparent one-logical-pixel margin around its declared window, so
   the crop lands a quarter texel off the grid on every side. All four edge lines
   inside the content box must be window content.
+- `720_subsurface_corner_radius.sh` checks that content drawn through a
+  full-window subsurface follows the window radius.
+- `721_offset_main_surface_radius.sh` puts the window geometry origin at a
+  subsurface above and left of the main surface. The inset main surface must
+  keep its interior corners square while both window corners still round.
 - `722_subsurface_border_corner.sh` checks the outer arc, smooth two-color seam,
   positive content radius, and straight-to-curve tangency against a full-window
   subsurface.

--- a/docs/design/overview-rendering.md
+++ b/docs/design/overview-rendering.md
@@ -43,7 +43,9 @@ only the projection into card coordinates, not a separate close timeline.
 ## Decoration and clipping
 
 Cards carry the same inner border, outer border, and corner radius as their
-windows. These values scale with the card.
+windows. These values scale with the card. Every surface of a card rounds
+against the card's content box, the rule live windows use, so a client that
+draws its corners from a subsurface keeps them rounded in the thumbnail.
 
 Each output's overview tree carries a `wlr_scene_tree_set_clip` of that
 output's logical bounds, the same primitive windows use. A workspace row that

--- a/src/layer/layer_surface.cpp
+++ b/src/layer/layer_surface.cpp
@@ -147,6 +147,7 @@ namespace umbriel {
           }
           wlr_scene_buffer_set_transform(copy, src->transform);
           wlr_scene_buffer_set_corner_radii(copy, src->corners);
+          wlr_scene_buffer_set_corner_box(copy, &src->corner_box);
           wlr_scene_buffer_set_opacity(copy, src->opacity);
           wlr_scene_buffer_set_transfer_function(copy, src->transfer_function);
           wlr_scene_buffer_set_primaries(copy, src->primaries);

--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -242,6 +242,13 @@ namespace umbriel {
       }
     }
 
+    // Every surface of the card rounds against the card's content box, the same rule the live window uses, so a
+    // client that draws its corners from a subsurface keeps them rounded in the thumbnail.
+    const auto roundToCardBox = [surfaceRadius, contentW, contentH](wlr_scene_buffer* buffer) {
+      const wlr_box cornerBox{-buffer->node.x, -buffer->node.y, contentW, contentH};
+      wlr_scene_buffer_set_corner_radii(buffer, corner_radii_all(surfaceRadius));
+      wlr_scene_buffer_set_corner_box(buffer, surfaceRadius > 0 ? &cornerBox : nullptr);
+    };
     const double fx = static_cast<double>(contentW) / geometry.width;
     const double fy = static_cast<double>(contentH) / geometry.height;
     bool blurUpdated = false;
@@ -263,6 +270,7 @@ namespace umbriel {
         wlr_scene_node_set_enabled(&entry->buffer->node, true);
         wlr_scene_node_set_position(&entry->buffer->node, sub.x - card.box.x, sub.y - card.box.y);
         wlr_scene_buffer_set_dest_size(entry->buffer, sub.width, sub.height);
+        roundToCardBox(entry->buffer);
         continue;
       }
       // Root surface: crop to the committed window geometry so CSD shadow padding never leaks into the thumbnail, then
@@ -290,7 +298,7 @@ namespace umbriel {
       wlr_scene_node_set_position(&entry->buffer->node, 0, 0);
       wlr_scene_buffer_set_source_box(entry->buffer, &src);
       wlr_scene_buffer_set_dest_size(entry->buffer, contentW, contentH);
-      wlr_scene_buffer_set_corner_radii(entry->buffer, corner_radii_all(surfaceRadius));
+      roundToCardBox(entry->buffer);
       const wlr_box blurBox{0, 0, contentW, contentH};
       card.blur.setAlpha(1.0F);
       card.blur.update(
@@ -602,6 +610,7 @@ namespace umbriel {
       }
       wlr_scene_buffer_set_transform(copy, source->transform);
       wlr_scene_buffer_set_corner_radii(copy, source->corners);
+      wlr_scene_buffer_set_corner_box(copy, &source->corner_box);
       wlr_scene_buffer_set_opacity(copy, source->opacity);
       wlr_scene_buffer_set_transfer_function(copy, source->transfer_function);
       wlr_scene_buffer_set_primaries(copy, source->primaries);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1173,10 +1173,9 @@ namespace umbriel {
   void View::applyCornerRadius() {
     // Apps that draw through subsurfaces (Firefox renders all of its chrome and web content into one desynchronized
     // MozContainer subsurface) leave their content square unless those buffers round too. Every buffer under the
-    // toplevel's surface tree is visited: the main surface rounds unconditionally (its quad is the content box in every
-    // clipped and animated state), a subsurface rounds only the corners where its quad, already cropped to the content
-    // box by setSurfaceTreeClip, actually reaches a content-box corner, so an interior subsurface (embedded video)
-    // stays square. Popups are excluded: their surface is its own root.
+    // toplevel's surface tree is visited: surfaces rounds only the corners where its quad, already cropped to
+    // the content box by setSurfaceTreeClip, actually reaches a content-box corner, so an interior subsurface (embedded
+    // video) stays square. Popups are excluded: their surface is its own root.
     const int radius = surfaceRadius();
     // A tiled target and an active resize animation can both lead committed
     // geometry, so use the presented size for corner membership in either case.
@@ -1207,10 +1206,7 @@ namespace umbriel {
               || wlr_surface_get_root_surface(sceneSurface->surface) != ctx->view->m_toplevel->base->surface) {
             return;
           }
-          if (sceneSurface->surface == ctx->view->m_toplevel->base->surface) {
-            wlr_scene_buffer_set_corner_radii(buffer, corner_radii_all(ctx->radius));
-            return;
-          }
+
           // The iterator accumulates positions from the node it was handed, so subtracting the tree's own position
           // yields tree-local coordinates. The xdg scene helper places the surface tree at (-geometry.x, -geometry.y),
           // which puts the content box at the tree origin.

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1173,12 +1173,13 @@ namespace umbriel {
   void View::applyCornerRadius() {
     // Apps that draw through subsurfaces (Firefox renders all of its chrome and web content into one desynchronized
     // MozContainer subsurface) leave their content square unless those buffers round too. Every buffer under the
-    // toplevel's surface tree is visited: surfaces rounds only the corners where its quad, already cropped to
-    // the content box by setSurfaceTreeClip, actually reaches a content-box corner, so an interior subsurface (embedded
-    // video) stays square. Popups are excluded: their surface is its own root.
+    // toplevel's surface tree is rounded against one box, the window's content box, so the arc always lands on the
+    // window's corners whichever surface draws them: an inset main surface, a full-window subsurface and an interior
+    // subsurface (embedded video) all follow from that box without knowing anything about each other. Popups are
+    // excluded: their surface is its own root.
     const int radius = surfaceRadius();
-    // A tiled target and an active resize animation can both lead committed
-    // geometry, so use the presented size for corner membership in either case.
+    // A tiled target and an active resize animation can both lead committed geometry, so the box follows the presented
+    // size in either case.
     const wlr_box& geometry = m_toplevel->base->geometry;
     const bool usePresentedSize =
         (m_tiled || sizeAnimating()) && m_presentation.width() > 0 && m_presentation.height() > 0;
@@ -1209,23 +1210,16 @@ namespace umbriel {
 
           // The iterator accumulates positions from the node it was handed, so subtracting the tree's own position
           // yields tree-local coordinates. The xdg scene helper places the surface tree at (-geometry.x, -geometry.y),
-          // which puts the content box at the tree origin.
-          const int x = sx - ctx->treeX;
-          const int y = sy - ctx->treeY;
-          const int w = buffer->dst_width > 0 ? buffer->dst_width : sceneSurface->surface->current.width;
-          const int h = buffer->dst_height > 0 ? buffer->dst_height : sceneSurface->surface->current.height;
-          const bool left = x == 0;
-          const bool top = y == 0;
-          const bool right = x + w == ctx->contentWidth;
-          const bool bottom = y + h == ctx->contentHeight;
-          const int r = ctx->radius;
-          // Always set, zeros included: a subsurface that moved or resized off a corner must lose its stale radius.
-          wlr_scene_buffer_set_corner_radii(
-              buffer,
-              corner_radii_new(
-                  top && left ? r : 0, top && right ? r : 0, bottom && right ? r : 0, bottom && left ? r : 0
-              )
-          );
+          // which puts the content box at the tree origin, and the corner box is node-relative.
+          const wlr_box cornerBox{
+              ctx->treeX - sx,
+              ctx->treeY - sy,
+              ctx->contentWidth,
+              ctx->contentHeight,
+          };
+          // Always set, zeros included: a window that lost its radius must lose the box with it.
+          wlr_scene_buffer_set_corner_radii(buffer, corner_radii_all(ctx->radius));
+          wlr_scene_buffer_set_corner_box(buffer, ctx->radius > 0 ? &cornerBox : nullptr);
         },
         &ctx
     );
@@ -1351,6 +1345,7 @@ namespace umbriel {
           }
           wlr_scene_buffer_set_transform(copy, src->transform);
           wlr_scene_buffer_set_corner_radii(copy, src->corners);
+          wlr_scene_buffer_set_corner_box(copy, &src->corner_box);
           wlr_scene_buffer_set_opacity(copy, src->opacity);
           wlr_scene_buffer_set_transfer_function(copy, src->transfer_function);
           wlr_scene_buffer_set_primaries(copy, src->primaries);

--- a/tests/harness/checks/721_offset_main_surface_radius.sh
+++ b/tests/harness/checks/721_offset_main_surface_radius.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# A window's rounding belongs to the window box, not to whichever buffer happens to draw there. This client puts its
+# window geometry origin at a subsurface placed above and left of its main surface, so the main surface is inset inside
+# the content box: rounding it as if its own quad were the content box cuts an arc out of the middle of the window.
+# The client paints its parent surface red and the subsurface underneath it blue over a green backdrop, so one sample
+# reports which surface drew a pixel and whether an arc was cut where no window corner is.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_SUBSURFACE_CLIENT:-./build-debug/tests/subsurface-client}"
+readonly CLIENT_LOG="$UMBRIEL_RUNTIME_DIR/offset-subsurface-client.log"
+readonly SCREENSHOT="$UMBRIEL_RUNTIME_DIR/offset-main-surface-radius.png"
+readonly RADIUS=64
+readonly OFFSET=40
+
+if [[ ! -x $CLIENT ]]; then
+  echo "subsurface client not built at $CLIENT"
+  exit 1
+fi
+
+cat >> "$UMBRIEL_CONFIG" <<EOF
+
+[animation]
+duration_ms = 1
+
+[appearance]
+border_width = 0
+outer_border_width = 0
+corner_radius = $RADIUS
+backdrop_color = "#00FF00FF"
+
+[appearance.shadow]
+enabled = false
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+OFFSET_GEOMETRY=$OFFSET "$CLIENT" "offset-radius" > "$CLIENT_LOG" 2>&1 &
+
+for _ in $(seq 60); do
+  grep -q '^mapped$' "$CLIENT_LOG" && break
+  sleep 0.05
+done
+if ! grep -q '^mapped$' "$CLIENT_LOG"; then
+  echo "subsurface client never mapped: $(cat "$CLIENT_LOG")"
+  exit 1
+fi
+
+window_box() {
+  "$UMBRIEL" windows --json | jq -r '.[] | select(.title == "offset-radius") | "\(.x) \(.y) \(.w) \(.h)"'
+}
+box=
+for _ in $(seq 60); do
+  box=$(window_box)
+  [[ -n $box ]] && break
+  sleep 0.1
+done
+if [[ -z $box ]]; then
+  echo "offset-radius window never appeared in the window list"
+  exit 1
+fi
+# Sample the box the layout settled on, after the (1 ms) open animation has run.
+sleep 0.5
+read -r win_x win_y win_w win_h <<< "$(window_box)"
+grim "$SCREENSHOT"
+
+sample() {
+  magick "$SCREENSHOT" -crop "1x1+$1+$2" \
+    -format '%[fx:round(255*mean.r)] %[fx:round(255*mean.g)] %[fx:round(255*mean.b)]' info:
+}
+
+# (OFFSET+3, OFFSET+3) from the window origin is the main surface's own top-left, ~86 px from an arc centre it must not
+# have. Red is the main surface; blue is the subsurface it would uncover if that corner were rounded.
+read -r inner_r inner_g inner_b <<< "$(sample $((win_x + OFFSET + 3)) $((win_y + OFFSET + 3)))"
+if (( inner_r < 200 || inner_b > 60 )); then
+  echo "an arc was cut out of the inset main surface: r=$inner_r g=$inner_g b=$inner_b"
+  exit 1
+fi
+
+# The window's own corners still round. The subsurface owns the top-left, the main surface reaches the bottom-right, so
+# a correctly rounded window leaves the backdrop visible at both.
+read -r tl_r tl_g tl_b <<< "$(sample $((win_x + 3)) $((win_y + 3)))"
+if (( tl_g < 200 || tl_r > 60 || tl_b > 60 )); then
+  echo "window top-left corner was not rounded: r=$tl_r g=$tl_g b=$tl_b"
+  exit 1
+fi
+read -r br_r br_g br_b <<< "$(sample $((win_x + win_w - 4)) $((win_y + win_h - 4)))"
+if (( br_g < 200 || br_r > 60 || br_b > 60 )); then
+  echo "window bottom-right corner was not rounded: r=$br_r g=$br_g b=$br_b"
+  exit 1
+fi
+
+# Content is still drawn: rounding that swallowed the inset surface would pass the probes above on its own.
+read -r mid_r mid_g mid_b <<< "$(sample $((win_x + win_w / 2)) $((win_y + win_h / 2)))"
+if (( mid_r < 200 )); then
+  echo "main surface missing at the window centre: r=$mid_r g=$mid_g b=$mid_b"
+  exit 1
+fi
+
+echo "inset main surface kept its interior corners square while the window rounded: interior red=$inner_r blue=$inner_b, corners green=$tl_g/$br_g"

--- a/tests/harness/clients/subsurface_client.cpp
+++ b/tests/harness/clients/subsurface_client.cpp
@@ -4,7 +4,10 @@
 // which surface a pixel came from and whether the compositor rounded the subsurface to the window corner radius. Prints
 // "mapped" once both surfaces are up, then keeps the connection alive until the harness kills it. The optional
 // "animate" mode continually damages only the child, matching Firefox's independent MozContainer commits. Setting
-// TRANSLUCENT_CONTENT gives the child premultiplied half-alpha magenta content over a transparent parent.
+// TRANSLUCENT_CONTENT gives the child premultiplied half-alpha magenta content over a transparent parent. Setting
+// OFFSET_GEOMETRY to a pixel margin places the child above and left of the parent and puts the window geometry origin
+// there, so the main surface is inset inside the window content box and its own corners are interior to the window;
+// the child then sits below the parent so both are visible.
 // Usage: subsurface-client [title [width height [animate]]]. The dimensions are a fallback: a configure adopts it.
 
 #include "xdg-shell-client-protocol.h"
@@ -44,6 +47,8 @@ namespace {
     int height = 480;
     int presentedWidth = 0;
     int presentedHeight = 0;
+    // Logical margin by which the child, and with it the window geometry origin, sits above and left of the parent.
+    int offset = 0;
     bool mapped = false;
     bool animateChild = false;
     bool initialFullscreen = false;
@@ -91,10 +96,10 @@ namespace {
     buffer.size = 0;
   }
 
-  Buffer createBuffer(State& state, uint32_t color) {
+  Buffer createBuffer(State& state, int width, int height, uint32_t color) {
     Buffer buffer;
-    const int stride = state.width * 4;
-    buffer.size = static_cast<size_t>(stride) * static_cast<size_t>(state.height);
+    const int stride = width * 4;
+    buffer.size = static_cast<size_t>(stride) * static_cast<size_t>(height);
     const int fd = memfd_create("umbriel-subsurface-client", MFD_CLOEXEC);
     if (fd < 0 || ftruncate(fd, static_cast<off_t>(buffer.size)) < 0) {
       if (fd >= 0) {
@@ -111,15 +116,15 @@ namespace {
     std::fill_n(static_cast<uint32_t*>(buffer.pixels), buffer.size / sizeof(uint32_t), color);
 
     wl_shm_pool* pool = wl_shm_create_pool(state.shm, fd, static_cast<int>(buffer.size));
-    buffer.resource = wl_shm_pool_create_buffer(pool, 0, state.width, state.height, stride, WL_SHM_FORMAT_ARGB8888);
+    buffer.resource = wl_shm_pool_create_buffer(pool, 0, width, height, stride, WL_SHM_FORMAT_ARGB8888);
     wl_shm_pool_destroy(pool);
     close(fd);
     return buffer;
   }
 
-  // Both surfaces always carry a buffer of the current window size: the compositor's rounding is measured against the
-  // window box, so a stale child size would move the corner the check samples. Re-attach only on an actual size change;
-  // the previous buffers are released after the commit that replaces them.
+  // The child always carries a buffer of the current window size: the compositor's rounding is measured against the
+  // window box, so a stale child size would move the corner the check samples. Re-attach only on an actual size
+  // change; the previous buffers are released after the commit that replaces them.
   bool presentSize(State& state) {
     if (state.width == state.presentedWidth && state.height == state.presentedHeight) {
       // Nothing to redraw, but the acked configure still needs a commit to be applied.
@@ -131,8 +136,12 @@ namespace {
     const uint32_t childColor = state.transparentContent ? 0x00000000
         : state.translucentContent                       ? 0x80800080
                                                          : 0xFF0000FF;
-    Buffer parent = createBuffer(state, parentColor);
-    Buffer child = createBuffer(state, childColor);
+    // The child always covers the whole window box. In offset mode the parent gives up the margin the child occupies
+    // above and left of it, so the two together still cover the box exactly once.
+    const int parentWidth = std::max(1, state.width - state.offset);
+    const int parentHeight = std::max(1, state.height - state.offset);
+    Buffer parent = createBuffer(state, parentWidth, parentHeight, parentColor);
+    Buffer child = createBuffer(state, state.width, state.height, childColor);
     if (parent.resource == nullptr || child.resource == nullptr) {
       destroyBuffer(parent);
       destroyBuffer(child);
@@ -146,8 +155,12 @@ namespace {
     }
     wl_surface_commit(state.child);
 
+    if (state.offset > 0) {
+      // The window box starts at the child's top-left, which is outside the parent surface.
+      xdg_surface_set_window_geometry(state.xdgSurface, -state.offset, -state.offset, state.width, state.height);
+    }
     wl_surface_attach(state.surface, parent.resource, 0, 0);
-    wl_surface_damage_buffer(state.surface, 0, 0, state.width, state.height);
+    wl_surface_damage_buffer(state.surface, 0, 0, parentWidth, parentHeight);
     wl_surface_commit(state.surface);
 
     destroyBuffer(state.parentBuffer);
@@ -253,6 +266,9 @@ int main(int argc, char** argv) {
   state.fullscreenBeforeMap = std::getenv("FULLSCREEN_BEFORE_MAP") != nullptr;
   state.transparentContent = std::getenv("TRANSPARENT_CONTENT") != nullptr;
   state.translucentContent = std::getenv("TRANSLUCENT_CONTENT") != nullptr;
+  if (const char* offset = std::getenv("OFFSET_GEOMETRY")) {
+    state.offset = std::max(0, std::atoi(offset));
+  }
   if (argc > 2) {
     state.width = std::max(1, std::atoi(argv[2]));
   }
@@ -291,7 +307,11 @@ int main(int argc, char** argv) {
   // Desynchronized, like Firefox: the child commits its own content without waiting for a parent commit.
   state.child = wl_compositor_create_surface(state.compositor);
   state.subsurface = wl_subcompositor_get_subsurface(state.subcompositor, state.child, state.surface);
-  wl_subsurface_set_position(state.subsurface, 0, 0);
+  wl_subsurface_set_position(state.subsurface, -state.offset, -state.offset);
+  if (state.offset > 0) {
+    // The parent has to stay visible: it is the surface whose own corners must not round in offset mode.
+    wl_subsurface_place_below(state.subsurface, state.surface);
+  }
   wl_subsurface_set_desync(state.subsurface);
 
   if (state.initialFullscreen) {

--- a/umbrielfx/include/umbrielfx/types/wlr_scene.h
+++ b/umbrielfx/include/umbrielfx/types/wlr_scene.h
@@ -295,6 +295,13 @@ struct wlr_scene_buffer {
 	} WLR_PRIVATE;
 
 	struct fx_corner_radii corners;
+	/**
+	 * Rounded rectangle `corners` describes, in node-relative coordinates. An
+	 * empty box rounds the buffer's own destination box. While `corners` has a
+	 * radius the draw is also confined to the box, so a buffer that does not
+	 * reach a box corner keeps that corner square.
+	 */
+	struct wlr_box corner_box;
 	struct linked_node blur;
 
 	/**
@@ -915,6 +922,13 @@ void wlr_scene_buffer_set_corner_radius(struct wlr_scene_buffer *scene_buffer,
 */
 void wlr_scene_buffer_set_corner_radii(struct wlr_scene_buffer *scene_buffer,
 	struct fx_corner_radii corner_radii);
+
+/**
+* Sets the box the corner radii of this buffer describe, in node-relative
+* coordinates. NULL or an empty box rounds the buffer's own destination box.
+*/
+void wlr_scene_buffer_set_corner_box(struct wlr_scene_buffer *scene_buffer,
+	const struct wlr_box *box);
 
 void wlr_scene_buffer_set_transfer_function(struct wlr_scene_buffer *scene_buffer,
 	enum wlr_color_transfer_function transfer_function);

--- a/umbrielfx/types/scene/wlr_scene.c
+++ b/umbrielfx/types/scene/wlr_scene.c
@@ -471,9 +471,20 @@ static void scene_node_opaque_region(struct wlr_scene_node *node, int x, int y,
 			pixman_region32_init_rect(opaque, x, y, width, height);
 		}
 
-		// subtract the corners from the opaque region
+		// The draw is confined to the corner box and rounded at its corners, so
+		// neither the part outside it nor the area under an arc is opaque.
+		struct wlr_box arc_box = { x, y, width, height };
+		if (!wlr_box_empty(&scene_buffer->corner_box)) {
+			arc_box = scene_buffer->corner_box;
+			arc_box.x += x;
+			arc_box.y += y;
+			pixman_region32_intersect_rect(opaque, opaque, arc_box.x, arc_box.y,
+				arc_box.width, arc_box.height);
+		}
+
 		if (!fx_corner_radii_is_empty(&scene_buffer->corners)) {
-			pixman_region32_t corners = create_corner_location_region(scene_buffer->corners, x, y, width, height);
+			pixman_region32_t corners = create_corner_location_region(scene_buffer->corners,
+				arc_box.x, arc_box.y, arc_box.width, arc_box.height);
 			pixman_region32_subtract(opaque, opaque, &corners);
 			pixman_region32_fini(&corners);
 		}
@@ -1891,6 +1902,17 @@ void wlr_scene_buffer_set_corner_radii(struct wlr_scene_buffer *scene_buffer,
 	scene_node_update(&scene_buffer->node, NULL);
 }
 
+void wlr_scene_buffer_set_corner_box(struct wlr_scene_buffer *scene_buffer,
+		const struct wlr_box *box) {
+	const struct wlr_box next = box != NULL ? *box : (struct wlr_box){0};
+	if (wlr_box_equal(&scene_buffer->corner_box, &next)) {
+		return;
+	}
+
+	scene_buffer->corner_box = next;
+	scene_node_update(&scene_buffer->node, NULL);
+}
+
 static struct wlr_texture *scene_buffer_get_texture(
 		struct wlr_scene_buffer *scene_buffer, struct wlr_renderer *renderer) {
 	if (scene_buffer->buffer == NULL || scene_buffer->texture != NULL) {
@@ -2360,7 +2382,21 @@ static void scene_entry_render(struct render_list_entry *entry, const struct ren
 		enum wl_output_transform transform =
 			wlr_output_transform_invert(scene_buffer->transform);
 		transform = wlr_output_transform_compose(transform, data->transform);
-		fx_corner_radii_transform(transform, &buffer_corners);
+
+		// A corner box lives in scene coordinates, so its radii follow the
+		// output transform alone. Radii on the buffer's own quad follow the
+		// buffer transform too.
+		struct wlr_box corner_box = scene_buffer->corner_box;
+		const bool has_corner_box = !wlr_box_empty(&corner_box);
+		if (has_corner_box) {
+			// Node relative -> Root relative
+			corner_box.x += x;
+			corner_box.y += y;
+			transform_output_box(&corner_box, data);
+			fx_corner_radii_transform(node_transform, &buffer_corners);
+		} else {
+			fx_corner_radii_transform(transform, &buffer_corners);
+		}
 
 		struct wlr_color_primaries primaries = {0};
 		if (scene_buffer->primaries != 0) {
@@ -2481,7 +2517,7 @@ static void scene_entry_render(struct render_list_entry *entry, const struct ren
 				.wait_timeline = scene_buffer->wait_timeline,
 				.wait_point = scene_buffer->wait_point,
 			},
-			.clip_box = &dst_box,
+			.clip_box = has_corner_box ? &corner_box : &dst_box,
 			.corners = fx_corner_radii_scale(buffer_corners, data->scale),
 			.clipped_region = {0},
 			.sample_box = sample_box,


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
unified the logic for main surface rounding to match the one used for subsurfaces. main surface should not be rounded unconditionally, since its position in the windows coordinate space may not be at the start, observed in the fastpotify client
<img width="95" height="104" alt="image" src="https://github.com/user-attachments/assets/4249bbb1-5be8-4ca9-90b7-c66e8c83d5fd" />

## Motivation

<!-- What problem does this solve? -->
solves the problem described above
<img width="125" height="109" alt="image" src="https://github.com/user-attachments/assets/178cb6bd-b27b-40f6-82a3-3695135357b4" />

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
manually tested with mentioned client, and some other apps, both with and without csd. seems like there are no regressions. did not run the automated tests.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [ ] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [ ] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [ ] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [ ] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
