### PR TITLE
feat: add center focused on overflow, rework center_focused setting

### DIFF
--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -86,14 +86,14 @@ horizontally scrolls vertically.
 [layout.scrolling]
 default_width_fraction = 0.5         # remove to let clients choose, 0.1-1.0
 center_underfull_strip = true
-center_focused = false
+center_focused = "never"             # "never", "always", or "on_overflow"
 ```
 
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `default_width_fraction` | float | unset | Initial strip-axis extent for new columns (0.1-1.0). The packaged config sets `0.5`; a matching output or workspace rule can override it. When it is unset at every level, the client chooses its initial extent. |
 | `center_underfull_strip` | bool | `true` | Center the complete strip when it is shorter than the viewport. Disable to align it at the start edge. |
-| `center_focused` | bool | `false` | Always center the focused column. |
+| `center_focused` | string | `"never"` | When a focus change centers the newly focused column. `"never"` only scrolls far enough to reveal it, `"always"` centers it, and `"on_overflow"` centers it when it cannot share the viewport with the neighboring column on the side focus came from. |
 
 ### Horizontal and vertical scrolling
 

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -198,7 +198,7 @@ Strut edges are resolved independently. A rule that sets only
 | `layout.width_presets` | float array | Fractions used by the width-cycle and height-cycle actions in every layout. |
 | `layout.scrolling.default_width_fraction` | float | Optional initial scrolling lane extent (0.1-1.0). It overrides the global and matching output values. When omitted at every level, the client chooses its initial logical extent. Reloading a default does not resize existing columns. |
 | `layout.scrolling.center_underfull_strip` | bool | Center the complete strip whenever it is narrower than the viewport. Disable to left-align underfull strips. |
-| `layout.scrolling.center_focused` | bool | Always center the focused column, including when the setting changes on config reload. |
+| `layout.scrolling.center_focused` | string | When a focus change centers the newly focused column. `"never"` only scrolls far enough to reveal it, `"always"` centers it, and `"on_overflow"` centers it when it cannot share the viewport with the neighboring column on the side focus came from. |
 | `layout.master.position` | string | Side occupied by the master area: `"left"` or `"right"`. |
 | `layout.master.default_width_fraction` | float | Master area fraction when both areas exist (0.1-0.9). |
 | `layout.master.new_on_top` | bool | Place newly opened windows at the top of the stack. Disable to place them at the bottom. |
@@ -218,7 +218,7 @@ layout.mode = "dwindle"
 output = "HDMI-A-1"
 name = "CHAT"
 layout.mode = "scrolling"
-layout.scrolling.center_focused = true
+layout.scrolling.center_focused = "always"
 
 [[workspace]]
 output = "HDMI-A-1"

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -476,7 +476,7 @@ bottom = 0
 # The strip axis is perpendicular to the output's workspace_axis.
 default_width_fraction = 0.5                    # Initial width for new columns, 0.1-1.0
 center_underfull_strip = true                   # Center a strip narrower than the viewport
-center_focused = false                          # Always center the focused column
+center_focused = "never"                        # never, always, or on_overflow
 
 [layout.dwindle]
 # preserve_split = false                        # Keep every split direction fixed after creation

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -374,6 +374,33 @@ namespace umbriel {
       return std::nullopt;
     }
 
+    std::optional<CenterFocusedColumn> readCenterFocused(Section& section, std::string_view context) {
+      const toml::node* node = section.take("center_focused");
+      if (node == nullptr) {
+        return std::nullopt;
+      }
+      const auto* value = node->as_string();
+      if (value == nullptr) {
+        warnAt(node->source(), R"({}.center_focused must be a string ("never", "always", or "on_overflow"))", context);
+        return std::nullopt;
+      }
+      const std::string_view mode = value->get();
+      if (mode == "never") {
+        return CenterFocusedColumn::Never;
+      }
+      if (mode == "always") {
+        return CenterFocusedColumn::Always;
+      }
+      if (mode == "on_overflow") {
+        return CenterFocusedColumn::OnOverflow;
+      }
+      warnAt(
+          node->source(), R"(unknown {}.center_focused "{}" (expected "never", "always", or "on_overflow"))", context,
+          mode
+      );
+      return std::nullopt;
+    }
+
     std::vector<std::string_view> splitWhitespace(std::string_view text) {
       std::vector<std::string_view> tokens;
       size_t offset = 0;
@@ -570,8 +597,10 @@ namespace umbriel {
             }
             s.sub("scrolling", [&](Section& sc) {
               sc.real("default_width_fraction", 0.1, 1.0, overrides.scrolling.defaultWidthFraction)
-                  .boolean("center_underfull_strip", overrides.scrolling.centerUnderfullStrip)
-                  .boolean("center_focused", overrides.scrolling.centerFocused);
+                  .boolean("center_underfull_strip", overrides.scrolling.centerUnderfullStrip);
+              if (const auto centerFocused = readCenterFocused(sc, layoutContext + ".scrolling")) {
+                overrides.scrolling.centerFocused = centerFocused;
+              }
             });
             s.sub("dwindle", [&](Section& sd) { sd.boolean("preserve_split", overrides.dwindle.preserveSplit); });
             s.sub("master", [&](Section& sm) {
@@ -1197,8 +1226,10 @@ namespace umbriel {
         }
         s.sub("scrolling", [&](Section& sc) {
           sc.real("default_width_fraction", 0.1, 1.0, loaded.layout.scrolling.defaultWidthFraction)
-              .boolean("center_underfull_strip", loaded.layout.scrolling.centerUnderfullStrip)
-              .boolean("center_focused", loaded.layout.scrolling.centerFocused);
+              .boolean("center_underfull_strip", loaded.layout.scrolling.centerUnderfullStrip);
+          if (const auto centerFocused = readCenterFocused(sc, "layout.scrolling")) {
+            loaded.layout.scrolling.centerFocused = *centerFocused;
+          }
         });
         s.sub("dwindle", [&](Section& sd) { sd.boolean("preserve_split", loaded.layout.dwindle.preserveSplit); });
         s.sub("master", [&](Section& sm) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -57,7 +57,7 @@ namespace umbriel {
     struct Scrolling {
       std::optional<double> defaultWidthFraction;
       std::optional<bool> centerUnderfullStrip;
-      std::optional<bool> centerFocused;
+      std::optional<CenterFocusedColumn> centerFocused;
       bool operator==(const Scrolling&) const = default;
     } scrolling;
     struct Dwindle {
@@ -103,7 +103,7 @@ namespace umbriel {
     struct Scrolling {
       std::optional<double> defaultWidthFraction;
       bool centerUnderfullStrip = true;
-      bool centerFocused = false;
+      CenterFocusedColumn centerFocused = CenterFocusedColumn::Never;
       // Axis-agnostic layout state is preserved when config reload changes direction.
       ScrollingDirection direction = ScrollingDirection::Horizontal;
       bool operator==(const Scrolling&) const = default;
@@ -635,7 +635,7 @@ namespace umbriel {
       struct Scrolling {
         std::optional<double> defaultWidthFraction;
         bool centerUnderfullStrip = true;
-        bool centerFocused = false;
+        CenterFocusedColumn centerFocused = CenterFocusedColumn::Never;
         bool operator==(const Scrolling&) const = default;
       } scrolling;
       struct Dwindle {

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -32,6 +32,12 @@ namespace umbriel {
     Right,
   };
 
+  enum class CenterFocusedColumn {
+    Never,
+    Always,
+    OnOverflow,
+  };
+
   struct LayoutStruts {
     int left = 0;
     int right = 0;

--- a/src/layout/scrolling.cpp
+++ b/src/layout/scrolling.cpp
@@ -244,6 +244,7 @@ namespace umbriel {
       m_scroll = 0.0;
       m_centeredRest = false;
     }
+    m_lastFocusedColumn = -1;
     m_lastAvailableCross = 0;
     return true;
   }
@@ -595,7 +596,7 @@ namespace umbriel {
   }
 
   void ScrollingLayout::reconcileFocusedColumn(int columnIndex, int viewportPrimary) {
-    if (m_config->scrolling.centerFocused) {
+    if (alwaysCentersFocus()) {
       centerColumn(columnIndex, viewportPrimary);
       return;
     }
@@ -603,7 +604,45 @@ namespace umbriel {
     ensureVisible(columnIndex, viewportPrimary);
   }
 
-  double ScrollingLayout::targetScrollForEnsureVisible(int columnIndex, int viewportPrimary, bool force) const {
+  bool ScrollingLayout::alwaysCentersFocus() const {
+    return m_config->scrolling.centerFocused == CenterFocusedColumn::Always;
+  }
+
+  bool ScrollingLayout::shouldCenterFocusedColumn(int columnIndex, int viewportPrimary) const {
+    switch (m_config->scrolling.centerFocused) {
+    case CenterFocusedColumn::Always:
+      return true;
+    case CenterFocusedColumn::OnOverflow:
+      return shouldCenterOnOverflow(columnIndex, viewportPrimary);
+    case CenterFocusedColumn::Never:
+      break;
+    }
+    return false;
+  }
+
+  // Centers the column focus is moving to when it and the column on the side focus came from cannot share the
+  // viewport. The reference is the immediate neighbor, not the previously focused column, so a jump across the strip
+  // is judged by the same pair spacing as a step.
+  bool ScrollingLayout::shouldCenterOnOverflow(int columnIndex, int viewportPrimary) const {
+    const int columnCount = static_cast<int>(m_columns.size());
+    if (columnIndex < 0 || columnIndex >= columnCount) {
+      return false;
+    }
+    if (m_lastFocusedColumn < 0 || m_lastFocusedColumn >= columnCount || m_lastFocusedColumn == columnIndex) {
+      return false;
+    }
+    const int neighbor =
+        m_lastFocusedColumn > columnIndex ? std::min(columnIndex + 1, columnCount - 1) : std::max(columnIndex - 1, 0);
+    // Leading edge of the first column to trailing edge of the second, so the pair's own widths both count.
+    const int first = std::min(columnIndex, neighbor);
+    const int last = std::max(columnIndex, neighbor);
+    const int span =
+        columnX(last, viewportPrimary) - columnX(first, viewportPrimary) + columnWidth(last, viewportPrimary);
+    return span > viewportPrimary;
+  }
+
+  double
+  ScrollingLayout::targetScrollForEnsureVisible(int columnIndex, int viewportPrimary, bool center, bool force) const {
     if (columnIndex < 0 || columnIndex >= static_cast<int>(m_columns.size()) || viewportPrimary <= 0) {
       return m_scroll;
     }
@@ -615,7 +654,7 @@ namespace umbriel {
       const double cover = static_cast<double>(x) + static_cast<double>(width - viewportPrimary) / 2.0;
       return std::clamp(cover, 0.0, max);
     }
-    if (m_config->scrolling.centerFocused) {
+    if (center) {
       return static_cast<double>(x) - (viewportPrimary - width) / 2.0;
     }
     if (force) {
@@ -640,7 +679,8 @@ namespace umbriel {
     if (viewportPrimary <= 0) {
       return 0.0;
     }
-    return std::abs(targetScrollForEnsureVisible(columnIndex, viewportPrimary) - m_scroll)
+    const bool centered = shouldCenterFocusedColumn(columnIndex, viewportPrimary);
+    return std::abs(targetScrollForEnsureVisible(columnIndex, viewportPrimary, centered) - m_scroll)
         / static_cast<double>(viewportPrimary);
   }
 
@@ -664,15 +704,27 @@ namespace umbriel {
     return std::clamp(hidden, 0.0, span);
   }
 
-  void ScrollingLayout::ensureVisible(int columnIndex, int viewportPrimary) {
-    const double target = targetScrollForEnsureVisible(columnIndex, viewportPrimary, false);
-    m_centeredRest = m_config->scrolling.centerFocused || (m_centeredRest && target == m_scroll);
+  void ScrollingLayout::revealColumn(int columnIndex, int viewportPrimary, bool center) {
+    const double target = targetScrollForEnsureVisible(columnIndex, viewportPrimary, center, false);
+    m_centeredRest = center || (m_centeredRest && target == m_scroll);
     m_scroll = target;
   }
 
+  void ScrollingLayout::ensureVisible(int columnIndex, int viewportPrimary) {
+    revealColumn(columnIndex, viewportPrimary, alwaysCentersFocus());
+  }
+
+  void ScrollingLayout::activateColumn(int columnIndex, int viewportPrimary) {
+    revealColumn(columnIndex, viewportPrimary, shouldCenterFocusedColumn(columnIndex, viewportPrimary));
+    if (columnIndex >= 0) {
+      m_lastFocusedColumn = columnIndex;
+    }
+  }
+
   void ScrollingLayout::snapVisible(int columnIndex, int viewportPrimary) {
-    m_centeredRest = m_config->scrolling.centerFocused;
-    m_scroll = targetScrollForEnsureVisible(columnIndex, viewportPrimary, true);
+    const bool centered = alwaysCentersFocus();
+    m_centeredRest = centered;
+    m_scroll = targetScrollForEnsureVisible(columnIndex, viewportPrimary, centered, true);
   }
 
   void ScrollingLayout::arrange(const wlr_box& usable) {

--- a/src/layout/scrolling.h
+++ b/src/layout/scrolling.h
@@ -59,6 +59,7 @@ namespace umbriel {
     // while the lane still exists.
     [[nodiscard]] double scrollShiftForColumnRemoval(int columnIndex, int viewportPrimary) const;
     void ensureVisible(int columnIndex, int viewportPrimary);
+    void activateColumn(int columnIndex, int viewportPrimary);
     void snapVisible(int columnIndex, int viewportPrimary);
     [[nodiscard]] double scrollAmountToEnsureVisible(int columnIndex, int viewportPrimary) const;
     void arrange(const wlr_box& usable) override;
@@ -99,7 +100,13 @@ namespace umbriel {
     [[nodiscard]] int totalWidth(int viewportPrimary) const;
     [[nodiscard]] int rawTotalWidth(int viewportPrimary) const;
     [[nodiscard]] int centeringOffset(int viewportPrimary) const;
-    [[nodiscard]] double targetScrollForEnsureVisible(int columnIndex, int viewportPrimary, bool force = false) const;
+    [[nodiscard]] double
+    targetScrollForEnsureVisible(int columnIndex, int viewportPrimary, bool center, bool force = false) const;
+    [[nodiscard]] bool alwaysCentersFocus() const;
+    [[nodiscard]] bool shouldCenterFocusedColumn(int columnIndex, int viewportPrimary) const;
+    [[nodiscard]] bool shouldCenterOnOverflow(int columnIndex, int viewportPrimary) const;
+    // Shared body of ensureVisible and activateColumn: they differ only in which centering policy applies.
+    void revealColumn(int columnIndex, int viewportPrimary, bool center);
     [[nodiscard]] bool vertical() const;
     void syncHeightWeights(Column& column);
     // Weight for a row being added to `column` at `row`, taking over the column's edge gap when the row lands against
@@ -110,6 +117,8 @@ namespace umbriel {
     std::vector<Target> m_targets;
     double m_scroll = 0;
     bool m_centeredRest = false;
+    // Column the last activation focused, so CenterFocusedColumn::OnOverflow knows which side focus came from.
+    int m_lastFocusedColumn = -1;
     int m_lastViewportPrimary = 0;
     const LayoutSnapshot* m_pendingViewportSnapshot = nullptr;
     View* m_pendingViewportAnchor = nullptr;

--- a/src/server/focus.cpp
+++ b/src/server/focus.cpp
@@ -127,7 +127,7 @@ namespace umbriel {
     case FocusReason::Startup:
     case FocusReason::XdgActivation:
     case FocusReason::ForeignActivation:
-      workspace->ensureFocusedVisible();
+      workspace->activateFocusedColumn();
       workspace->markArrange(true);
       break;
     case FocusReason::Grab:

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1302,6 +1302,14 @@ namespace umbriel {
     scrolling->ensureVisible(scrolling->columnOf(m_focusedView), scrollViewportExtent());
   }
 
+  void Workspace::activateFocusedColumn() {
+    ScrollingLayout* scrolling = scrollingLayout();
+    if (scrolling == nullptr || m_group == nullptr || m_group->output() == nullptr) {
+      return;
+    }
+    scrolling->activateColumn(scrolling->columnOf(m_focusedView), scrollViewportExtent());
+  }
+
   void Workspace::snapVisible(const View* view) {
     ScrollingLayout* scrolling = scrollingLayout();
     if (scrolling == nullptr || m_group == nullptr || m_group->output() == nullptr) {

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -149,6 +149,7 @@ namespace umbriel {
     bool toggleFocusedFullscreen();
     bool toggleFocusedFloating();
     void ensureFocusedVisible();
+    void activateFocusedColumn();
     void snapVisible(const View* view);
     [[nodiscard]] double scrollFractionToReveal(const View* view) const;
     void applyVisibility();

--- a/tests/harness/checks/110_scrolling_layout.sh
+++ b/tests/harness/checks/110_scrolling_layout.sh
@@ -39,7 +39,7 @@ readonly EXPECT_W=624
 readonly EXPECT_H=700
 readonly EXPECT_CENTER_X=$(( (1280 - EXPECT_W) / 2 ))
 
-printf '\n[layout.scrolling]\ndefault_width_fraction = 0.5\ncenter_focused = false\n' >> "$UMBRIEL_CONFIG"
+printf '\n[layout.scrolling]\ndefault_width_fraction = 0.5\ncenter_focused = "never"\n' >> "$UMBRIEL_CONFIG"
 "$UMBRIEL" msg config-reload > /dev/null
 
 spawn_client a
@@ -83,10 +83,10 @@ fi
 # Reloading the focus policy applies it to the currently focused column.
 "$UMBRIEL" msg window-focus-right > /dev/null
 wait_for_x harness-b 646 "expected disabled center_focused to leave the last column at its bounded position"
-sed -i 's/center_focused = false/center_focused = true/' "$UMBRIEL_CONFIG"
+sed -i 's/center_focused = "never"/center_focused = "always"/' "$UMBRIEL_CONFIG"
 "$UMBRIEL" msg config-reload > /dev/null
 wait_for_x harness-b "$EXPECT_CENTER_X" "enabling center_focused did not center the focused column on reload"
-sed -i 's/center_focused = true/center_focused = false/' "$UMBRIEL_CONFIG"
+sed -i 's/center_focused = "always"/center_focused = "never"/' "$UMBRIEL_CONFIG"
 "$UMBRIEL" msg config-reload > /dev/null
 wait_for_x harness-b 646 "disabling center_focused did not restore the bounded focused-column position"
 

--- a/tests/harness/checks/513_scrolling_hover_focus_stability.sh
+++ b/tests/harness/checks/513_scrolling_hover_focus_stability.sh
@@ -43,7 +43,7 @@ mode = "scrolling"
 
 [layout.scrolling]
 default_width_fraction = 0.6
-center_focused = true
+center_focused = "always"
 
 [animation]
 duration_ms = 1200

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -653,6 +653,36 @@ layout.scrolling.direction = "vertical"
   CHECK(containsDiagnostic(store, "unknown key workspace[0].layout.scrolling.direction"));
 }
 
+UMBRIEL_TEST(centerFocusedReadsItsModeVocabulary) {
+  const TempConfig file;
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  file.write(R"(
+[layout.scrolling]
+center_focused = "on_overflow"
+
+[[workspace]]
+index = 1
+layout.scrolling.center_focused = "always"
+)");
+  CHECK(store.reload().success);
+  CHECK(store.config().layout.scrolling.centerFocused == umbriel::CenterFocusedColumn::OnOverflow);
+  CHECK_EQ(store.config().workspaceRules.size(), size_t{1});
+  CHECK(store.config().workspaceRules[0].layout.scrolling.centerFocused == umbriel::CenterFocusedColumn::Always);
+
+  file.write("[layout.scrolling]\ncenter_focused = \"sometimes\"\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().layout.scrolling.centerFocused == umbriel::CenterFocusedColumn::Never);
+  CHECK(containsDiagnostic(store, R"(unknown layout.scrolling.center_focused "sometimes")"));
+  CHECK(!containsDiagnostic(store, "unknown key layout.scrolling.center_focused"));
+
+  // The old boolean form is a hard error, not a silent fallback.
+  file.write("[layout.scrolling]\ncenter_focused = false\n");
+  CHECK(store.reload().success);
+  CHECK(containsDiagnostic(store, "layout.scrolling.center_focused must be a string"));
+}
+
 UMBRIEL_TEST(modKeyIsUserConfigurable) {
   const TempConfig file;
   ConfigStore& store = umbriel::configStore();

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -368,11 +368,11 @@ UMBRIEL_TEST(workspaceRulesCannotOverrideTheResolvedStripDirection) {
 
   WorkspaceConfig rule;
   rule.name = "dev";
-  rule.layout.scrolling.centerFocused = true;
+  rule.layout.scrolling.centerFocused = umbriel::CenterFocusedColumn::Always;
   config.workspaceRules.push_back(std::move(rule));
 
   const auto resolved = umbriel::resolveWorkspaceLayout(config, identity("DP-1"), "dev", 0);
-  CHECK(resolved.scrolling.centerFocused);
+  CHECK(resolved.scrolling.centerFocused == umbriel::CenterFocusedColumn::Always);
   CHECK(resolved.scrolling.direction == umbriel::ScrollingDirection::Vertical);
 }
 

--- a/tests/unit/scrolling_layout.cpp
+++ b/tests/unit/scrolling_layout.cpp
@@ -11,6 +11,7 @@
 #include <wlr/util/edges.h>
 // clang-format on
 
+using umbriel::CenterFocusedColumn;
 using umbriel::Column;
 using umbriel::Layout;
 using umbriel::LayoutConstraints;
@@ -904,7 +905,7 @@ UMBRIEL_TEST(snapVisibleCentersFullWidthColumn) {
 UMBRIEL_TEST(centerFocusedCentersAnInteriorColumn) {
   Fixture fixture;
   fixture.addColumns(3);
-  fixture.config.scrolling.centerFocused = true;
+  fixture.config.scrolling.centerFocused = CenterFocusedColumn::Always;
 
   fixture.layout.ensureVisible(1, kViewport);
 
@@ -918,7 +919,7 @@ UMBRIEL_TEST(centerFocusedCentersAnInteriorColumn) {
 UMBRIEL_TEST(centerFocusedAllowsEdgeColumnsToOverscroll) {
   Fixture fixture;
   fixture.addColumns(3);
-  fixture.config.scrolling.centerFocused = true;
+  fixture.config.scrolling.centerFocused = CenterFocusedColumn::Always;
 
   fixture.layout.ensureVisible(0, kViewport);
   CHECK(fixture.layout.scroll() < 0.0);
@@ -930,15 +931,70 @@ UMBRIEL_TEST(centerFocusedAllowsEdgeColumnsToOverscroll) {
 UMBRIEL_TEST(disablingCenterFocusedReturnsTheFocusedColumnToTheScrollRange) {
   Fixture fixture;
   fixture.addColumns(3);
-  fixture.config.scrolling.centerFocused = true;
+  fixture.config.scrolling.centerFocused = CenterFocusedColumn::Always;
   fixture.layout.reconcileFocusedColumn(2, kViewport);
   CHECK(fixture.layout.scroll() > static_cast<double>(fixture.layout.maxScroll(kViewport)));
 
-  fixture.config.scrolling.centerFocused = false;
+  fixture.config.scrolling.centerFocused = CenterFocusedColumn::Never;
   fixture.layout.reconcileFocusedColumn(2, kViewport);
 
   CHECK_EQ(fixture.layout.scroll(), static_cast<double>(fixture.layout.maxScroll(kViewport)));
   CHECK(!fixture.layout.centeredRest());
+}
+
+UMBRIEL_TEST(onOverflowCentersWhenTheColumnPairExceedsTheViewport) {
+  Fixture fixture;
+  fixture.config.scrolling.centerFocused = CenterFocusedColumn::OnOverflow;
+  fixture.addColumns(3);
+  // Two 700 wide columns plus the gap between them overrun the 1260 viewport.
+  for (int column = 0; column < 3; ++column) {
+    CHECK(fixture.layout.setWidthFromPixels(column, kViewport, 700));
+  }
+
+  // The first activation only records where focus came from.
+  fixture.layout.activateColumn(0, kViewport);
+  fixture.layout.activateColumn(1, kViewport);
+
+  const int centeredX = fixture.layout.columnX(1, kViewport)
+      + fixture.layout.columnWidth(1, kViewport) / 2
+      - static_cast<int>(std::lround(fixture.layout.scroll()));
+  CHECK_EQ(centeredX, kViewport / 2);
+  CHECK(fixture.layout.centeredRest());
+}
+
+UMBRIEL_TEST(onOverflowLeavesAFittingColumnPairAtTheEdge) {
+  Fixture fixture;
+  // Two 0.5-fraction columns and the gap between them fill the viewport exactly.
+  fixture.config.scrolling.centerFocused = CenterFocusedColumn::OnOverflow;
+  fixture.addColumns(3);
+
+  fixture.layout.activateColumn(0, kViewport);
+  fixture.layout.activateColumn(1, kViewport);
+
+  const int right = fixture.layout.columnX(1, kViewport) + fixture.layout.columnWidth(1, kViewport);
+  CHECK_EQ(fixture.layout.scroll(), static_cast<double>(right - kViewport));
+  CHECK(!fixture.layout.centeredRest());
+}
+
+// Focus moving left measures the pair by the neighbor on the right, whose width is the one that decides whether both
+// fit. Measuring the target twice instead would call this pair 1012 wide and leave it uncentered.
+UMBRIEL_TEST(onOverflowMeasuresTheRightHandColumnWhenFocusMovesLeft) {
+  Fixture fixture;
+  fixture.config.scrolling.centerFocused = CenterFocusedColumn::OnOverflow;
+  fixture.addColumns(3);
+  CHECK(fixture.layout.setWidthFromPixels(0, kViewport, 500));
+  CHECK(fixture.layout.setWidthFromPixels(1, kViewport, 500));
+  CHECK(fixture.layout.setWidthFromPixels(2, kViewport, 800));
+
+  // 500 + gap + 800 overruns the 1260 viewport, so stepping back onto column 1 centers it.
+  fixture.layout.activateColumn(2, kViewport);
+  fixture.layout.activateColumn(1, kViewport);
+
+  const int centeredX = fixture.layout.columnX(1, kViewport)
+      + fixture.layout.columnWidth(1, kViewport) / 2
+      - static_cast<int>(std::lround(fixture.layout.scroll()));
+  CHECK_EQ(centeredX, kViewport / 2);
+  CHECK(fixture.layout.centeredRest());
 }
 
 UMBRIEL_TEST(ensureVisibleIsANoOpForAnAlreadyVisibleColumn) {


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
Added `on_overflow` option for the `center_focused` setting.
```toml
center_focused = "never"
```
accepted values are `"never"`,  `"always"`, or `"on_overflow"`.

The `on_overflow` option will center if it doesn't fit on screen together with the previously focused column.

This is a breaking change, previous config is a bool, now it's a string.

## Motivation

<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Closes #100.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just format`
`just test`
`just lint`

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
The tests needs to be updated.