### PR TITLE
feat(ipc): report PID for wayland windows

### DIFF
--- a/docs/user/ipc.md
+++ b/docs/user/ipc.md
@@ -18,7 +18,7 @@ printf '{"cmd":"workspaces"}\n' | socat -t 5 STDIO "$UMBRIEL_SOCKET"
 
 | Request | CLI | Reply |
 | ------- | --- | ----- |
-| `{"cmd":"windows"}` | `umbriel windows --json` | window list with ids, app ids, titles, geometry, workspace ids |
+| `{"cmd":"windows"}` | `umbriel windows --json` | window list with ids, app ids, titles, client pids, geometry, workspace ids |
 | `{"cmd":"workspaces"}` | `umbriel workspaces --json` | workspace list with names, indices, outputs, active/focused flags, layout modes |
 | `{"cmd":"submap"}` | `umbriel submap --json` | active keybind submap, or `null` |
 | `{"cmd":"layers"}` | `umbriel layers --json` | layer-shell surfaces |
@@ -26,6 +26,13 @@ printf '{"cmd":"workspaces"}\n' | socat -t 5 STDIO "$UMBRIEL_SOCKET"
 
 A connection with no subscription closes once its replies are written, and a
 connection that sends nothing is dropped after a second.
+
+Each window entry carries `pid`, the process that owns the window's Wayland
+connection. It is `-1` when that process is unknown, which covers every
+XWayland window, since all of them belong to the single xwayland-satellite
+connection. The pid is only meaningful in the compositor's own namespaces: for
+a sandboxed client it names the process the sandbox engine connected, and paths
+under `/proc/<pid>` resolve in that sandbox's mount namespace.
 
 ## Event stream
 

--- a/docs/user/window-rules.md
+++ b/docs/user/window-rules.md
@@ -37,7 +37,8 @@ toolbox, and never selects windows that are simply waiting to be titled.
 Run `umbriel windows` to inspect open windows. Its human-readable output adds
 suffixes such as `[xdg_tag=proton-game]` and `[content_type=game]` when those
 values are present. The JSON form, `umbriel windows --json`, always reports
-`xdg_tag` and `content_type`, and also includes the `xwayland` boolean.
+`xdg_tag` and `content_type`, and also includes the `xwayland` boolean and the
+client `pid` described in [IPC](ipc.md#queries).
 
 An XDG toplevel tag is one client-defined string, not a fixed vocabulary. A
 client can set it before the window opens and replace it later if the window's

--- a/src/server/ipc_commands.cpp
+++ b/src/server/ipc_commands.cpp
@@ -354,6 +354,16 @@ namespace umbriel {
       entry["focused"] = v->workspace() != nullptr && v->workspace()->focusedView() == v.get();
       entry["urgent"] = v->urgent();
       entry["xwayland"] = v->xwayland();
+      // Native clients report their pid (used e.g. to resolve a focused
+      // terminal's cwd via /proc). XWayland views would resolve to the
+      // XWayland server process, so report nothing for them.
+      pid_t pid = -1;
+      if (!v->xwayland()) {
+        if (wlr_surface* surface = v->toplevel()->base->surface; surface != nullptr && surface->resource != nullptr) {
+          wl_client_get_credentials(wl_resource_get_client(surface->resource), &pid, nullptr, nullptr);
+        }
+      }
+      entry["pid"] = pid;
       // Tiled windows report their layout slot, which the layout computes even for hidden workspaces; floats report
       // their own position. Ordering a listing by these positions then matches the strip (scrolling) or tile tree
       // (dwindle) regardless of visibility or in-flight animations.

--- a/src/server/ipc_commands.cpp
+++ b/src/server/ipc_commands.cpp
@@ -354,16 +354,8 @@ namespace umbriel {
       entry["focused"] = v->workspace() != nullptr && v->workspace()->focusedView() == v.get();
       entry["urgent"] = v->urgent();
       entry["xwayland"] = v->xwayland();
-      // Native clients report their pid (used e.g. to resolve a focused
-      // terminal's cwd via /proc). XWayland views would resolve to the
-      // XWayland server process, so report nothing for them.
-      pid_t pid = -1;
-      if (!v->xwayland()) {
-        if (wlr_surface* surface = v->toplevel()->base->surface; surface != nullptr && surface->resource != nullptr) {
-          wl_client_get_credentials(wl_resource_get_client(surface->resource), &pid, nullptr, nullptr);
-        }
-      }
-      entry["pid"] = pid;
+      // -1 whenever the owning process is unknown, including for every XWayland view.
+      entry["pid"] = v->pid();
       // Tiled windows report their layout slot, which the layout computes even for hidden workspaces; floats report
       // their own position. Ordering a listing by these positions then matches the strip (scrolling) or tile tree
       // (dwindle) regardless of visibility or in-flight animations.

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -239,15 +239,20 @@ namespace umbriel {
     }
   }
 
+  pid_t surfaceClientPid(const wlr_surface* surface) {
+    if (surface == nullptr || surface->resource == nullptr) {
+      return -1;
+    }
+    pid_t pid = -1;
+    wl_client_get_credentials(wl_resource_get_client(surface->resource), &pid, nullptr, nullptr);
+    return pid > 0 ? pid : -1;
+  }
+
   bool Server::isXwaylandSurface(const wlr_surface* surface) const {
-    if (m_xwayland == nullptr || surface == nullptr || surface->resource == nullptr) {
+    if (m_xwayland == nullptr) {
       return false;
     }
-
-    pid_t pid = -1;
-    uid_t uid = 0;
-    gid_t gid = 0;
-    wl_client_get_credentials(wl_resource_get_client(surface->resource), &pid, &uid, &gid);
+    const pid_t pid = surfaceClientPid(surface);
     return pid > 0 && pid == m_xwayland->pid();
   }
 

--- a/src/server/server.h
+++ b/src/server/server.h
@@ -90,6 +90,10 @@ namespace umbriel {
   // networking alive at negligible cost.
   inline constexpr int kBackgroundFrameIntervalMs = 100;
 
+  // The pid of the process owning a surface's Wayland connection, or -1 when the surface has no client or the kernel
+  // cannot represent that pid in the compositor's pid namespace.
+  [[nodiscard]] pid_t surfaceClientPid(const wlr_surface* surface);
+
   enum class WheelDirection;
   struct Keybind;
 

--- a/src/server/server_events.cpp
+++ b/src/server/server_events.cpp
@@ -61,17 +61,6 @@ namespace umbriel {
       return viewForToplevel(server, wlr_xdg_toplevel_try_from_wlr_surface(root));
     }
 
-    pid_t surfaceClientPid(wlr_surface* surface) {
-      if (surface == nullptr || surface->resource == nullptr) {
-        return -1;
-      }
-      pid_t pid = -1;
-      uid_t uid = 0;
-      gid_t gid = 0;
-      wl_client_get_credentials(wl_resource_get_client(surface->resource), &pid, &uid, &gid);
-      return pid;
-    }
-
     const char* deviceName(const wlr_input_device* device) {
       return device->name != nullptr ? device->name : "unknown";
     }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1017,6 +1017,8 @@ namespace umbriel {
 
   bool View::layoutFullscreen() const { return m_toplevel->scheduled.fullscreen || m_pendingUnfullscreenSize; }
 
+  pid_t View::pid() const { return m_xwayland ? -1 : surfaceClientPid(m_toplevel->base->surface); }
+
   void View::onMap(wl_listener* listener, void* /*data*/) {
     View* self = wl_container_of(listener, self, m_map);
     self->handleMap();

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -14,6 +14,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <sys/types.h>
 #include <vector>
 #include <wayland-server-core.h>
 
@@ -56,6 +57,9 @@ namespace umbriel {
     [[nodiscard]] wlr_scene_tree* captureTree() const;
     [[nodiscard]] bool mapped() const { return m_mapped; }
     [[nodiscard]] bool xwayland() const { return m_xwayland; }
+    // The pid of the application process, or -1 when it is unknown. XWayland views all share the xwayland-satellite
+    // connection, so their client pid identifies the satellite rather than the application and is never reported.
+    [[nodiscard]] pid_t pid() const;
     [[nodiscard]] Workspace* workspace() const { return m_workspace; }
     // The output currently presenting this view. Unassigned views follow the
     // preferred output until they are attached to a workspace.

--- a/tests/harness/checks/010_ipc.sh
+++ b/tests/harness/checks/010_ipc.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 spawn_client() {
   foot --title="ipc-client" sh -c 'sleep 120' > /dev/null 2>&1 &
+  CLIENT_PID=$!
 }
 
 wait_for_windows() {
@@ -117,6 +118,11 @@ if ! jq -e '.[0].id != "" and (.[0].workspace | test("^HEADLESS-1:[0-9]+$"))' <<
 fi
 if [[ $(jq -r '.[0].active' <<< "$windows") != $(jq -r '.[0].focused' <<< "$windows") ]]; then
   echo "active flag does not match the focused state of the only window: $windows"
+  exit 1
+fi
+# The reported pid is the client's own process, not the compositor's or the CLI's.
+if [[ $(jq -r '.[0].pid' <<< "$windows") != "$CLIENT_PID" ]]; then
+  echo "expected pid $CLIENT_PID for the only window: $windows"
   exit 1
 fi
 


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Added the process PID to umbriel window event data if available - XWayland apps will return -1 as they return the X-Server PID otherwise.

```
{
    "active": true,
    "app_id": "com.mitchellh.ghostty",
    "content_type": "none",
    "floating": false,
    "focused": true,
    "h": 1386,
    "id": "e90c7b90bce6c7f20e74ca0958036497",
    "pid": 339271,
    "title": "umbriel windows --json | jq",
    "urgent": false,
    "w": 1228,
    "workspace": "DP-8:1",
    "x": 3242,
    "xdg_tag": "",
    "xwayland": false,
    "y": 44
  },
  {
    "active": false,
    "app_id": "XEyes",
    "content_type": "none",
    "floating": false,
    "focused": false,
    "h": 1386,
    "id": "ea9e951ccc7b945a9fb7eadb974bfa9e",
    "pid": -1,
    "title": "xeyes",
    "urgent": false,
    "w": 1228,
    "workspace": "DP-8:1",
    "x": 2002,
    "xdg_tag": "",
    "xwayland": true,
    "y": 44
  },
```

## Motivation

I want to use umbriel IPC to get the current working directory of the focused shell. With a helper script, I want to spawn new shells in the same CWD with Super+Enter.

Example for Ghostty:

```bash
#!/bin/sh
# Spawn ghostty in the working directory of the focused window.
# cwd = focused ghostty's child shell via /proc/<pid>/cwd, using the pid
# umbriel reports in its window IPC.
# `--print` only prints the resolved cwd (debugging) and exits.

state=$(umbriel windows --json 2>/dev/null) || true
entry=$(printf '%s' "$state" | jq -c '.[] | select(.focused == true)' 2>/dev/null || true)

cwd=""
if [ -n "$entry" ]; then
  app=$(printf '%s' "$entry" | jq -r '.app_id' 2>/dev/null || true)
  pid=$(printf '%s' "$entry" | jq -r '.pid // -1' 2>/dev/null || true)
  if [ "$app" = "com.mitchellh.ghostty" ] && [ "${pid:-0}" -gt 0 ] 2>/dev/null; then
    shell=""
    for p in $(pgrep -P "$pid" 2>/dev/null); do
      case "$(cat /proc/$p/comm 2>/dev/null)" in
        zsh|fish|bash|sh|dash|nu|elvish|xonsh) shell=$p; break ;;
      esac
    done
    if [ -n "$shell" ]; then
      resolved=$(readlink /proc/$shell/cwd 2>/dev/null)
      [ -n "$resolved" ] && [ -d "$resolved" ] && cwd=$resolved
    fi
  fi
fi

if [ "$1" = "--print" ]; then
  printf '%s\n' "${cwd:-<none>}"
  exit 0
fi

exec ghostty ${cwd:+--working-directory="$cwd"}
```

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->
None

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested in a nested Umbriel session
- [X] Tested in a native Umbriel session
- [X] Tested with multiple monitors
- [ ] Tested with a scaled output
- [X] Tested with native Wayland applications
- [X] Tested with X11 applications through xwayland-satellite
- [X] Tested with the scrolling layout
- [X] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->
None

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [X] This PR is ready for review, or it is marked as Draft.
- [X] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format`, or this PR has no C++ changes.
- [X] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [X] I functionally verified compositor behavior where automated checks are insufficient.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [X] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
I just scratched my own itch, please state so if this implementation needs work.
