### PR TITLE
start-umbriel: dbus-run-session if needed

### DIFF
--- a/data/start-umbriel.in
+++ b/data/start-umbriel.in
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-drs=
-if [ -z "${DBUS_SESSION_BUS_ADDRESS}" ]; then
-  drs=dbus-run-session
+if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ] &&
+   command -v dbus-run-session >/dev/null 2>&1; then
+    drs=dbus-run-session
 fi
 
 if [ -n "${MANAGERPID:-}" ] && [ "${SYSTEMD_EXEC_PID:-}" = "$$" ]; then

--- a/data/start-umbriel.in
+++ b/data/start-umbriel.in
@@ -1,17 +1,22 @@
 #!/bin/sh
 
+drs=
+if [ -z "${DBUS_SESSION_BUS_ADDRESS}" ]; then
+  drs=dbus-run-session
+fi
+
 if [ -n "${MANAGERPID:-}" ] && [ "${SYSTEMD_EXEC_PID:-}" = "$$" ]; then
-  exec @UMBRIEL_EXECUTABLE@ "$@"
+  exec ${drs} @UMBRIEL_EXECUTABLE@ "$@"
 fi
 
 if [ -n "${WAYLAND_DISPLAY:-}" ] || [ -n "${WAYLAND_SOCKET:-}" ] ||
   [ -n "${DISPLAY:-}" ]; then
-  exec @UMBRIEL_EXECUTABLE@ "$@"
+  exec ${drs} @UMBRIEL_EXECUTABLE@ "$@"
 fi
 
 if ! command -v systemctl >/dev/null 2>&1 ||
   ! systemctl --user show-environment >/dev/null 2>&1; then
-  exec @UMBRIEL_EXECUTABLE@ "$@"
+  exec ${drs} @UMBRIEL_EXECUTABLE@ "$@"
 fi
 
 if systemctl --user --quiet is-active umbriel.service; then


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary
Let start-umbriel start a dbus session if one it not already running.

## Motivation

Avoid the need for non systemd users to manually have to edit their desktop file to append dbus-run-session to the exec line of the desktop file

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix (Non SystemD)
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Testing
just running the compositor with start-umbriel

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
