### PR TITLE
fix(cli): validate included config files

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -45,7 +45,7 @@ configuration from applying. Each entry names its file, line, and column.
 A panel that reports only warnings hides itself after ten seconds; one that
 reports an error stays until the next successful reload. At most six entries are
 listed, and the footer counts the rest. `umbriel validate` prints the full list
-without a running compositor.
+without a running compositor and exits nonzero when it reports a diagnostic.
 
 ## Include
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,17 +50,16 @@ namespace {
       std::println("config: ok ({})", umbriel::configRootPath().string());
       return EXIT_SUCCESS;
     }
-    bool hasError = false;
     for (const auto& d : diags) {
       const std::string loc = d.location();
       if (d.severity == umbriel::ConfigDiagnostic::Severity::Error) {
-        hasError = true;
         std::println(stderr, "error: {}{}", loc.empty() ? "" : loc + ": ", d.message);
       } else {
         std::println(stderr, "warning: {}{}", loc.empty() ? "" : loc + ": ", d.message);
       }
     }
-    return hasError ? EXIT_FAILURE : EXIT_SUCCESS;
+    std::println(stderr, "configuration invalid");
+    return EXIT_FAILURE;
   }
 
   void printHelp(FILE* stream) {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -60,6 +60,12 @@ foreach unit_test : unit_tests
   test(unit_test[0], test_exe)
 endforeach
 
+test(
+  'validate-config',
+  find_program('validate_config.sh'),
+  args: [umbriel],
+)
+
 # Harness helper, not a unit test: drives virtual pointer and modifier input against a running compositor. The headless backend has no input devices, so protocol
 # input is the only way to exercise pointer hit-testing and grabs.
 pointer_client = executable(

--- a/tests/validate_config.sh
+++ b/tests/validate_config.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -eu
+
+umbriel=$1
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+mkdir -p "$fixture/components/nested"
+
+expect_invalid() {
+  config=$1
+  expected=$2
+  if "$umbriel" validate -c "$config" >"$fixture/stdout" 2>"$fixture/stderr"; then
+    printf 'expected validation failure for %s\n' "$config" >&2
+    cat "$fixture/stderr" >&2
+    exit 1
+  fi
+  if ! grep -F "$expected" "$fixture/stderr" >/dev/null; then
+    printf 'expected diagnostic containing %s\n' "$expected" >&2
+    cat "$fixture/stderr" >&2
+    exit 1
+  fi
+  grep -F "configuration invalid" "$fixture/stderr" >/dev/null
+}
+
+cat >"$fixture/config.toml" <<'EOF'
+[include]
+files = ["components/layout.toml"]
+EOF
+cat >"$fixture/components/layout.toml" <<'EOF'
+[overview]
+zoom = 900
+EOF
+expect_invalid "$fixture/config.toml" "$fixture/components/layout.toml:2:8"
+
+cat >"$fixture/components/layout.toml" <<'EOF'
+[include]
+files = ["nested/broken.toml"]
+EOF
+cat >"$fixture/components/nested/broken.toml" <<'EOF'
+[overview
+zoom = 0.5
+EOF
+expect_invalid "$fixture/config.toml" "$fixture/components/nested/broken.toml:1:10"
+
+cat >"$fixture/config.toml" <<'EOF'
+[include]
+files = ["components/missing.toml"]
+EOF
+expect_invalid "$fixture/config.toml" "include not found: $fixture/components/missing.toml"
+
+cat >"$fixture/config.toml" <<'EOF'
+[include]
+files = ["components/layout.toml"]
+EOF
+cat >"$fixture/components/layout.toml" <<'EOF'
+[include]
+files = ["../config.toml"]
+EOF
+expect_invalid "$fixture/config.toml" "include cycle or duplicate skipped: $fixture/config.toml"
+
+cat >"$fixture/config.toml" <<'EOF'
+[include]
+files = ["components/layout.toml"]
+
+[layout]
+gap = 19
+EOF
+cat >"$fixture/components/layout.toml" <<'EOF'
+[layout]
+gap = 7
+EOF
+"$umbriel" validate -c "$fixture/config.toml" >"$fixture/stdout" 2>"$fixture/stderr"
+grep -F "config: ok ($fixture/config.toml)" "$fixture/stdout" >/dev/null


### PR DESCRIPTION
## Summary

Make `umbriel validate` fail when any diagnostic is reported while loading the complete effective configuration, including files referenced through [include].files. Include loading and validation were already shared with normal startup, but warning-level problems such as invalid values, missing files, and include cycles did not cause validate to return a failure status.

## Motivation

`umbriel validate` previously returned success when included files contained invalid Umbriel values or when an included file was missing. Those conditions were reported as warnings by the shared runtime loader, while the CLI only returned failure for error-severity diagnostics.

This made the command unreliable for scripts, editor integrations, and preflight checks because exit status `0` did not necessarily mean the complete effective configuration was valid.


## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Testing

- `just format`
- `meson compile -C build-debug`
- `meson test -C build-debug config-load validate-config --print-errorlogs`: 2 passed
- Manual CLI validation with an invalid value in an arbitrarily named include path (`extras/layout.toml`): reported the included file at line 2, column 8, printed `configuration invalid`, and exited with status 1
- Full `meson test -C build-debug --print-errorlogs`: 46 passed

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format`, or this PR has no C++ changes.
- [X] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [X] I functionally verified compositor behavior where automated checks are insufficient.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [X] I used canonical names for config keys, IPC actions, paths, and identifiers.
