### PR TITLE
feat(input): add mouse side button scrolling

### DIFF
--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -190,9 +190,9 @@ natural_scroll = false
 # accel_profile = "flat"  # "flat", "adaptive", or a custom curve
 sensitivity = 0.0        # -1.0 to 1.0
 scroll_wheel_step = 60  # 1-1000, pixels per step for layout-scroll-left/right
-# scroll_method = "on_button_down"
-# scroll_button = 276
-# scroll_button_lock = true
+# scroll_method = "on_button_down"  # no_scroll, two_finger, edge, or on_button_down
+# scroll_button = 276               # evdev button code held to scroll with pointer motion
+# scroll_button_lock = false        # click toggles scrolling instead of holding
 ```
 
 Omitting `accel_profile` preserves each device's libinput default, which is

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -190,6 +190,9 @@ natural_scroll = false
 # accel_profile = "flat"  # "flat", "adaptive", or a custom curve
 sensitivity = 0.0        # -1.0 to 1.0
 scroll_wheel_step = 60  # 1-1000, pixels per step for layout-scroll-left/right
+# scroll_method = "on_button_down"
+# scroll_button = 276
+# scroll_button_lock = true
 ```
 
 Omitting `accel_profile` preserves each device's libinput default, which is
@@ -210,6 +213,22 @@ libinput default. `layout-scroll-left` and `layout-scroll-right` clamp to the
 strip bounds, so the columns never park
 past either edge. Wheel-triggered scrolling uses twice `scroll_wheel_step`
 during an active tiled window drag.
+
+`scroll_method` picks the gesture that makes a device scroll: `no_scroll`
+mutes touch scrolling, `two_finger` and `edge` are touchpad gestures, and
+`on_button_down` scrolls while the scroll button is down. A mouse's wheel
+ignores the method entirely and keeps scrolling under every value. Omitted,
+each device keeps its libinput default.
+
+`scroll_button` takes an evdev button code (find it with `libinput
+debug-events`; 275 is `BTN_SIDE`, 276 is `BTN_EXTRA`) and repurposes it: the
+button never clicks, motion while it is down scrolls the surface under the
+cursor like wheel input, and it implies `scroll_method = "on_button_down"`.
+`scroll_button_lock = true` toggles scrolling per press instead of requiring a
+hold; if your side button clicks instead of holding, use it. Scrolling applies
+to non-touchpad pointers, a touchpad only through an `[[input.device]]` rule;
+removing the keys restores the device default, and an unsupported value is
+ignored with a warning.
 
 ### Per-device overrides
 
@@ -237,6 +256,9 @@ disable_while_typing = false
 name = "Acme Gaming Mouse"
 accel_profile = "flat"
 sensitivity = 0.0
+scroll_method = "on_button_down"
+scroll_button = 275
+scroll_button_lock = false
 ```
 
 Each rule inherits the matching class settings and overrides only the keys it

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -225,7 +225,7 @@ tap = true                                      # Tap-to-click
 # accel_profile = "flat"                        # Omit to preserve the libinput default
 sensitivity = 0.0                               # Pointer speed, -1.0 to 1.0
 scroll_wheel_step = 60                          # Logical pixels per layout-scroll action, 1-1000
-# scroll_method = "on_button_down"
+# scroll_method = "on_button_down"              # no_scroll, two_finger, edge, or on_button_down
 # scroll_button = 276                           # Evdev button code held to scroll with pointer motion
 # scroll_button_lock = false                    # Click toggles the scroll button instead of holding
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -225,6 +225,9 @@ tap = true                                      # Tap-to-click
 # accel_profile = "flat"                        # Omit to preserve the libinput default
 sensitivity = 0.0                               # Pointer speed, -1.0 to 1.0
 scroll_wheel_step = 60                          # Logical pixels per layout-scroll action, 1-1000
+# scroll_method = "on_button_down"
+# scroll_button = 276                           # Evdev button code held to scroll with pointer motion
+# scroll_button_lock = false                    # Click toggles the scroll button instead of holding
 
 [input.tablet]
 enabled = true                                  # False disables tablet tools and pads
@@ -271,6 +274,9 @@ follows_mouse = false                           # Focus the pointer target after
 # name = "Acme Gaming Mouse"
 # accel_profile = "flat"
 # sensitivity = 0.0
+# scroll_method = "on_button_down"
+# scroll_button = 275
+# scroll_button_lock = false
 
 # ─────────────────────────────── Keybinds ───────────────────────────────────
 # Bind chords to compositor actions. Configured chords replace matching

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -363,6 +363,36 @@ namespace umbriel {
       };
     }
 
+    std::optional<ScrollMethod> readScrollMethod(Section& section, std::string_view key, std::string_view context) {
+      const toml::node* node = section.take(key);
+      if (node == nullptr) {
+        return std::nullopt;
+      }
+      const auto* value = node->as_string();
+      if (value == nullptr) {
+        warnAt(node->source(), "{}.{} must be a string", context, key);
+        return std::nullopt;
+      }
+      const std::string method = lowercase(value->get());
+      if (method == "no_scroll") {
+        return ScrollMethod::NoScroll;
+      }
+      if (method == "two_finger") {
+        return ScrollMethod::TwoFinger;
+      }
+      if (method == "edge") {
+        return ScrollMethod::Edge;
+      }
+      if (method == "on_button_down") {
+        return ScrollMethod::OnButtonDown;
+      }
+      warnAt(
+          node->source(), R"(invalid {}.{} "{}" (expected "no_scroll", "two_finger", "edge", or "on_button_down"))",
+          context, key, value->get()
+      );
+      return std::nullopt;
+    }
+
     std::optional<std::array<float, 6>> readCalibrationMatrix(Section& section, std::string_view context) {
       const toml::node* node = section.take("calibration_matrix");
       if (node == nullptr) {
@@ -1163,8 +1193,11 @@ namespace umbriel {
             .boolean("tap", device.tap)
             .boolean("natural_scroll", device.naturalScroll)
             .real("sensitivity", -1.0, 1.0, device.sensitivity)
-            .boolean("disable_while_typing", device.disableWhileTyping);
+            .boolean("disable_while_typing", device.disableWhileTyping)
+            .integer("scroll_button", 0, 767, device.scrollButton)
+            .boolean("scroll_button_lock", device.scrollButtonLock);
         device.accelProfile = readAccelProfile(keys, "accel_profile", "input.device");
+        device.scrollMethod = readScrollMethod(keys, "scroll_method", "input.device");
 
         if (!validName) {
           continue;
@@ -1241,9 +1274,14 @@ namespace umbriel {
         s.sub("mouse", [&](Section& m) {
           m.boolean("natural_scroll", in.mouse.naturalScroll)
               .real("sensitivity", -1.0, 1.0, in.mouse.sensitivity)
-              .integer("scroll_wheel_step", 1, 1000, in.mouse.scrollWheelStep);
+              .integer("scroll_wheel_step", 1, 1000, in.mouse.scrollWheelStep)
+              .integer("scroll_button", 0, 767, in.mouse.scrollButton)
+              .boolean("scroll_button_lock", in.mouse.scrollButtonLock);
           if (const auto profile = readAccelProfile(m, "accel_profile", "input.mouse")) {
             in.mouse.accelProfile = *profile;
+          }
+          if (const auto method = readScrollMethod(m, "scroll_method", "input.mouse")) {
+            in.mouse.scrollMethod = method;
           }
         });
         s.sub("tablet", [&](Section& t) {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -40,6 +40,13 @@ namespace umbriel {
     bool operator==(const AccelProfile&) const = default;
   };
 
+  enum class ScrollMethod : std::uint8_t {
+    NoScroll,
+    TwoFinger,
+    Edge,
+    OnButtonDown,
+  };
+
   // Per-workspace layout overrides (all optional → inherit Config::Layout).
   struct WorkspaceLayoutOverrides {
     std::optional<LayoutMode> mode;
@@ -685,6 +692,11 @@ namespace umbriel {
       struct Mouse {
         std::optional<bool> naturalScroll;
         std::optional<AccelProfile> accelProfile;
+        std::optional<ScrollMethod> scrollMethod;
+        // Evdev button code (275 = BTN_SIDE, 276 = BTN_EXTRA) held to scroll with pointer motion; unset or 0 disables.
+        std::optional<int> scrollButton;
+        // With a scroll button configured: a click toggles scrolling instead of requiring a hold.
+        std::optional<bool> scrollButtonLock;
         double sensitivity = 0.0;
         int scrollWheelStep = 60;
         bool operator==(const Mouse&) const = default;
@@ -732,6 +744,9 @@ namespace umbriel {
         std::optional<AccelProfile> accelProfile;
         std::optional<double> sensitivity;
         std::optional<bool> disableWhileTyping;
+        std::optional<ScrollMethod> scrollMethod;
+        std::optional<int> scrollButton;
+        std::optional<bool> scrollButtonLock;
         bool operator==(const Device&) const = default;
       };
 

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -27,6 +27,7 @@
 #include <charconv>
 #include <limits>
 #include <optional>
+#include <string_view>
 #include <vector>
 
 namespace umbriel {
@@ -169,6 +170,103 @@ namespace umbriel {
       if (libinput_device_config_scroll_set_natural_scroll_enabled(libinputDevice, enabled)
           != LIBINPUT_CONFIG_STATUS_SUCCESS) {
         kLog.warn("input: failed to apply {} to '{}'", setting, deviceName(device));
+      }
+    }
+
+    void applyScrollConfig(
+        libinput_device* libinputDevice, const wlr_input_device* device,
+        const std::optional<ScrollMethod>& configuredMethod, const std::optional<int>& configuredButton,
+        const std::optional<bool>& configuredLock, std::string_view methodSetting, std::string_view buttonSetting,
+        std::string_view lockSetting
+    ) {
+      const bool hasButton = configuredButton.has_value() && *configuredButton > 0;
+      if (!configuredMethod && !hasButton && !configuredLock) {
+        if (libinput_device_config_scroll_set_method(
+                libinputDevice, libinput_device_config_scroll_get_default_method(libinputDevice)
+            ) != LIBINPUT_CONFIG_STATUS_SUCCESS
+            || libinput_device_config_scroll_set_button(
+                   libinputDevice, libinput_device_config_scroll_get_default_button(libinputDevice)
+               ) != LIBINPUT_CONFIG_STATUS_SUCCESS
+            || libinput_device_config_scroll_set_button_lock(
+                   libinputDevice, libinput_device_config_scroll_get_default_button_lock(libinputDevice)
+               ) != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+          kLog.warn("input: failed to restore the default scroll method state for '{}'", deviceName(device));
+        }
+        return;
+      }
+
+      enum libinput_config_scroll_method method = libinput_device_config_scroll_get_default_method(libinputDevice);
+      if (configuredMethod) {
+        switch (*configuredMethod) {
+        case ScrollMethod::NoScroll:
+          method = LIBINPUT_CONFIG_SCROLL_NO_SCROLL;
+          break;
+        case ScrollMethod::TwoFinger:
+          method = LIBINPUT_CONFIG_SCROLL_2FG;
+          break;
+        case ScrollMethod::Edge:
+          method = LIBINPUT_CONFIG_SCROLL_EDGE;
+          break;
+        case ScrollMethod::OnButtonDown:
+          method = LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN;
+          break;
+        }
+      } else if (hasButton) {
+        // A scroll button actives the method, otherwise button wouldn't scroll anything.
+        method = LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN;
+      }
+      if ((libinput_device_config_scroll_get_methods(libinputDevice) & method) == 0) {
+        kLog.warn(
+            "input: '{}' does not support {}", configuredMethod ? methodSetting : buttonSetting, deviceName(device)
+        );
+        return;
+      }
+      if (libinput_device_config_scroll_set_method(libinputDevice, method) != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+        kLog.warn("input: failed to apply {} to '{}'", methodSetting, deviceName(device));
+        return;
+      }
+      if (method != LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN) {
+        if (hasButton || configuredLock) {
+          kLog.warn(
+              "input: '{}' ignores {} and {} unless {} is \"on_button_down\"", deviceName(device), buttonSetting,
+              lockSetting, methodSetting
+          );
+        }
+        return;
+      }
+      if (!hasButton) {
+        if (configuredMethod) {
+          kLog.warn(
+              "input: '{}' sets {} \"on_button_down\" without {}, so motion never scrolls", deviceName(device),
+              methodSetting, buttonSetting
+          );
+        }
+        if (configuredLock) {
+          kLog.warn("input: '{}' ignores {} because {} is not set", deviceName(device), lockSetting, buttonSetting);
+        }
+        if (libinput_device_config_scroll_set_button(
+                libinputDevice, libinput_device_config_scroll_get_default_button(libinputDevice)
+            ) != LIBINPUT_CONFIG_STATUS_SUCCESS
+            || libinput_device_config_scroll_set_button_lock(
+                   libinputDevice, libinput_device_config_scroll_get_default_button_lock(libinputDevice)
+               ) != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+          kLog.warn("input: failed to restore the default scroll button state for '{}'", deviceName(device));
+        }
+        return;
+      }
+      if (libinput_device_config_scroll_set_button(libinputDevice, static_cast<uint32_t>(*configuredButton))
+          != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+        kLog.warn("input: failed to apply {} to '{}'", buttonSetting, deviceName(device));
+        return;
+      }
+      const auto lockState = configuredLock.value_or(
+                                 libinput_device_config_scroll_get_default_button_lock(libinputDevice)
+                                 == LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_ENABLED
+                             )
+          ? LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_ENABLED
+          : LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_DISABLED;
+      if (libinput_device_config_scroll_set_button_lock(libinputDevice, lockState) != LIBINPUT_CONFIG_STATUS_SUCCESS) {
+        kLog.warn("input: failed to apply {} to '{}'", lockSetting, deviceName(device));
       }
     }
 
@@ -325,6 +423,27 @@ namespace umbriel {
               : isTouchpad                               ? "input.touchpad.natural_scroll"
                                                          : "input.mouse.natural_scroll"
       );
+
+      const bool scrollOverride = override != nullptr
+          && (override->scrollMethod.has_value()
+              || override->scrollButton.has_value()
+              || override->scrollButtonLock.has_value());
+      if (!isTouchpad || scrollOverride) {
+        const std::optional<ScrollMethod>& scrollMethod =
+            override != nullptr && override->scrollMethod ? override->scrollMethod : input.mouse.scrollMethod;
+        const std::optional<int>& scrollButton =
+            override != nullptr && override->scrollButton ? override->scrollButton : input.mouse.scrollButton;
+        const std::optional<bool>& scrollButtonLock = override != nullptr && override->scrollButtonLock
+            ? override->scrollButtonLock
+            : input.mouse.scrollButtonLock;
+        applyScrollConfig(
+            libinputDevice, device, scrollMethod, scrollButton, scrollButtonLock,
+            override != nullptr && override->scrollMethod ? "input.device.scroll_method" : "input.mouse.scroll_method",
+            override != nullptr && override->scrollButton ? "input.device.scroll_button" : "input.mouse.scroll_button",
+            override != nullptr && override->scrollButtonLock ? "input.device.scroll_button_lock"
+                                                              : "input.mouse.scroll_button_lock"
+        );
+      }
 
       const std::optional<AccelProfile> accelProfile = override != nullptr && override->accelProfile
           ? override->accelProfile

--- a/tests/unit/config_change.cpp
+++ b/tests/unit/config_change.cpp
@@ -101,6 +101,24 @@ UMBRIEL_TEST(eachSectionIsReportedOnItsOwn) {
   }
   {
     Config after;
+    after.input.mouse.scrollMethod = umbriel::ScrollMethod::OnButtonDown;
+    CHECK(ConfigChange::between(before, after).input);
+    CHECK(ConfigEffects::between(before, after).input);
+  }
+  {
+    Config after;
+    after.input.mouse.scrollButton = 276;
+    CHECK(ConfigChange::between(before, after).input);
+    CHECK(ConfigEffects::between(before, after).input);
+  }
+  {
+    Config after;
+    after.input.mouse.scrollButtonLock = true;
+    CHECK(ConfigChange::between(before, after).input);
+    CHECK(ConfigEffects::between(before, after).input);
+  }
+  {
+    Config after;
     after.input.middleClickPaste = !after.input.middleClickPaste;
     const ConfigChange change = ConfigChange::between(before, after);
     CHECK(change.input);

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -1459,6 +1459,9 @@ disable_on_external_mouse = true
 [input.mouse]
 accel_profile = "custom 0.2 0.0 0.5 1.0 2.0"
 sensitivity = 0.25
+scroll_method = "on_button_down"
+scroll_button = 276
+scroll_button_lock = true
 
 [[input.device]]
 name = "Acme Split Keyboard"
@@ -1479,6 +1482,9 @@ disable_while_typing = false
 name = "Acme Gaming Mouse"
 accel_profile = "flat"
 sensitivity = -0.5
+scroll_method = "on_button_down"
+scroll_button = 275
+scroll_button_lock = false
 )");
 
   ConfigStore& store = umbriel::configStore();
@@ -1492,6 +1498,10 @@ sensitivity = -0.5
   CHECK_EQ(input.mouse.accelProfile->step, 0.2);
   CHECK_EQ(input.mouse.accelProfile->points, std::vector<double>({0.0, 0.5, 1.0, 2.0}));
   CHECK_EQ(input.mouse.sensitivity, 0.25);
+  CHECK(input.mouse.scrollMethod.has_value());
+  CHECK(input.mouse.scrollMethod == std::optional(umbriel::ScrollMethod::OnButtonDown));
+  CHECK(input.mouse.scrollButton == std::optional<int>(276));
+  CHECK(input.mouse.scrollButtonLock == std::optional<bool>(true));
   CHECK(input.touchpad.accelProfile.has_value());
   if (input.touchpad.accelProfile.has_value()) {
     CHECK(input.touchpad.accelProfile->kind == umbriel::AccelProfile::Kind::Adaptive);
@@ -1530,6 +1540,10 @@ sensitivity = -0.5
     CHECK(mouse->accelProfile.has_value());
     CHECK(mouse->accelProfile->kind == umbriel::AccelProfile::Kind::Flat);
     CHECK(mouse->sensitivity == std::optional<double>(-0.5));
+    CHECK(mouse->scrollMethod.has_value());
+    CHECK(mouse->scrollMethod == std::optional(umbriel::ScrollMethod::OnButtonDown));
+    CHECK(mouse->scrollButton == std::optional<int>(275));
+    CHECK(mouse->scrollButtonLock == std::optional<bool>(false));
   }
 
   CHECK(input.findDevice("acme split keyboard") == nullptr);
@@ -1540,6 +1554,13 @@ UMBRIEL_TEST(mouseAccelerationPreservesDeviceProfileByDefault) {
   const umbriel::Config defaults;
   CHECK(!defaults.input.mouse.accelProfile.has_value());
   CHECK_EQ(defaults.input.mouse.sensitivity, 0.0);
+}
+
+UMBRIEL_TEST(mouseScrollButtonDefaultsToUnset) {
+  const umbriel::Config defaults;
+  CHECK(!defaults.input.mouse.scrollMethod.has_value());
+  CHECK(!defaults.input.mouse.scrollButton.has_value());
+  CHECK(!defaults.input.mouse.scrollButtonLock.has_value());
 }
 
 UMBRIEL_TEST(touchpadAccelerationDefaultsToUnset) {


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

This PR add mouse side button scrolling, three new config in `[input.mouse]`/ `[[input.device]]` keys:- `scroll_method` (`no_scroll`, `two_finger`, `edge`, `on_button_down`), `scroll_button` (evdev button code), and `scroll_button_lock` - `false` (default) requires holding the button to scroll, `true` makes one press toggle scrolling on and off.

## Motivation

For the people who uses mouse button for scrolling and since its already in other WMs so should have in umbriel too.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

Closes #132 

## Testing

`just format && just test && just lint && just lint` everything was clean, 2-3 files had lint error but those aren't my files.
- Installed the branch to test natively, first i got the button evdev code from running this cmd `sudo libinput debug-events`, then added in config. 

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos


## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

Didn't implemented sway-style button-name parsing (`button8`), numeric codes matchs Hyprland and niri.