### PR TITLE
feat(config): support optional includes

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -51,12 +51,21 @@ without a running compositor and exits nonzero when it reports a diagnostic.
 
 ```toml
 [include]
-files = ["appearance.toml", "keybinds.toml"]
+files = [
+    "appearance.toml",
+    "keybinds.toml",
+    "?~/.config/umbriel/noctalia.toml",
+]
 ```
 
-Paths are resolved relative to the main config file. A leading `~` or `~/`
-expands to your home directory, and `$VAR` or `${VAR}` expands environment
-variables. Later files override earlier files, and values in the main file
+Paths are resolved relative to the main config file.
+
+**Prefix Modifiers and Variables**
+* `?`: Marks a file as optional; missing files are silently ignored.
+* `~` or `~/`: Expands to the user's home directory.
+* `$VAR` or `${VAR}`: Expands environment variables.
+
+Later files override earlier files, and values in the main file
 override every include.
 
 `files` is the only key `[include]` accepts. Anything else in the section is

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -54,22 +54,28 @@ without a running compositor and exits nonzero when it reports a diagnostic.
 files = [
     "appearance.toml",
     "keybinds.toml",
-    "?~/.config/umbriel/noctalia.toml",
+]
+
+[include.optional]
+files = [
+    "~/.config/umbriel/noctalia.toml",
 ]
 ```
 
-Paths are resolved relative to the main config file.
+Paths are resolved relative to the file that declares them. `~` and `~/`
+expand to the user's home directory. `$VAR` and `${VAR}` expand environment
+variables.
 
-**Prefix Modifiers and Variables**
-* `?`: Marks a file as optional; missing files are silently ignored.
-* `~` or `~/`: Expands to the user's home directory.
-* `$VAR` or `${VAR}`: Expands environment variables.
+Missing files in `[include.optional]` are silently ignored and remain watched.
+Creating one applies it without a restart. An optional file that exists must
+contain valid TOML.
 
-Later files override earlier files, and values in the main file
-override every include.
+Files in `[include]` are applied in list order, followed by files in
+`[include.optional]`. Values in the including file override every include.
 
-`files` is the only key `[include]` accepts. Anything else in the section is
-reported as an unknown key, in the main config and in included files alike.
+`[include]` accepts `files` and the `optional` sub-table.
+`[include.optional]` accepts only `files`. Anything else is reported as an
+unknown key, in the main config and in included files alike.
 
 You can split your config into multiple files for clarity:
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -13,14 +13,18 @@
 # Complete documentation: https://docs.noctalia.dev/umbriel/
 
 # ─────────────────────────────── Includes ───────────────────────────────────
-# Split large configurations into smaller files. Included files are applied in
-# list order, then values in this main file take precedence over every include.
-# Relative paths start from the directory containing this file.
+# Split large configurations into smaller files. Required files are applied in
+# list order, followed by optional files, then values in this main file.
+# Missing optional files are silently ignored and remain watched. Relative
+# paths start from the directory containing this file.
 # Documentation: https://docs.noctalia.dev/umbriel/configuration/#include
 # ────────────────────────────────────────────────────────────────────────────
 
 [include]
-files = []                                      # Example: ["noctalia.toml", "outputs.toml"]
+files = []                                      # Example: ["appearance.toml", "outputs.toml"]
+
+[include.optional]
+files = []                                      # Example: ["~/.config/umbriel/noctalia.toml"]
 
 # ─────────────────────────────── General ────────────────────────────────────
 # Configure startup commands, session behavior, environment variables, and

--- a/src/config/config_merge.cpp
+++ b/src/config/config_merge.cpp
@@ -284,19 +284,30 @@ namespace umbriel::configmerge {
     toml::table
     loadAndExpand(const std::filesystem::path& path, std::set<std::filesystem::path>& visited, MergeResult& result) {
       toml::table parsed;
+      auto pathStr = path.string();
+      const bool optional = pathStr.starts_with("?");
+      if (optional) {
+        pathStr = pathStr.erase(0, 1);
+      }
+
       try {
-        parsed = toml::parse_file(path.string());
+        parsed = toml::parse_file(pathStr);
       } catch (const toml::parse_error& error) {
         result.hadParseError = true;
-        const auto key = canonicalKey(path);
+        const auto key = canonicalKey(pathStr);
         if (std::ranges::find(result.loadedFiles, key) == result.loadedFiles.end()) {
           result.loadedFiles.push_back(key);
         }
+
+        if (optional && !std::filesystem::exists(pathStr)) {
+          return {};
+        }
+
         auto source = error.source();
         if (source.path == nullptr) {
-          source.path = std::make_shared<const std::string>(path.string());
+          source.path = std::make_shared<const std::string>(pathStr);
         }
-        emit(result, ConfigDiagnostic::Severity::Error, &source, parseErrorMessage(error, path));
+        emit(result, ConfigDiagnostic::Severity::Error, &source, parseErrorMessage(error, pathStr));
         return {};
       }
       return expandFile(path, std::move(parsed), visited, result);

--- a/src/config/config_merge.cpp
+++ b/src/config/config_merge.cpp
@@ -189,8 +189,40 @@ namespace umbriel::configmerge {
         std::string path;
         toml::source_region source;
       };
-      std::vector<Entry> entries;
+      std::vector<Entry> files;
+      std::vector<Entry> optionalFiles;
     };
+
+    void readIncludeFiles(
+        const toml::node* node, std::string_view name, std::vector<IncludeDirective::Entry>& entries,
+        MergeResult& result
+    ) {
+      if (node == nullptr) {
+        return;
+      }
+      const auto* files = node->as_array();
+      if (files == nullptr) {
+        emit(
+            result, ConfigDiagnostic::Severity::Warning, &node->source(),
+            std::format("ignoring {} (expected array of strings)", name)
+        );
+        return;
+      }
+      for (const auto& entry : *files) {
+        if (!entry.is_string()) {
+          emit(
+              result, ConfigDiagnostic::Severity::Warning, &entry.source(),
+              std::format("ignoring {} (expected array of strings)", name)
+          );
+          entries.clear();
+          return;
+        }
+        entries.push_back({
+            .path = *entry.value<std::string>(),
+            .source = entry.source(),
+        });
+      }
+    }
 
     IncludeDirective readInclude(const toml::table& table, MergeResult& result) {
       IncludeDirective directive;
@@ -206,32 +238,10 @@ namespace umbriel::configmerge {
       // `include` is erased from the table before the config readers run, so the root section never sees it and never
       // reports its unknown keys. This reader owns that report for the section's fixed vocabulary.
       Section keys(*include, "include", result.diagnostics);
-      const toml::node* filesNode = keys.take("files");
-      if (filesNode == nullptr) {
-        return directive;
-      }
-      const auto* files = filesNode->as_array();
-      if (files == nullptr) {
-        emit(
-            result, ConfigDiagnostic::Severity::Warning, &filesNode->source(),
-            "ignoring include.files (expected array of strings)"
-        );
-        return directive;
-      }
-      for (const auto& entry : *files) {
-        if (!entry.is_string()) {
-          emit(
-              result, ConfigDiagnostic::Severity::Warning, &entry.source(),
-              "ignoring include.files (expected array of strings)"
-          );
-          directive.entries.clear();
-          return directive;
-        }
-        directive.entries.push_back({
-            .path = *entry.value<std::string>(),
-            .source = entry.source(),
-        });
-      }
+      readIncludeFiles(keys.take("files"), "include.files", directive.files, result);
+      keys.sub("optional", [&](Section& optional) {
+        readIncludeFiles(optional.take("files"), "include.optional.files", directive.optionalFiles, result);
+      });
       return directive;
     }
 
@@ -256,27 +266,34 @@ namespace umbriel::configmerge {
       IncludeDirective directive = readInclude(parsed, result);
       parsed.erase("include");
 
-      if (directive.entries.empty()) {
+      if (directive.files.empty() && directive.optionalFiles.empty()) {
         // No includes: return parsed directly, preserving toml++ source regions
         // (copies lose them; only moves keep line/column/path).
         return parsed;
       }
 
       toml::table base;
-      for (const auto& entry : directive.entries) {
-        const auto target = expandPath(entry.path, path.parent_path());
-        std::error_code error;
-        if (std::filesystem::is_regular_file(target, error) && !error) {
-          deepMerge(base, loadAndExpand(target, visited, result));
-          continue;
+      const auto mergeEntries = [&](const std::vector<IncludeDirective::Entry>& entries, bool optional) {
+        for (const auto& entry : entries) {
+          const auto target = expandPath(entry.path, path.parent_path());
+          std::error_code error;
+          if (std::filesystem::is_regular_file(target, error) && !error) {
+            deepMerge(base, loadAndExpand(target, visited, result));
+            continue;
+          }
+          result.loadedFiles.push_back(canonicalKey(target));
+          if (optional) {
+            continue;
+          }
+          result.missingIncludes = true;
+          emit(
+              result, ConfigDiagnostic::Severity::Warning, &entry.source,
+              std::format("include not found: {} (from {})", target.string(), path.string())
+          );
         }
-        result.missingIncludes = true;
-        emit(
-            result, ConfigDiagnostic::Severity::Warning, &entry.source,
-            std::format("include not found: {} (from {})", target.string(), path.string())
-        );
-        result.loadedFiles.push_back(canonicalKey(target));
-      }
+      };
+      mergeEntries(directive.files, false);
+      mergeEntries(directive.optionalFiles, true);
       deepMerge(base, std::move(parsed));
       return base;
     }
@@ -284,30 +301,19 @@ namespace umbriel::configmerge {
     toml::table
     loadAndExpand(const std::filesystem::path& path, std::set<std::filesystem::path>& visited, MergeResult& result) {
       toml::table parsed;
-      auto pathStr = path.string();
-      const bool optional = pathStr.starts_with("?");
-      if (optional) {
-        pathStr = pathStr.erase(0, 1);
-      }
-
       try {
-        parsed = toml::parse_file(pathStr);
+        parsed = toml::parse_file(path.string());
       } catch (const toml::parse_error& error) {
         result.hadParseError = true;
-        const auto key = canonicalKey(pathStr);
+        const auto key = canonicalKey(path);
         if (std::ranges::find(result.loadedFiles, key) == result.loadedFiles.end()) {
           result.loadedFiles.push_back(key);
         }
-
-        if (optional && !std::filesystem::exists(pathStr)) {
-          return {};
-        }
-
         auto source = error.source();
         if (source.path == nullptr) {
-          source.path = std::make_shared<const std::string>(pathStr);
+          source.path = std::make_shared<const std::string>(path.string());
         }
-        emit(result, ConfigDiagnostic::Severity::Error, &source, parseErrorMessage(error, pathStr));
+        emit(result, ConfigDiagnostic::Severity::Error, &source, parseErrorMessage(error, path));
         return {};
       }
       return expandFile(path, std::move(parsed), visited, result);

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -1262,7 +1262,7 @@ UMBRIEL_TEST(unknownIncludeKeysAreReported) {
   // The merge erases `include` before the config readers run, so the merge is the only place that can report a typo in
   // this section. Every file's own `include` table is checked, not just the root's.
   const TempConfig file;
-  file.write("[include]\nfiles = [\"" + file.includeName() + "\"]\ndirs = [\"themes\"]\n");
+  file.write("[include]\nfiles = [\"" + file.includeName() + ", \"missing_file\"\"]\ndirs = [\"themes\"]\n");
   file.writeInclude("[include]\npaths = []\n");
 
   ConfigStore& store = umbriel::configStore();

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -1262,7 +1262,7 @@ UMBRIEL_TEST(unknownIncludeKeysAreReported) {
   // The merge erases `include` before the config readers run, so the merge is the only place that can report a typo in
   // this section. Every file's own `include` table is checked, not just the root's.
   const TempConfig file;
-  file.write("[include]\nfiles = [\"" + file.includeName() + ", \"missing_file\"\"]\ndirs = [\"themes\"]\n");
+  file.write("[include]\nfiles = [\"" + file.includeName() + "\"]\ndirs = [\"themes\"]\n");
   file.writeInclude("[include]\npaths = []\n");
 
   ConfigStore& store = umbriel::configStore();
@@ -1273,6 +1273,73 @@ UMBRIEL_TEST(unknownIncludeKeysAreReported) {
   CHECK(containsDiagnostic(store, "unknown key include.dirs"));
   CHECK(containsDiagnostic(store, "unknown key include.paths"));
   CHECK(!containsDiagnostic(store, "unknown key include.files"));
+}
+
+UMBRIEL_TEST(missingOptionalIncludesAreSilentWatchedAndLoadWhenCreated) {
+  const TempConfigTree tree;
+  const std::filesystem::path optional = tree.path("generated/colors.toml");
+  tree.write("config.toml", "[include.optional]\nfiles = [\"generated/colors.toml\"]\n");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(tree.path("config.toml"), true);
+  const umbriel::ConfigReloadResult missing = store.reload();
+
+  CHECK(missing.success);
+  CHECK(!store.missingIncludes());
+  CHECK(!containsDiagnostic(store, "include not found"));
+  CHECK(std::ranges::find(store.watchPaths(), optional) != store.watchPaths().end());
+
+  tree.write("generated/colors.toml", "[colors]\naccent_primary = \"#123456FF\"\n");
+  const umbriel::ConfigReloadResult loaded = store.reload();
+
+  CHECK(loaded.success);
+  CHECK(!store.missingIncludes());
+  CHECK(!containsDiagnostic(store, "include not found"));
+  CHECK_EQ(store.config().colors.accentPrimary[0], 18.0F / 255.0F);
+}
+
+UMBRIEL_TEST(optionalIncludesExpandPathsAndApplyAfterRequiredIncludes) {
+  const TempConfigTree tree;
+  const ScopedEnvironment home("HOME", tree.path("home").string());
+  const ScopedEnvironment generated("UMBRIEL_OPTIONAL_INCLUDE", tree.path("generated.toml").string());
+  tree.write("required.toml", "[layout]\ngap = 11\n");
+  tree.write("generated.toml", "[layout]\ngap = 22\n");
+  tree.write("home/override.toml", "[layout]\ngap = 33\n");
+  tree.write(
+      "config.toml",
+      "[include]\nfiles = [\"required.toml\"]\n"
+      "[include.optional]\nfiles = [\"$UMBRIEL_OPTIONAL_INCLUDE\", \"~/override.toml\"]\n"
+  );
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(tree.path("config.toml"), true);
+  const umbriel::ConfigReloadResult loaded = store.reload();
+
+  CHECK(loaded.success);
+  CHECK_EQ(store.config().layout.gap, 33);
+  CHECK(!containsDiagnostic(store, "unknown key include.optional"));
+}
+
+UMBRIEL_TEST(malformedOptionalIncludeRejectsReload) {
+  const TempConfigTree tree;
+  tree.write(
+      "config.toml",
+      "[layout]\ngap = 7\n"
+      "[include.optional]\nfiles = [\"generated.toml\"]\n"
+  );
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(tree.path("config.toml"), true);
+  CHECK(store.reload().success);
+  const uint64_t generation = store.generation();
+
+  tree.write("generated.toml", "[layout\n");
+  const umbriel::ConfigReloadResult malformed = store.reload();
+
+  CHECK(!malformed.success);
+  CHECK_EQ(store.generation(), generation);
+  CHECK_EQ(store.config().layout.gap, 7);
+  CHECK(!store.diagnostics().empty());
 }
 
 UMBRIEL_TEST(mainFileOverridesIncludedFiles) {


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Allow prefixing paths with a `?` in `include.files`, so they can be ignored if not present. Inspired by similar functionality in [ghostty](https://ghostty.org/docs/config#splitting-into-multiple-files).

## Motivation

Prevents errors when trying to include absolute paths to the home directory while validating within the nix sandbox, which does not have access to /home. Also prevents the brief flash of an error when generated files like noctalia colors are briefly deleted before being recreated.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [ ] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes