### PR TITLE
fix(nix): remove config validation

### DIFF
--- a/nix/hjem-module.nix
+++ b/nix/hjem-module.nix
@@ -5,36 +5,37 @@
   ...
 }:
 let
-  inherit (lib.modules) mkIf;
+  inherit (lib.modules) mkIf mkRemovedOptionModule;
   inherit (lib.options) mkEnableOption mkOption;
   inherit (lib.lists) optional;
 
   cfg = config.programs.umbriel;
   tomlFormat = pkgs.formats.toml { };
-  generateConfig =
-    format: name: value:
+  generateToml =
+    name: value:
     if lib.isString value then
       pkgs.writeText name value
     else if builtins.isPath value || lib.isStorePath value then
       value
     else
-      format.generate name value;
-
-  generateToml = generateConfig tomlFormat;
+      tomlFormat.generate name value;
 in
 {
+  imports = [
+    (mkRemovedOptionModule [
+      "programs"
+      "umbriel"
+      "validateConfig"
+    ] "Build-time validation was removed. Umbriel reports configuration errors at runtime.")
+  ];
+
   options.programs.umbriel = {
-    enable = mkEnableOption "Umbriel, a Wayland compositor built on wlroots.";
+    enable = mkEnableOption "Umbriel, a Wayland compositor built on wlroots";
 
     package = mkOption {
       type = lib.types.nullOr lib.types.package;
       default = null;
       description = "The umbriel package to install.";
-    };
-    validateConfig = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Validate the configuration file at build time.";
     };
     settings = mkOption {
       type =
@@ -58,17 +59,16 @@ in
         See {file}`examples/config.toml` in the Umbriel repository for every available option.
       '';
       example = lib.literalExpression ''
-        general.autostart = [ "noctalia" ];
-
-        layout.gap = 5;
-
-        input.keyboard.layout = "de";
-
-        keybinds = {
-          "Mod+Return" = "spawn:kitty";
-          "Mod+Q" = "window-close";
-          "Mod+R" = "spawn:noctalia msg panel-toggle launcher";
-        };
+        {
+          general.autostart = [ "noctalia" ];
+          layout.gap = 5;
+          input.keyboard.layout = "de";
+          keybinds = {
+            "Mod+Return" = "spawn:kitty";
+            "Mod+Q" = "window-close";
+            "Mod+R" = "spawn:noctalia msg panel-toggle launcher";
+          };
+        }
       '';
     };
   };
@@ -77,17 +77,7 @@ in
     packages = optional (cfg.package != null) cfg.package;
 
     xdg.config.files = mkIf (cfg.settings != null) {
-      "umbriel/config.toml".source =
-        let
-          rawConfig = generateToml "umbriel-config.toml" cfg.settings;
-        in
-        if cfg.validateConfig && cfg.package != null then
-          pkgs.runCommand "umbriel-config" { } ''
-            ${lib.getExe cfg.package} validate -c ${rawConfig}
-            cp ${rawConfig} $out
-          ''
-        else
-          rawConfig;
+      "umbriel/config.toml".source = generateToml "umbriel-config.toml" cfg.settings;
     };
   };
 

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -8,20 +8,26 @@ let
   cfg = config.programs.umbriel;
   tomlFormat = pkgs.formats.toml { };
 
-  generateConfig =
-    format: name: value:
+  generateToml =
+    name: value:
     if lib.isString value then
       pkgs.writeText name value
     else if builtins.isPath value || lib.isStorePath value then
       value
     else
-      format.generate name value;
-
-  generateToml = generateConfig tomlFormat;
+      tomlFormat.generate name value;
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "programs"
+      "umbriel"
+      "validateConfig"
+    ] "Build-time validation was removed. Umbriel reports configuration errors at runtime.")
+  ];
+
   options.programs.umbriel = {
-    enable = lib.mkEnableOption "Umbriel, a Wayland compositor built on wlroots.";
+    enable = lib.mkEnableOption "Umbriel, a Wayland compositor built on wlroots";
 
     package = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
@@ -50,23 +56,17 @@ in
         See {file}`examples/config.toml` in the Umbriel repository for every available option.
       '';
       example = lib.literalExpression ''
-        general.autostart = [ "noctalia" ];
-
-        layout.gap = 5;
-
-        input.keyboard.layout = "de";
-
-        keybinds = {
-          "Mod+Return" = "spawn:kitty";
-          "Mod+Q" = "window-close";
-          "Mod+R" = "spawn:noctalia msg panel-toggle launcher";
-        };
+        {
+          general.autostart = [ "noctalia" ];
+          layout.gap = 5;
+          input.keyboard.layout = "de";
+          keybinds = {
+            "Mod+Return" = "spawn:kitty";
+            "Mod+Q" = "window-close";
+            "Mod+R" = "spawn:noctalia msg panel-toggle launcher";
+          };
+        }
       '';
-    };
-    validateConfig = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Validate the configuration file at build time.";
     };
   };
 
@@ -74,20 +74,7 @@ in
     home.packages = lib.optional (cfg.package != null) cfg.package;
 
     xdg.configFile = lib.mkIf (cfg.settings != null) {
-      "umbriel/config.toml" = {
-        source =
-          let
-            rawConfig = generateToml "umbriel-config.toml" cfg.settings;
-          in
-          if cfg.validateConfig && cfg.package != null then
-            pkgs.runCommand "umbriel-config" { } ''
-              ${lib.getExe cfg.package} validate -c ${rawConfig}
-              cp ${rawConfig} $out
-            ''
-          else
-            rawConfig;
-        force = true;
-      };
+      "umbriel/config.toml".source = generateToml "umbriel-config.toml" cfg.settings;
     };
   };
 


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

removed config validation from hm module and hjem module

added a `mkRemovedOptionModule` for `validateConfig` so folks who used it to work around the build failure don't get confused (can remove this after a while)

also made some other minor improvements to both modules:
- simplified config generation (using `generateToml` directly)
- fixed double `.` in `mkEnableOption`
- made the example config valid nix by wrapping with `{}`

## Motivation

it broke due to an upstream change, its possible this will happen again. it's unconventional to handle validation in the module like this anyway, umbriel validates config at runtime so it's not really an issue if the generated config is bad.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging
- [ ] Documentation

## Testing

- `nix-instantiate --parse` and `nixfmt --check` pass on both modules
- tested the hm module within actual hm config
- same with hjem module

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
