### PR TITLE
fix(home-manager module): incorrect label on runCommand

### DIFF
--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -80,7 +80,7 @@ in
             rawConfig = generateToml "umbriel-config.toml" cfg.settings;
           in
           if cfg.validateConfig && cfg.package != null then
-            pkgs.runCommand "noctalia-config" { } ''
+            pkgs.runCommand "umbriel-config" { } ''
               ${lib.getExe cfg.package} validate -c ${rawConfig}
               cp ${rawConfig} $out
             ''


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Changed error message to read "umbriel-config" rather than "noctalia-config" when running the Home-Manager Module.

## Motivation

Reduces confusion when parsing error messages.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging
- [ ] Documentation

## Related Issue

None

## Testing

1. Ran a `nh os switch` with a home-manager setup that had an intentional error to throw the error message

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1dbd92f1-d20f-4a05-9e86-8b0ca3e410cc" />

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
