### PR TITLE
fix(umbrielfx): enable GLES3 color paths

### DIFF
--- a/umbrielfx/internal/render/fx_renderer/shaders.h
+++ b/umbrielfx/internal/render/fx_renderer/shaders.h
@@ -156,7 +156,7 @@ struct tex_shader {
 };
 
 bool link_tex_program(struct tex_shader *shader, enum fx_tex_shader_source source,
-		bool effects, bool sample_clamp);
+		bool effects, bool sample_clamp, bool force_high_precision);
 
 struct output_shader {
 	GLuint program;

--- a/umbrielfx/render/fx_renderer/fx_renderer.c
+++ b/umbrielfx/render/fx_renderer/fx_renderer.c
@@ -418,7 +418,7 @@ struct wlr_renderer *fx_renderer_create(struct wlr_backend *backend) {
 	return renderer_autocreate(backend, -1);
 }
 
-static bool link_shaders(struct fx_renderer *renderer) {
+static bool link_shaders(struct fx_renderer *renderer, bool force_high_precision) {
 	// quad fragment shader
 	if (!link_quad_program(&renderer->shaders.quad, false)) {
 		wlr_log(WLR_ERROR, "Could not link quad shader");
@@ -454,66 +454,66 @@ static bool link_shaders(struct fx_renderer *renderer) {
 
 	// Basic fragment shaders
 	if (!link_tex_program(&renderer->shaders.tex_rgba,
-				SHADER_SOURCE_TEXTURE_RGBA, false, false)) {
+				SHADER_SOURCE_TEXTURE_RGBA, false, false, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_RGBA shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_rgbx,
-				SHADER_SOURCE_TEXTURE_RGBX, false, false)) {
+				SHADER_SOURCE_TEXTURE_RGBX, false, false, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_RGBX shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_ext,
-				SHADER_SOURCE_TEXTURE_EXTERNAL, false, false)) {
+				SHADER_SOURCE_TEXTURE_EXTERNAL, false, false, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_EXTERNAL shader");
 		goto error;
 	}
 
 	// Effects fragment shaders
 	if (!link_tex_program(&renderer->shaders.tex_effects_rgba,
-				SHADER_SOURCE_TEXTURE_RGBA, true, false)) {
+				SHADER_SOURCE_TEXTURE_RGBA, true, false, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_effects_RGBA shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_effects_rgbx,
-				SHADER_SOURCE_TEXTURE_RGBX, true, false)) {
+				SHADER_SOURCE_TEXTURE_RGBX, true, false, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_effects_RGBX shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_effects_ext,
-				SHADER_SOURCE_TEXTURE_EXTERNAL, true, false)) {
+				SHADER_SOURCE_TEXTURE_EXTERNAL, true, false, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_effects_EXTERNAL shader");
 		goto error;
 	}
 
 	// Sample-clamp fragment shaders for fractionally cropped surfaces
 	if (!link_tex_program(&renderer->shaders.tex_clamp_rgba,
-				SHADER_SOURCE_TEXTURE_RGBA, false, true)) {
+				SHADER_SOURCE_TEXTURE_RGBA, false, true, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_clamp_RGBA shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_clamp_rgbx,
-				SHADER_SOURCE_TEXTURE_RGBX, false, true)) {
+				SHADER_SOURCE_TEXTURE_RGBX, false, true, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_clamp_RGBX shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_clamp_ext,
-				SHADER_SOURCE_TEXTURE_EXTERNAL, false, true)) {
+				SHADER_SOURCE_TEXTURE_EXTERNAL, false, true, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_clamp_EXTERNAL shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_clamp_effects_rgba,
-				SHADER_SOURCE_TEXTURE_RGBA, true, true)) {
+				SHADER_SOURCE_TEXTURE_RGBA, true, true, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_clamp_effects_RGBA shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_clamp_effects_rgbx,
-				SHADER_SOURCE_TEXTURE_RGBX, true, true)) {
+				SHADER_SOURCE_TEXTURE_RGBX, true, true, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_clamp_effects_RGBX shader");
 		goto error;
 	}
 	if (!link_tex_program(&renderer->shaders.tex_clamp_effects_ext,
-				SHADER_SOURCE_TEXTURE_EXTERNAL, true, true)) {
+				SHADER_SOURCE_TEXTURE_EXTERNAL, true, true, force_high_precision)) {
 		wlr_log(WLR_ERROR, "Could not link tex_clamp_effects_EXTERNAL shader");
 		goto error;
 	}
@@ -579,7 +579,12 @@ struct wlr_renderer *fx_renderer_create_egl(struct wlr_egl *egl) {
 	renderer->drm_fd = -1;
 
 	wlr_log(WLR_INFO, "Creating umbrielfx renderer");
-	wlr_log(WLR_INFO, "Using %s", glGetString(GL_VERSION));
+	const char *gl_version = (const char *)glGetString(GL_VERSION);
+	wlr_log(WLR_INFO, "Using %s", gl_version);
+	int gles_major = 0;
+	const bool is_gles3 = gl_version != NULL &&
+		sscanf(gl_version, "OpenGL ES %d", &gles_major) == 1 &&
+		gles_major >= 3;
 	wlr_log(WLR_INFO, "GL vendor: %s", glGetString(GL_VENDOR));
 	wlr_log(WLR_INFO, "GL renderer: %s", glGetString(GL_RENDERER));
 	wlr_log(WLR_INFO, "Supported FX extensions: %s", exts_str);
@@ -604,6 +609,7 @@ struct wlr_renderer *fx_renderer_create_egl(struct wlr_egl *egl) {
 		check_gl_ext(exts_str, "GL_EXT_read_format_bgra");
 
 	renderer->exts.EXT_texture_type_2_10_10_10_REV =
+		is_gles3 ||
 		check_gl_ext(exts_str, "GL_EXT_texture_type_2_10_10_10_REV");
 
 	renderer->exts.OES_texture_half_float_linear =
@@ -684,7 +690,7 @@ struct wlr_renderer *fx_renderer_create_egl(struct wlr_egl *egl) {
 	)
 
 	// Link all shaders
-	if (!link_shaders(renderer)) {
+	if (!link_shaders(renderer, is_gles3)) {
 		goto error;
 	}
 

--- a/umbrielfx/render/fx_renderer/shaders.c
+++ b/umbrielfx/render/fx_renderer/shaders.c
@@ -278,11 +278,11 @@ bool link_quad_grad_round_program(struct quad_grad_round_shader *shader, int max
 }
 
 bool link_tex_program(struct tex_shader *shader, enum fx_tex_shader_source source,
-		bool effects, bool sample_clamp) {
+		bool effects, bool sample_clamp, bool force_high_precision) {
 	GLchar frag_src_part[8192];
 	GLchar frag_src[12288];
 	snprintf(frag_src_part, sizeof(frag_src_part),
-		tex_frag_src, source, effects, sample_clamp);
+		tex_frag_src, source, effects, sample_clamp, force_high_precision);
 	snprintf(frag_src, sizeof(frag_src),
 		"%s\n%s\n", frag_src_part, effects ? corner_alpha_frag_src : "");
 

--- a/umbrielfx/render/fx_renderer/shaders/tex.frag
+++ b/umbrielfx/render/fx_renderer/shaders/tex.frag
@@ -1,12 +1,13 @@
 #define SOURCE %d
 #define EFFECTS %d
 #define SAMPLE_CLAMP %d
+#define FORCE_HIGH_PRECISION %d
 
 #define SOURCE_TEXTURE_RGBA 1
 #define SOURCE_TEXTURE_RGBX 2
 #define SOURCE_TEXTURE_EXTERNAL 3
 
-#if !defined(SOURCE) || !defined(EFFECTS) || !defined(SAMPLE_CLAMP)
+#if !defined(SOURCE) || !defined(EFFECTS) || !defined(SAMPLE_CLAMP) || !defined(FORCE_HIGH_PRECISION)
 #error "Missing shader preamble"
 #endif
 
@@ -14,7 +15,7 @@
 #extension GL_OES_EGL_image_external : require
 #endif
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
+#if FORCE_HIGH_PRECISION || defined(GL_FRAGMENT_PRECISION_HIGH)
 precision highp float;
 #else
 precision mediump float;


### PR DESCRIPTION
## Summary

Enable the GLES3 core color paths in umbrielfx while preserving the existing GLES2 shader behavior.

## Motivation

GLES3 provides the packed 2_10_10_10 texture format as core functionality and supports high precision fragment floats. The renderer previously detected these capabilities only through extensions or compile-time shader macros, so valid GLES3 contexts could miss both paths.

This change detects the GLES major version from `GL_VERSION`, enables the core packed-texture path for GLES3, and passes the context capability into the texture shader preamble. GLES2 retains its existing `GL_FRAGMENT_PRECISION_HIGH` check and `mediump` fallback.

## Type of Change

- [x] Bug fix

## Testing

- `just format`
- `just test`
- All 50 tests passed on the final GLES2-compatible implementation.

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [ ] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
