### PR TITLE
fix(workspace): enforce the runtime workspace limit

### DIFF
--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -4,7 +4,7 @@ Choose a workspace model, inspect its state, and customize layout per workspace.
 
 ## Choose a workspace model
 
-Each output can use dynamic or static workspaces.
+Each output can use dynamic or static workspaces, up to 64 including empty ones.
 
 ### Dynamic workspaces
 

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -5,6 +5,8 @@ Choose a workspace model, inspect its state, and customize layout per workspace.
 ## Choose a workspace model
 
 Each output can use dynamic or static workspaces, up to 64 including empty ones.
+At the limit, a workspace transfer reuses an empty destination on a dynamic
+output and is rejected when it would require another workspace.
 
 ### Dynamic workspaces
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -98,6 +98,7 @@ honor_restored_maximize = false                 # Honor restored maximized state
 # ────────────────────────────────────────────────────────────────────────────
 
 [workspaces]
+# Each output supports at most 64 workspaces, including empty ones.
 back_and_forth = false                          # Re-select active workspace to switch back
 empty_above = false                             # Keep one empty workspace above active range
 

--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -2085,7 +2085,7 @@ namespace umbriel {
         continue;
       }
       WorkspaceGroup* group = state->output->workspaceGroup();
-      if (group == nullptr || !group->dynamic()) {
+      if (group == nullptr || !group->dynamic() || group->workspaceCount() >= kMaxWorkspaces) {
         continue;
       }
       const size_t rowCount = std::min(group->workspaceCount(), state->workspaceBackgrounds.size());

--- a/src/server/actions.cpp
+++ b/src/server/actions.cpp
@@ -1131,6 +1131,9 @@ namespace umbriel {
         return reject(error, "output has no workspace");
       }
       Workspace* destination = targetGroup->createWorkspace(source->name().c_str());
+      if (destination == nullptr) {
+        return reject(error, "output workspace limit reached");
+      }
       View* focused = source->focusedView();
 
       // Snapshot the source contents first: every setWorkspace below triggers reconcileDynamic on both groups, and

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -2060,8 +2060,14 @@ namespace umbriel {
 
   Workspace* WorkspaceGroup::createWorkspace(const char* name) {
     if (m_dynamic) {
-      kLog.debug("using trailing dynamic workspace for create request on {}", m_output->wlr()->name);
-      return m_workspaces.empty() ? appendDynamicWorkspace() : m_workspaces.back().get();
+      const auto empty = std::ranges::find_if(m_workspaces.rbegin(), m_workspaces.rend(), [](const auto& workspace) {
+        return !workspace->hasViews();
+      });
+      if (empty != m_workspaces.rend()) {
+        kLog.debug("using empty dynamic workspace for create request on {}", m_output->wlr()->name);
+        return empty->get();
+      }
+      return insertDynamicWorkspace(m_workspaces.size());
     }
     if (m_workspaces.size() >= kMaxWorkspaces) {
       return nullptr;

--- a/src/workspace/workspace.cpp
+++ b/src/workspace/workspace.cpp
@@ -1576,7 +1576,7 @@ namespace umbriel {
   }
 
   Workspace* WorkspaceGroup::insertDynamicWorkspace(size_t index) {
-    if (!m_dynamic || m_output == nullptr || m_output->wlr() == nullptr) {
+    if (!m_dynamic || m_output == nullptr || m_output->wlr() == nullptr || m_workspaces.size() >= kMaxWorkspaces) {
       return nullptr;
     }
     index = std::min(index, m_workspaces.size());
@@ -1747,7 +1747,7 @@ namespace umbriel {
       return;
     }
 
-    // Dynamic groups keep one trailing empty workspace. Prefer an empty active workspace so closing its last window
+    // Dynamic groups keep a trailing empty below the limit. Prefer an empty active workspace so closing its last window
     // does not destroy the workspace the user is currently viewing; otherwise retain the existing trailing empty to
     // avoid replacing its protocol identity on every reconciliation.
     const bool emptyAbove = config().workspaces.emptyAbove;
@@ -1789,10 +1789,10 @@ namespace umbriel {
     while (m_workspaces.size() < minimum) {
       backKeeper = appendDynamicWorkspace();
     }
-    if (backKeeper == nullptr) {
+    if (backKeeper == nullptr && m_workspaces.size() < kMaxWorkspaces) {
       appendDynamicWorkspace();
     }
-    if (emptyAbove && frontKeeper == nullptr) {
+    if (emptyAbove && frontKeeper == nullptr && m_workspaces.size() < kMaxWorkspaces) {
       prependDynamicWorkspace();
     }
 
@@ -2062,6 +2062,9 @@ namespace umbriel {
     if (m_dynamic) {
       kLog.debug("using trailing dynamic workspace for create request on {}", m_output->wlr()->name);
       return m_workspaces.empty() ? appendDynamicWorkspace() : m_workspaces.back().get();
+    }
+    if (m_workspaces.size() >= kMaxWorkspaces) {
+      return nullptr;
     }
 
     wlr_ext_workspace_manager_v1* manager = m_server->workspaceManager();

--- a/src/workspace/workspace.h
+++ b/src/workspace/workspace.h
@@ -234,6 +234,8 @@ namespace umbriel {
     void activate(Workspace* workspace, bool animate = true);
     void select(Workspace* workspace);
     void deactivate(Workspace* workspace);
+    // Dynamic groups reuse their highest empty workspace before appending. Returns null when no workspace can be
+    // allocated within the per-output limit.
     Workspace* createWorkspace(const char* name);
     // Insert an empty numbered workspace into a dynamic group and renumber the following workspaces. Static configured
     // groups cannot be extended this way and return null.

--- a/tests/harness/checks/216_min_workspaces.sh
+++ b/tests/harness/checks/216_min_workspaces.sh
@@ -83,4 +83,17 @@ write_config '[output.HEADLESS-1]
 min_workspaces = 4'
 expect_names HEADLESS-1 "1 2 3 4" "static inventory replaced by a floored dynamic one"
 
+write_config '[workspaces]
+empty_above = true
+[output.HEADLESS-1]
+min_workspaces = 64'
+"$UMBRIEL" msg workspace-switch:64/HEADLESS-1 > /dev/null
+foot --title=workspace-limit-view sleep 120 > /dev/null 2>&1 &
+wait_for_windows 1
+expect_names HEADLESS-1 "$(seq -s ' ' 64)" "trailing empty respects the limit"
+[[ $(workspace_index_of_window) == 64 ]]
+"$UMBRIEL" msg window-move-to-workspace:1/HEADLESS-1 > /dev/null
+expect_names HEADLESS-1 "$(seq -s ' ' 64)" "leading empty respects the limit"
+[[ $(workspace_index_of_window) == 1 ]]
+
 echo "min_workspaces holds a per-output floor, grows above it, and prunes back to it"

--- a/tests/harness/checks/216_min_workspaces.sh
+++ b/tests/harness/checks/216_min_workspaces.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # harness: outputs=2
 # min_workspaces is a per-output floor on the dynamic workspace count. The configured output holds its floor while
-# every workspace is empty, still grows a trailing empty above it, prunes back down to it, and leaves the other
-# output's inventory alone. Lowering the floor on reload shrinks the inventory again.
+# every workspace is empty, grows and prunes around it, and leaves the other output's inventory alone. At the runtime
+# limit, moving a workspace onto the output reuses an empty workspace instead of merging with an occupied one.
 set -euo pipefail
 
 readonly BASELINE="$(< "$UMBRIEL_CONFIG")"
@@ -86,7 +86,13 @@ expect_names HEADLESS-1 "1 2 3 4" "static inventory replaced by a floored dynami
 write_config '[workspaces]
 empty_above = true
 [output.HEADLESS-1]
-min_workspaces = 64'
+position = [0, 0]
+min_workspaces = 64
+[output.HEADLESS-2]
+position = [1280, 0]
+[[window_rule]]
+match.title = "^workspace-limit-source$"
+default_output = "HEADLESS-2"'
 "$UMBRIEL" msg workspace-switch:64/HEADLESS-1 > /dev/null
 foot --title=workspace-limit-view sleep 120 > /dev/null 2>&1 &
 wait_for_windows 1
@@ -95,5 +101,29 @@ expect_names HEADLESS-1 "$(seq -s ' ' 64)" "trailing empty respects the limit"
 "$UMBRIEL" msg window-move-to-workspace:1/HEADLESS-1 > /dev/null
 expect_names HEADLESS-1 "$(seq -s ' ' 64)" "leading empty respects the limit"
 [[ $(workspace_index_of_window) == 1 ]]
+"$UMBRIEL" msg window-move-to-workspace:64/HEADLESS-1 > /dev/null
+foot --title=workspace-limit-source sleep 120 > /dev/null 2>&1 &
+wait_for_windows 2
+before_transfer=$("$UMBRIEL" windows --json)
+source_id=$(jq -r '.[] | select(.title == "workspace-limit-source") | .id' <<< "$before_transfer")
+source_workspace=$(jq -r '.[] | select(.title == "workspace-limit-source") | .workspace' <<< "$before_transfer")
+if [[ $source_workspace != HEADLESS-2:* ]]; then
+  echo "workspace transfer source did not map on HEADLESS-2: $before_transfer"
+  exit 1
+fi
+"$UMBRIEL" msg "window-focus-warp:$source_id" > /dev/null
+"$UMBRIEL" msg workspace-move-to-output-left > /dev/null
+expect_names HEADLESS-1 "$(seq -s ' ' 64)" "workspace transfer respects the limit"
+transferred=$("$UMBRIEL" windows --json)
+limit_workspace=$(jq -r '.[] | select(.title == "workspace-limit-view") | .workspace' <<< "$transferred")
+source_workspace=$(jq -r '.[] | select(.title == "workspace-limit-source") | .workspace' <<< "$transferred")
+if [[ $limit_workspace != HEADLESS-1:* || $source_workspace != HEADLESS-1:* ]]; then
+  echo "workspace transfer did not move both windows onto HEADLESS-1: $transferred"
+  exit 1
+fi
+if [[ $limit_workspace == "$source_workspace" ]]; then
+  echo "workspace transfer merged both windows into occupied workspace $limit_workspace"
+  exit 1
+fi
 
 echo "min_workspaces holds a per-output floor, grows above it, and prunes back to it"


### PR DESCRIPTION
## Summary

Keep workspace creation within the existing limit of 64 per output, including empty workspaces and overview insertion. Reject moves that would grow a full static output.

## Motivation

Dynamic growth could create workspace 65, which configured selectors cannot address.

## Type of Change

- [x] Bug fix

## Testing

- `just format`, `nix fmt`, and a warning-free GCC build with `werror=true`.
- 37 unit/config tests and the relevant headless checks passed. The existing minimum-workspace check now covers both ends of the 64-workspace limit.
- A separate local check covers overview insertion and moves to a full static output. It reproduces 65 workspaces on upstream and passes with this fix; removing only the insertion guard makes its overview assertion fail.
- `just lint range-rebased` fails with 71 existing diagnostics in 13 unchanged files. The same diagnostics were reproduced on upstream `203950f`; none are introduced by this change.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
