### PR TITLE
feat: add horizontal scroll to overview, with 2 or 3 fingers

### DIFF
--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -967,25 +967,45 @@ namespace umbriel {
 
     // Unmodified scrolling drives the overview filmstrip instead of the inert desktop under the cursor. Panels
     // (top/overlay) keep their own scrolling, and modifier chords still fall through to the wheel binds below.
-    if (Overview* overview = m_server->overview(); overview != nullptr && overview->active() && effective == 0) {
-      double sx = 0;
-      double sy = 0;
-      wlr_surface* surface = nullptr;
-      LayerSurface* layer = nullptr;
-      m_server->viewAt(m_cursor->x, m_cursor->y, &surface, &sx, &sy, &layer);
-      if (!overviewPassthroughLayer(layer)) {
-        if (!overview->interactive()) {
+    const bool isFingerScroll =
+        event->source == WL_POINTER_AXIS_SOURCE_FINGER || event->source == WL_POINTER_AXIS_SOURCE_CONTINUOUS;
+    if (isFingerScroll) {
+      Overview* overview = m_server->overview();
+      if (overview != nullptr && overview->active() && effective == 0) {
+        double sx = 0;
+        double sy = 0;
+        wlr_surface* surface = nullptr;
+        LayerSurface* layer = nullptr;
+        m_server->viewAt(m_cursor->x, m_cursor->y, &surface, &sx, &sy, &layer);
+        if (!overviewPassthroughLayer(layer)) {
+          if (!overview->interactive()) {
+            return;
+          }
+          if (isVertical) {
+            // Vertical 2-finger drives the filmstrip between workspaces.
+            m_wheelAccum[0] +=
+                event->delta_discrete != 0 ? static_cast<double>(event->delta_discrete) / 120.0 : event->delta / 15.0;
+            double& accumulated = m_wheelAccum[0];
+            while (std::abs(accumulated) >= 1.0) {
+              overview->handleAxisNotch(accumulated, m_cursor->x, m_cursor->y);
+              accumulated -= std::copysign(1.0, accumulated);
+            }
+          } else {
+            // Horizontal 2-finger scroll moves the strip like a 3-fingers swipe
+            Workspace* ws = overview->workspaceAt(m_cursor->x, m_cursor->y);
+            if (ws != nullptr && ws->scrollingLayout() != nullptr && !ws->scrollingVertical()) {
+              if (event->delta == 0 && event->delta_discrete == 0) {
+                m_server->gestures()->overviewWheelEnd(event->time_msec);
+              } else {
+                const double delta =
+                    event->delta_discrete != 0 ? static_cast<double>(event->delta_discrete) * 120.0 : event->delta;
+                m_server->gestures()->overviewWheel(ws, delta, event->time_msec);
+              }
+            }
+            m_wheelAccum[1] = 0;
+          }
           return;
         }
-        const int axis = isVertical ? 0 : 1;
-        m_wheelAccum[axis] +=
-            event->delta_discrete != 0 ? static_cast<double>(event->delta_discrete) / 120.0 : event->delta / 15.0;
-        double& accumulated = m_wheelAccum[axis];
-        while (std::abs(accumulated) >= 1.0) {
-          overview->handleAxisNotch(isVertical, accumulated, m_cursor->x, m_cursor->y);
-          accumulated -= std::copysign(1.0, accumulated);
-        }
-        return;
       }
     }
 

--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -130,6 +130,7 @@ namespace umbriel {
       m_scrollWorkspace = nullptr;
       m_switchGroup = nullptr;
       m_scrollSource = ScrollSource::None;
+      m_scrollOverview = false;
       m_state = State::Idle;
     }
   }
@@ -181,7 +182,7 @@ namespace umbriel {
       return;
     }
     WorkspaceGroup* group = m_output != nullptr ? m_output->workspaceGroup() : nullptr;
-    if (group == nullptr || group->active() != m_scrollWorkspace) {
+    if (!m_scrollOverview && (group == nullptr || group->active() != m_scrollWorkspace)) {
       finishScroll(true, timeMsec);
       return;
     }
@@ -225,6 +226,34 @@ namespace umbriel {
   void Gestures::endPointerScroll(bool cancelled, uint32_t timeMsec) {
     if (m_state == State::Scroll && m_scrollSource == ScrollSource::Pointer) {
       finishScroll(cancelled, timeMsec);
+    }
+  }
+
+  void Gestures::overviewWheel(Workspace* workspace, double delta, uint32_t timeMsec) {
+    if (workspace == nullptr || workspace->scrollingLayout() == nullptr || workspace->scrollingVertical()) {
+      return;
+    }
+    if (m_state == State::Scroll && m_scrollSource != ScrollSource::Pointer) {
+      return;
+    }
+    if (m_state != State::Scroll || m_scrollWorkspace != workspace || m_scrollSource != ScrollSource::Pointer) {
+      wlr_output* wlrOut = wlr_output_layout_output_at(
+          m_server->outputLayout(), m_server->cursor()->wlr()->x, m_server->cursor()->wlr()->y
+      );
+      m_output = m_server->outputFromWlr(wlrOut);
+      const double scale = static_cast<double>(workspace->scrollViewportExtent()) / kViewGestureMovementPx;
+      if (!beginScroll(workspace, scale, ScrollSource::Pointer)) {
+        m_output = nullptr;
+        return;
+      }
+      m_scrollOverview = true;
+    }
+    updateScroll(-delta, timeMsec);
+  }
+
+  void Gestures::overviewWheelEnd(uint32_t timeMsec) {
+    if (m_state == State::Scroll && m_scrollOverview && m_scrollSource == ScrollSource::Pointer) {
+      finishScroll(false, timeMsec);
     }
   }
 
@@ -285,6 +314,7 @@ namespace umbriel {
       m_accumX = 0;
       m_accumY = 0;
       m_output = nullptr;
+      m_scrollOverview = false;
       return;
     }
     m_state = State::Forward;
@@ -328,10 +358,19 @@ namespace umbriel {
       m_output = out;
 
       if (Overview* overview = m_server->overview(); overview != nullptr && overview->interactive()) {
-        // Horizontal has no meaning over the filmstrip, and letting it through
-        // would step rows on any swipe that drifted off true.
         if (std::abs(m_accumX) > std::abs(m_accumY)) {
-          m_state = State::Idle;
+          Workspace* ws = overview->workspaceAt(m_server->cursor()->wlr()->x, m_server->cursor()->wlr()->y);
+          if (ws == nullptr || ws->scrollingLayout() == nullptr || ws->scrollingVertical()) {
+            m_state = State::Idle;
+            return;
+          }
+          const double scale =
+              static_cast<double>(ws->scrollViewportExtent()) / kViewGestureMovementPx * m_naturalScrollDirection;
+          if (!beginScroll(ws, scale, ScrollSource::Swipe)) {
+            m_state = State::Idle;
+            return;
+          }
+          m_scrollOverview = true;
           return;
         }
         // Start measuring row travel from the lock point, not the touch down.
@@ -523,8 +562,10 @@ namespace umbriel {
   void Gestures::finishScroll(bool cancelled, uint32_t timeMsec) {
     Workspace* workspace = m_scrollWorkspace;
     Output* output = m_output;
+    const bool overviewMode = m_scrollOverview;
     m_state = State::Idle;
     m_scrollSource = ScrollSource::None;
+    m_scrollOverview = false;
     m_scrollWorkspace = nullptr;
     m_output = nullptr;
     if (workspace == nullptr) {
@@ -535,12 +576,17 @@ namespace umbriel {
       return;
     }
     WorkspaceGroup* group = output != nullptr ? output->workspaceGroup() : nullptr;
-    if (group == nullptr || group->active() != workspace) {
+    if (!overviewMode && (group == nullptr || group->active() != workspace)) {
       cancelled = true;
     }
     if (cancelled) {
       scrolling->setScroll(m_scrollStart, m_scrollStartCentered);
       workspace->markArrange(true);
+      if (overviewMode) {
+        if (Overview* overview = m_server->overview()) {
+          overview->refreshWorkspace(workspace);
+        }
+      }
       return;
     }
 
@@ -605,6 +651,11 @@ namespace umbriel {
     if (best < 0) {
       workspace->ensureFocusedVisible();
       workspace->markArrange(true);
+      if (overviewMode) {
+        if (Overview* overview = m_server->overview()) {
+          overview->refreshWorkspace(workspace);
+        }
+      }
       return;
     }
 
@@ -617,12 +668,30 @@ namespace umbriel {
       // Snap back / settle: target column already focused.
       workspace->ensureFocusedVisible();
       workspace->markArrange(true);
+      if (overviewMode) {
+        if (Overview* overview = m_server->overview()) {
+          overview->refreshWorkspace(workspace);
+        }
+      }
     } else if (!scrolling->columns()[static_cast<size_t>(best)].views.empty()) {
       View* target = scrolling->columns()[static_cast<size_t>(best)].views.front();
-      m_server->focusView(target, FocusReason::Directional);
+      if (overviewMode) {
+        workspace->setFocusedView(target);
+        workspace->markArrange(true);
+        if (Overview* overview = m_server->overview()) {
+          overview->refreshWorkspace(workspace);
+        }
+      } else {
+        m_server->focusView(target, FocusReason::Directional);
+      }
     } else {
       workspace->ensureFocusedVisible();
       workspace->markArrange(true);
+      if (overviewMode) {
+        if (Overview* overview = m_server->overview()) {
+          overview->refreshWorkspace(workspace);
+        }
+      }
     }
   }
 

--- a/src/input/gestures.h
+++ b/src/input/gestures.h
@@ -27,6 +27,8 @@ namespace umbriel {
     [[nodiscard]] bool beginPointerScroll();
     void updatePointerScroll(double dx, double dy, uint32_t timeMsec);
     void endPointerScroll(bool cancelled, uint32_t timeMsec);
+    void overviewWheel(Workspace* workspace, double delta, uint32_t timeMsec);
+    void overviewWheelEnd(uint32_t timeMsec);
 
   private:
     enum class State { Idle, Forward, Pending, Scroll, Switch, Overview, OverviewSelect };
@@ -74,6 +76,7 @@ namespace umbriel {
     bool m_scrollVertical = false;
     ScrollSource m_scrollSource = ScrollSource::None;
     SwipeTracker m_scrollTracker;
+    bool m_scrollOverview = false;
 
     // Switch state (vertical 3-finger).
     WorkspaceGroup* m_switchGroup = nullptr;

--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -1897,13 +1897,22 @@ namespace umbriel {
     return true;
   }
 
-  bool Overview::handleAxisNotch(bool vertical, double direction, double lx, double ly) {
-    if (!interactive() || !vertical) {
+  bool Overview::handleAxisNotch(double direction, double lx, double ly) {
+    if (!interactive()) {
       return true;
     }
     wlr_output* wlrOutput = wlr_output_layout_output_at(m_server->outputLayout(), lx, ly);
     selectRelativeWorkspace(direction < 0 ? -1 : 1, m_server->outputFromWlr(wlrOutput));
     return true;
+  }
+
+  Workspace* Overview::workspaceAt(double lx, double ly) { return rowAt(lx, ly, nullptr, nullptr, false); }
+
+  void Overview::refreshWorkspace(Workspace* workspace) {
+    if (OutputState* state = stateForWorkspace(workspace)) {
+      layoutOutput(*state);
+      wlr_output_schedule_frame(state->output->wlr());
+    }
   }
 
   void Overview::refreshShortcutMatches() {

--- a/src/overview/overview.h
+++ b/src/overview/overview.h
@@ -89,7 +89,7 @@ namespace umbriel {
     // Input entry points; called from Cursor/Keyboard while active.
     bool handleButton(uint32_t button, bool pressed, double lx, double ly);
     void handleMotion(double lx, double ly);
-    bool handleAxisNotch(bool vertical, double direction, double lx, double ly);
+    bool handleAxisNotch(double direction, double lx, double ly);
     bool handleFallbackKey(uint32_t keysym);
     // Give direct vertical focus actions overview-row semantics, clear pending
     // badge input for directional focus, and consume those actions while the
@@ -101,6 +101,9 @@ namespace umbriel {
     // up the real trees are hidden, so there is nothing to slide and switching is a discrete step rather than the
     // animated transition it is outside.
     bool selectRelativeWorkspace(int delta, Output* output);
+    // The workspace under the pointer, for horizontal scroll/drag over the filmstrip.
+    [[nodiscard]] Workspace* workspaceAt(double lx, double ly);
+    void refreshWorkspace(Workspace* workspace);
     [[nodiscard]] bool dragging() const { return m_dragCard != nullptr || m_middlePressed; }
 
   private:


### PR DESCRIPTION
<!-- If this PR is not ready for review yet, please mark it as Draft. -->

## Summary

<!-- What changed and why? -->
add 2 or 3 fingers horizontal scroll to the overview.

## Motivation

<!-- What problem does this solve? -->
Not being able to scroll the windows when the overview is open is very annoying.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
Closes #97.

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just format`
`just test`
`just lint`

I tested it with 2 or 3 fingers with my touchpad but I don't have a mouse with horizontal scroll wheel.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
