### PR TITLE
Fix compilation on libc++

### DIFF
--- a/src/cli/ipc_client.cpp
+++ b/src/cli/ipc_client.cpp
@@ -9,6 +9,7 @@
 #include <print>
 #include <string>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <sys/un.h>
 #include <unistd.h>
 #include <vector>

--- a/umbrielfx/include/umbrielfx/types/fx/clipped_region.h
+++ b/umbrielfx/include/umbrielfx/types/fx/clipped_region.h
@@ -1,6 +1,7 @@
 #ifndef UMBRIELFX_TYPES_FX_CLIPPED_REGION_H
 #define UMBRIELFX_TYPES_FX_CLIPPED_REGION_H
 
+#include <linux/stddef.h>
 #include <wlr/util/box.h>
 
 // uint16_t is a reasonable enough range for corner radius


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Added two `#include` statements without which compilation fails when using libc++.

## Motivation

This fixes compilation and building Umbriel with libc++, allowing packaging on distributions that do not use libstdc++.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [X] Build / packaging
- [ ] Documentation

## Related Issue

None

## Testing

I've made sure that Umbriel compiles and launches correctly, in both nested and native sessions, with both libc++ (on a Chimera Linux laptop) and libstdc++ (on an Arch Linux laptop) as well.

## Manual Coverage

- [X] Tested in a nested Umbriel session
- [X] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

None

## Checklist

- [X] This PR is ready for review, or it is marked as Draft.
- [X] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format`, or this PR has no C++ changes.
- [X] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [X] I functionally verified compositor behavior where automated checks are insufficient.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [X] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

None
