### PR TITLE
feat(workspaces): support min_workspaces for dynamic outputs

### DIFF
--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -102,12 +102,14 @@ umbriel workspaces --json | jq -r '.[] | select(.focused).layout'
 [workspaces]
 back_and_forth = true
 empty_above = false
+min_workspaces = 1
 ```
 
 | Key              | Type | Default | Description                                                                                     |
 | ---------------- | ---- | ------- | ----------------------------------------------------------------------------------------------- |
 | `back_and_forth` | bool | `false` | Re-selecting the active workspace jumps back to the previously active workspace on that output. |
 | `empty_above`    | bool | `false` | Add an empty workspace at the start, in addition to the workspace at the end.                    |
+| `min_workspaces` | int  | `1`     | Minimum number of workspaces to retain on dynamic outputs (1-64).                               |
 
 Output workspaces are dynamic by default. The workspace models and rules are
 documented below.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -37,6 +37,7 @@ honor_restored_maximize = false # let apps restore their saved maximized state
 [workspaces]
 back_and_forth = false
 empty_above = false
+min_workspaces = 1             # minimum number of workspaces to retain on dynamic outputs (1-64)
 
 # Colors ---------------------------------------------------------------------
 

--- a/src/config/change.cpp
+++ b/src/config/change.cpp
@@ -122,8 +122,10 @@ namespace umbriel {
         || !sameWindowTearingPolicy(before, after);
     const bool directScanoutPolicy =
         outputNamesChanged || outputProjectionChanged(before, after, sameOutputDirectScanoutPolicy);
-    const bool workspaceInventory =
-        outputNamesChanged || outputProjectionChanged(before, after, sameWorkspaceInventory);
+    const bool workspaceInventory = outputNamesChanged
+        || outputProjectionChanged(before, after, sameWorkspaceInventory)
+        || before.workspaces.emptyAbove != after.workspaces.emptyAbove
+        || before.workspaces.minWorkspaces != after.workspaces.minWorkspaces;
     const bool outputLayout = outputNamesChanged || outputProjectionChanged(before, after, sameOutputLayout);
     const bool sceneBlur =
         before.appearance.blur != after.appearance.blur || before.optimizedBlurNeeded() != after.optimizedBlurNeeded();

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -973,7 +973,8 @@ namespace umbriel {
     void readWorkspaceSettings(Section& root, Config& loaded) {
       root.sub("workspaces", [&](Section& s) {
         s.boolean("back_and_forth", loaded.workspaces.backAndForth)
-            .boolean("empty_above", loaded.workspaces.emptyAbove);
+            .boolean("empty_above", loaded.workspaces.emptyAbove)
+            .integer("min_workspaces", 1, static_cast<int>(kMaxWorkspaces), loaded.workspaces.minWorkspaces);
       });
     }
 

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -591,6 +591,7 @@ namespace umbriel {
       // Re-selecting the active workspace jumps back to the previous one.
       bool backAndForth = false;
       bool emptyAbove = false;
+      int minWorkspaces = 1;
       bool operator==(const Workspaces&) const = default;
     } workspaces;
 

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -370,7 +370,8 @@ namespace umbriel {
     ResolvedWorkspaceSet result;
     if (!names) {
       result.dynamic = true;
-      const size_t count = config.workspaces.emptyAbove ? 2 : 1;
+      const size_t minCount = static_cast<size_t>(std::max(1, config.workspaces.minWorkspaces));
+      const size_t count = config.workspaces.emptyAbove ? std::max(minCount, size_t{2}) : minCount;
       result.workspaces.reserve(count);
       for (size_t index = 0; index < count; ++index) {
         const std::string name = std::to_string(index + 1);

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1715,15 +1715,19 @@ namespace umbriel {
       backKeeper = m_workspaces.back().get();
     }
 
+    const size_t minWorkspaces = static_cast<size_t>(std::max(1, config().workspaces.minWorkspaces));
     for (size_t index = m_workspaces.size(); index-- > 0;) {
       Workspace* workspace = m_workspaces[index].get();
-      if (!workspace->hasViews() && workspace != backKeeper && workspace != frontKeeper) {
+      if (!workspace->hasViews() && workspace != backKeeper && workspace != frontKeeper && index >= minWorkspaces) {
         if (m_previous == workspace) {
           m_previous = nullptr;
         }
         m_workspaces.erase(m_workspaces.begin() + static_cast<std::ptrdiff_t>(index));
         m_server->scheduleIpcWorkspacesEvent();
       }
+    }
+    while (m_workspaces.size() < minWorkspaces) {
+      appendDynamicWorkspace();
     }
     if (backKeeper == nullptr) {
       appendDynamicWorkspace();

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -146,6 +146,15 @@ UMBRIEL_TEST(eachSectionIsReportedOnItsOwn) {
   }
   {
     Config after;
+    after.workspaces.minWorkspaces = 5;
+    const ConfigChange change = ConfigChange::between(before, after);
+    CHECK(change.workspaces);
+    const ConfigEffects effects = ConfigEffects::between(before, after);
+    CHECK(effects.workspaceInventory);
+    CHECK(effects.workspaceLayout);
+  }
+  {
+    Config after;
     after.animation.windowsMove.durationMs += 1;
     const ConfigChange change = ConfigChange::between(before, after);
     CHECK(change.animation);

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -600,6 +600,26 @@ UMBRIEL_TEST(hotCornersLoadActionsAndValidate) {
   CHECK(containsDiagnostic(store, "hot_corners.top_right.delay_ms = -1"));
 }
 
+UMBRIEL_TEST(workspacesMinWorkspacesLoads) {
+  const TempConfig file;
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  file.write("[workspaces]\nmin_workspaces = 4\n");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().workspaces.minWorkspaces, 4);
+
+  file.write("[workspaces]\nmin_workspaces = 0\n");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().workspaces.minWorkspaces, 1);
+  CHECK(containsDiagnostic(store, "clamped to 1"));
+
+  file.write("[workspaces]\nmin_workspaces = 100\n");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().workspaces.minWorkspaces, 64);
+  CHECK(containsDiagnostic(store, "clamped to 64"));
+}
+
 UMBRIEL_TEST(overviewBackgroundBlurLoads) {
   const TempConfig file;
   ConfigStore& store = umbriel::configStore();

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -233,6 +233,17 @@ UMBRIEL_TEST(workspaceInventoryResolvesStaticAndDynamicOutputs) {
     CHECK_EQ(dynamicSetWithEmptyAbove.workspaces[0].name, std::string{"1"});
     CHECK_EQ(dynamicSetWithEmptyAbove.workspaces[1].name, std::string{"2"});
   }
+
+  config.workspaces.emptyAbove = false;
+  config.workspaces.minWorkspaces = 3;
+  const auto dynamicSetWithMin = umbriel::resolveWorkspacesForOutput(config, identity("DP-2"));
+  CHECK(dynamicSetWithMin.dynamic);
+  CHECK_EQ(dynamicSetWithMin.workspaces.size(), size_t{3});
+  if (dynamicSetWithMin.workspaces.size() == 3) {
+    CHECK_EQ(dynamicSetWithMin.workspaces[0].name, std::string{"1"});
+    CHECK_EQ(dynamicSetWithMin.workspaces[1].name, std::string{"2"});
+    CHECK_EQ(dynamicSetWithMin.workspaces[2].name, std::string{"3"});
+  }
 }
 UMBRIEL_TEST(workspaceRulesMatchConnectorAndDescriptorWithoutOutputSection) {
   Config config;


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

Adds a `min_workspaces` configuration option (integer from 1 to 64, default 1) to `[workspaces]`.

When using dynamic workspaces on an output:
- Initial workspace resolution guarantees at least `min_workspaces` are created.
- During dynamic reconciliation (`WorkspaceGroup::reconcileDynamic()`), empty workspaces with indices `< min_workspaces` (0-based) are retained rather than pruned.
- Workspaces beyond `min_workspaces` continue to be dynamically created and destroyed as views open and close.
- Runtime changes to `min_workspaces` trigger `workspaceInventory` and `workspaceLayout` refreshes.

## Motivation

Users who enjoy dynamic workspaces often still want a persistent minimum set of workspaces (e.g. 3, 4, or 5) always available and visible in their status bar, dock, or overview without having to switch completely to static workspace rules.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

- Added unit tests:
  - `tests/unit/config_load.cpp`: verifies loading and clamping of `min_workspaces` (clamp to 1 min, 64 max).
  - `tests/unit/config_resolve.cpp`: verifies `resolveWorkspacesForOutput` produces at least `min_workspaces` on dynamic outputs.
  - `tests/unit/config_change.cpp`: verifies `ConfigEffects::between` reports `workspaceInventory` and `workspaceLayout` when `min_workspaces` changes.
- Automated tests passed:
  - `meson test -C build --no-suite umbrielfx` (all 35/35 unit tests passed).
- Code formatting verified with `clang-format`.

## Manual Coverage

- [x] Tested in a native Umbriel session
- [x] Tested with native Wayland applications
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

None.
