### PR TITLE
fix(input): suppress releases of consumed keys

### DIFF
--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -328,11 +328,15 @@ namespace umbriel {
           sheet->hide();
         }
       }
+      if (handled) {
+        m_consumedKeycodes.insert(event->keycode);
+      }
     } else if (event->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
       if (m_repeatArmed && event->keycode == m_repeatKeycode) {
         cancelRepeat();
       }
       modifierTap = m_server->releaseModifierTap(this, event->keycode);
+      handled = m_consumedKeycodes.erase(event->keycode) > 0;
     }
 
     if (!handled) {

--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <wayland-server-core.h>
 #include <xkbcommon/xkbcommon.h>
 
@@ -73,6 +74,10 @@ namespace umbriel {
     uint32_t m_repeatKeycode = 0;
     int m_repeatIntervalMs = 0;
     bool m_repeatArmed = false;
+    // A keybind consumes both halves of its key event. Without remembering the
+    // press, the release reaches the focused client as a release-only key and
+    // applications may still act on it (for example, Space toggling playback).
+    std::unordered_set<uint32_t> m_consumedKeycodes;
   };
 
 } // namespace umbriel


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

<!-- What changed and why? -->
Track consumed key presses by physical keycode per keyboard and suppress their matching releases.

## Motivation

<!-- What problem does this solve? -->
Super+Space opens the launcher but can also toggle playback in the focused browser. The binding consumes the Space press, but its release is still forwarded to the client.

The original behavior was reproduced in both Zen and Helium under Umbriel and did not occur under Niri.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- `git diff --check`: passed.
- `just lint release`: clean rebuild passed without compiler warnings. Clang-tidy reported one finding in unchanged code: `src/view/view.cpp:440` (`modernize-loop-convert`). No findings in the changed keyboard files.
- `meson test -C build-release --print-errorlogs`: 46 passed, 5 failed. Failures were in the separate umbrielfx color tests: one PQ roundtrip mismatch and four FP16 tests reporting unsupported pixel readback format `0x30334241`. These tests do not link the modified keyboard code.
- Manually verified the playback fix in a nested Umbriel session.


## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [ ] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->
release: 
https://github.com/user-attachments/assets/e78a454d-6fae-47ce-8639-328577e0e07b
fix:
https://github.com/user-attachments/assets/3947d083-ea42-44d9-ae4a-50eff61be7cc

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
