### PR TITLE
fix(umbrielfx): preserve surface frame pacing across capture scenes

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -75,7 +75,7 @@ distribution-provided LTO and archive member pruning.
 
 ### Build and link dependencies
 
-- wlroots 0.20, and strictly below 0.21: `umbrielfx` compiles against wlroots' private struct layouts
+- wlroots 0.20.1 or newer, and strictly below 0.21: `umbrielfx` compiles against wlroots' private struct layouts
 - wayland-server 1.24 or newer, plus the Wayland client library
 - wayland-protocols 1.47 or newer
 - xkbcommon

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ The scene graph and renderer live in [`umbrielfx/`](umbrielfx/) and build as par
 
 ### System build
 
-Install a C++23 compiler, Meson, Ninja, pkg-config, wayland-scanner, and development packages for wlroots 0.20,
-Wayland, xkbcommon, libinput, pixman, libdrm, EGL, GLES2, GBM, lcms2, Cairo, Pango, tomlplusplus, and
-nlohmann-json. Then build Umbriel:
+Install a C++23 compiler, Meson, Ninja, pkg-config, wayland-scanner, and development packages for wlroots 0.20
+(0.20.1 or newer), Wayland, xkbcommon, libinput, pixman, libdrm, EGL, GLES2, GBM, lcms2, Cairo, Pango, tomlplusplus,
+and nlohmann-json. Then build Umbriel:
 
 ```sh
 just release

--- a/docs/design/scene-helper-ownership.md
+++ b/docs/design/scene-helper-ownership.md
@@ -8,7 +8,7 @@ A node is therefore only usable if `umbrielfx` allocated it. Every scene helper
 that creates or destroys nodes has to live in `umbrielfx/types/scene/`, even the
 ones that are thin wrappers over wlroots types and carry no effects of their
 own: `surface.c`, `subsurface_tree.c`, `xdg_shell.c`, `layer_shell_v1.c`,
-`drag_icon.c`, `output_layout.c`. They are vendored from wlroots 0.20.0 and
+`drag_icon.c`, `output_layout.c`. They are vendored from wlroots 0.20.2 and
 adapted only in their includes.
 
 ## Why borrowing them looked fine

--- a/meson.build
+++ b/meson.build
@@ -51,8 +51,9 @@ wayland_server_dep = dependency('wayland-server', version: '>=1.24')
 wayland_client_dep = dependency('wayland-client')
 wayland_protocols_dep = dependency('wayland-protocols', version: '>=1.47')
 # umbrielfx compiles against wlroots' private struct layouts, so it is pinned to
-# one minor series rather than tracking whatever is installed.
-wlroots_dep = dependency('wlroots-0.20', version: ['>=0.20.0', '<0.21.0'])
+# one minor series rather than tracking whatever is installed. The floor is
+# 0.20.1: its scene surface code reads `wlr_surface_output.suspended`.
+wlroots_dep = dependency('wlroots-0.20', version: ['>=0.20.1', '<0.21.0'])
 cpp = meson.get_compiler('cpp')
 fs = import('fs')
 

--- a/umbrielfx/README.md
+++ b/umbrielfx/README.md
@@ -42,6 +42,14 @@ meson test -C build --suite umbrielfx
   Both rules exist for the same reason, and the reason is not obvious. See
   [scene helper ownership](../docs/design/scene-helper-ownership.md).
 
+- A window's desktop and capture scenes share its `wlr_surface`. Each scene
+  must update only its own output memberships, and frame pacing must ignore
+  suspended outputs. Keep this logic aligned with
+  [wlroots 0.20.2 surface.c](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/0.20.2/types/scene/surface.c).
+  Otherwise capture can replace the desktop output in `current_outputs` and
+  leave the application waiting for frame callbacks after capture stops.
+  `tests/capture_pacing.c` covers capture start/stop and hidden-window pacing.
+
 ## License
 
 MIT, see `LICENSE`. Copyright is held by the SceneFX and wlroots contributors

--- a/umbrielfx/README.md
+++ b/umbrielfx/README.md
@@ -13,7 +13,7 @@ Umbriel's scene graph and GLES2 renderer, a hard fork of
 | `render/fx_renderer/`   | GLES2 renderer, render passes, shaders            |
 | `types/`                | Scene graph, output helpers, blur and clip state   |
 | `util/`                 | Helpers shared inside the library                  |
-| `tests/`                | Color transform and scene ABI regressions          |
+| `tests/`                | Color transform, scene ABI, and frame pacing regressions |
 
 ## Building
 
@@ -42,13 +42,13 @@ meson test -C build --suite umbrielfx
   Both rules exist for the same reason, and the reason is not obvious. See
   [scene helper ownership](../docs/design/scene-helper-ownership.md).
 
-- A window's desktop and capture scenes share its `wlr_surface`. Each scene
-  must update only its own output memberships, and frame pacing must ignore
-  suspended outputs. Keep this logic aligned with
-  [wlroots 0.20.2 surface.c](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/0.20.2/types/scene/surface.c).
-  Otherwise capture can replace the desktop output in `current_outputs` and
-  leave the application waiting for frame callbacks after capture stops.
-  `tests/capture_pacing.c` covers capture start/stop and hidden-window pacing.
+- A window's desktop and capture scenes share its `wlr_surface`, so
+  `types/scene/surface.c` updates only its own scene's output memberships and
+  skips suspended outputs when picking the frame-pacing output. Otherwise
+  capture replaces the desktop output in `current_outputs` and the client waits
+  for frame callbacks that never arrive. Keep it aligned with
+  [wlroots 0.20.2 surface.c](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/0.20.2/types/scene/surface.c);
+  `tests/capture_pacing.c` covers it.
 
 ## License
 

--- a/umbrielfx/meson.build
+++ b/umbrielfx/meson.build
@@ -183,15 +183,6 @@ umbrielfx_dep = declare_dependency(
 )
 
 if build_tests
-  capture_pacing_test = executable(
-    'umbrielfx-capture-pacing-test', 'tests/capture_pacing.c',
-    c_args: umbrielfx_c_args,
-    dependencies: umbrielfx_deps,
-    include_directories: [umbrielfx_inc, umbrielfx_internal_inc],
-    link_with: umbrielfx_lib,
-    build_by_default: false,
-  )
-  test('capture-pacing', capture_pacing_test, suite: 'umbrielfx')
   umbrielfx_color_test = executable(
     'umbrielfx-color-test',
     'tests/color.c',
@@ -224,6 +215,22 @@ if build_tests
       suite: 'umbrielfx',
     )
   endforeach
+
+  umbrielfx_capture_pacing_test = executable(
+    'umbrielfx-capture-pacing-test',
+    'tests/capture_pacing.c',
+    c_args: umbrielfx_c_args,
+    dependencies: umbrielfx_deps,
+    include_directories: [umbrielfx_inc, umbrielfx_internal_inc],
+    link_with: umbrielfx_lib,
+    build_by_default: false,
+  )
+
+  test(
+    'capture-pacing',
+    umbrielfx_capture_pacing_test,
+    suite: 'umbrielfx',
+  )
 
   # The compositor calls scene helpers umbrielfx does not reimplement, so they
   # resolve to libwlroots and read umbrielfx's structs at wlroots' field offsets.

--- a/umbrielfx/meson.build
+++ b/umbrielfx/meson.build
@@ -183,6 +183,15 @@ umbrielfx_dep = declare_dependency(
 )
 
 if build_tests
+  capture_pacing_test = executable(
+    'umbrielfx-capture-pacing-test', 'tests/capture_pacing.c',
+    c_args: umbrielfx_c_args,
+    dependencies: umbrielfx_deps,
+    include_directories: [umbrielfx_inc, umbrielfx_internal_inc],
+    link_with: umbrielfx_lib,
+    build_by_default: false,
+  )
+  test('capture-pacing', capture_pacing_test, suite: 'umbrielfx')
   umbrielfx_color_test = executable(
     'umbrielfx-color-test',
     'tests/color.c',

--- a/umbrielfx/tests/capture_pacing.c
+++ b/umbrielfx/tests/capture_pacing.c
@@ -1,7 +1,6 @@
 // Exercise the real scene-surface listeners with two scenes sharing a surface.
 // No renderer or running desktop is required.
 #undef NDEBUG
-#include "umbrielfx/types/wlr_scene.h"
 #include <assert.h>
 #include <stdio.h>
 #include <sys/socket.h>
@@ -10,6 +9,8 @@
 #include <wlr/backend/headless.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_output.h>
+
+#include "umbrielfx/types/wlr_scene.h"
 
 static int failures;
 #define CHECK(condition)                                                                           \
@@ -73,6 +74,8 @@ int main(void) {
 	struct wlr_scene_output *desktop_output = wlr_scene_output_create(desktop, monitor);
 	struct wlr_scene_output *capture_output = wlr_scene_output_create(mirror, capture);
 	assert(desktop_output && capture_output);
+	// Hand-built surface: only the fields the scene-surface listeners and
+	// wlr_surface_send_enter/leave touch. A wlroots bump can add more.
 	struct wlr_surface surface = {0};
 	surface.resource = wl_resource_create(client, &wl_surface_interface, 1, 0);
 	assert(surface.resource);

--- a/umbrielfx/tests/capture_pacing.c
+++ b/umbrielfx/tests/capture_pacing.c
@@ -1,0 +1,134 @@
+// Exercise the real scene-surface listeners with two scenes sharing a surface.
+// No renderer or running desktop is required.
+#undef NDEBUG
+#include "umbrielfx/types/wlr_scene.h"
+#include <assert.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <wayland-server-core.h>
+#include <wlr/backend/headless.h>
+#include <wlr/types/wlr_compositor.h>
+#include <wlr/types/wlr_output.h>
+
+static int failures;
+#define CHECK(condition)                                                                           \
+	do {                                                                                           \
+		if (!(condition)) {                                                                        \
+			fprintf(stderr, "%d: %s\n", __LINE__, #condition);                                     \
+			failures++;                                                                            \
+		}                                                                                          \
+	} while (0)
+
+static void update(struct wlr_scene_surface *surface, struct wlr_scene_output *output) {
+	struct wlr_scene_outputs_update_event event = {.active = &output, .size = output ? 1 : 0};
+	wl_signal_emit_mutable(&surface->buffer->events.outputs_update, &event);
+}
+
+static struct wlr_surface_output *membership(struct wlr_surface *surface,
+											 struct wlr_output *output) {
+	struct wlr_surface_output *item;
+	wl_list_for_each(item, &surface->current_outputs, link) {
+		if (item->output == output) {
+			return item;
+		}
+	}
+	return NULL;
+}
+
+static int callbacks;
+static void callback_destroy(struct wl_resource *resource) {
+	wl_list_remove(wl_resource_get_link(resource));
+	callbacks++;
+}
+
+static void request_frame(struct wlr_surface *surface, struct wl_client *client) {
+	struct wl_resource *callback = wl_resource_create(client, &wl_callback_interface, 1, 0);
+	assert(callback);
+	wl_resource_set_implementation(callback, NULL, NULL, callback_destroy);
+	wl_list_insert(&surface->current.frame_callback_list, wl_resource_get_link(callback));
+}
+
+static void frame(struct wlr_scene_surface *surface, struct wlr_scene_output *output) {
+	struct wlr_scene_frame_done_event event = {.output = output, .when = {1, 0}};
+	wl_signal_emit_mutable(&surface->buffer->events.frame_done, &event);
+}
+
+int main(void) {
+	struct wl_display *display = wl_display_create();
+	assert(display);
+	int sockets[2];
+	assert(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sockets) == 0);
+	struct wl_client *client = wl_client_create(display, sockets[0]);
+	assert(client);
+	struct wlr_backend *backend = wlr_headless_backend_create(wl_display_get_event_loop(display));
+	assert(backend);
+	struct wlr_output *monitor = wlr_headless_add_output(backend, 800, 600);
+	struct wlr_output *capture = wlr_headless_add_output(backend, 800, 600);
+	assert(monitor && capture);
+	monitor->refresh = 60000;
+	capture->refresh = 0;
+	struct wlr_scene *desktop = wlr_scene_create(), *mirror = wlr_scene_create();
+	assert(desktop && mirror);
+	struct wlr_scene_output *desktop_output = wlr_scene_output_create(desktop, monitor);
+	struct wlr_scene_output *capture_output = wlr_scene_output_create(mirror, capture);
+	assert(desktop_output && capture_output);
+	struct wlr_surface surface = {0};
+	surface.resource = wl_resource_create(client, &wl_surface_interface, 1, 0);
+	assert(surface.resource);
+	wl_list_init(&surface.current_outputs);
+	wl_list_init(&surface.current.frame_callback_list);
+	wl_signal_init(&surface.events.destroy);
+	wl_signal_init(&surface.events.commit);
+	wlr_addon_set_init(&surface.addons);
+	pixman_region32_init(&surface.opaque_region);
+	struct wlr_scene_surface *real = wlr_scene_surface_create(&desktop->tree, &surface);
+	struct wlr_scene_surface *copy = wlr_scene_surface_create(&mirror->tree, &surface);
+	assert(real && copy);
+	update(real, desktop_output);
+	CHECK(membership(&surface, monitor) != NULL);
+	// Starting capture must preserve membership and frame pacing on the monitor.
+	update(copy, capture_output);
+	CHECK(membership(&surface, monitor) != NULL);
+	CHECK(membership(&surface, capture) != NULL);
+	request_frame(&surface, client);
+	frame(real, desktop_output);
+	CHECK(callbacks == 1);
+	update(real, desktop_output);
+	CHECK(membership(&surface, capture) != NULL);
+	// Stopping capture must not prevent the next desktop frame callback.
+	update(copy, NULL);
+	struct wlr_surface_output *capture_member = membership(&surface, capture);
+	CHECK(capture_member != NULL && capture_member->suspended);
+	frame(real, desktop_output);
+	CHECK(callbacks == 1);
+	request_frame(&surface, client);
+	frame(real, desktop_output);
+	CHECK(callbacks == 2);
+	// A hidden window can be paced by capture; once capture stops, neither output
+	// may deliver callbacks until the desktop or capture scene is active again.
+	update(real, NULL);
+	update(copy, capture_output);
+	request_frame(&surface, client);
+	frame(real, desktop_output);
+	CHECK(callbacks == 2);
+	frame(copy, capture_output);
+	CHECK(callbacks == 3);
+	update(copy, NULL);
+	request_frame(&surface, client);
+	frame(copy, capture_output);
+	CHECK(callbacks == 3);
+	update(real, desktop_output);
+	frame(real, desktop_output);
+	CHECK(callbacks == 4);
+	wl_signal_emit_mutable(&surface.events.destroy, &surface);
+	wlr_scene_node_destroy(&desktop->tree.node);
+	wlr_scene_node_destroy(&mirror->tree.node);
+	wlr_backend_destroy(backend);
+	pixman_region32_fini(&surface.opaque_region);
+	wlr_addon_set_finish(&surface.addons);
+	wl_display_destroy_clients(display);
+	wl_display_destroy(display);
+	close(sockets[1]);
+	return failures ? 1 : 0;
+}

--- a/umbrielfx/types/scene/surface.c
+++ b/umbrielfx/types/scene/surface.c
@@ -30,8 +30,8 @@ static struct wlr_output *get_surface_frame_pacing_output(struct wlr_surface *su
 	struct wlr_output *frame_pacing_output = NULL;
 	struct wlr_surface_output *surface_output;
 	wl_list_for_each(surface_output, &surface->current_outputs, link) {
-		if (frame_pacing_output == NULL ||
-				surface_output->output->refresh > frame_pacing_output->refresh) {
+		if (!surface_output->suspended && (frame_pacing_output == NULL ||
+				surface_output->output->refresh > frame_pacing_output->refresh)) {
 			frame_pacing_output = surface_output->output;
 		}
 	}
@@ -97,11 +97,9 @@ static void handle_scene_buffer_outputs_update(
 	struct wlr_scene_outputs_update_event *event = data;
 	struct wlr_scene *scene = scene_node_get_root(&surface->buffer->node);
 
-	// If the surface is no longer visible on any output, keep the last sent
-	// preferred configuration to avoid unnecessary redraws
-	if (event->size == 0) {
-		return;
-	}
+	// If the surface is no longer visible on any output in the scene, keep the
+	// last sent preferred configuration to avoid unnecessary redraws
+	bool suspend = event->size == 0;
 
 	// To avoid sending redundant leave/enter events when a surface is hidden and then shown
 	// without moving to a different output the following policy is implemented:
@@ -121,9 +119,22 @@ static void handle_scene_buffer_outputs_update(
 				break;
 			}
 		}
-		if (!active) {
-			wlr_surface_send_leave(surface->surface, entered_output->output);
+
+		struct wlr_scene_output *scene_output;
+		wl_list_for_each(scene_output, &scene->outputs, link) {
+			if (scene_output->output == entered_output->output) {
+				entered_output->suspended = suspend;
+				if (!suspend && !active) {
+					wlr_surface_send_leave(surface->surface, entered_output->output);
+				}
+				break;
+			}
 		}
+	}
+
+	// No reason to update the preferred configuration if we aren't sending leave/enter events.
+	if (suspend) {
+		return;
 	}
 
 	for (size_t i = 0; i < event->size; i++) {
@@ -361,10 +372,9 @@ static void handle_scene_surface_surface_commit(
 	// the surface anyway.
 	int lx, ly;
 	bool enabled = wlr_scene_node_coords(&scene_buffer->node, &lx, &ly);
-
-	if (!wl_list_empty(&surface->surface->current.frame_callback_list) &&
-			surface->buffer->primary_output != NULL && enabled) {
-		wlr_output_schedule_frame(surface->buffer->primary_output->output);
+	struct wlr_output *output = get_surface_frame_pacing_output(surface->surface);
+	if (!wl_list_empty(&surface->surface->current.frame_callback_list) && output && enabled) {
+		wlr_output_schedule_frame(output);
 	}
 }
 


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

<!-- What changed and why? -->
Restore wlroots 0.20.2’s handling of surfaces shared between desktop and capture scenes.

- Restrict output membership updates to the scene that owns those outputs.
- Exclude suspended outputs when choosing the surface’s frame-pacing output.
- Schedule frame callbacks on that chosen output.
- Add regression coverage for capture start/stop and hidden-window frame pacing.

## Motivation

<!-- What problem does this solve? -->
Sharing a window, then stopping the stream, could leave the application frozen even though Umbriel could still move its window. Taking window-preview snapshots triggered the same issue.

The capture scene could remove the real monitor from the surface’s output membership. When capture stopped, the inactive virtual output could remain responsible for frame pacing, leaving the application waiting for callbacks that never arrived.

This restores the corresponding behavior from the wlroots version Umbriel already uses.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
- Release build completed successfully.
- `meson test -C build-release --print-errorlogs`: all 53 tests passed, including capture pacing and scene ABI checks.
- The new regression reproduced missing desktop frame callbacks before the fix and passed afterward.
- Verified all three changed functions match wlroots 0.20.2’s implementation.
- `git diff --check` passed.
- Verified screen and window snapshots in an isolated headless Umbriel session.
- Manually verified Discord window sharing and picker previews with native Wayland applications in a multi-monitor session. Stopping capture no longer froze the applications.

Scaled outputs and X11 clients were not specifically exercised.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
This restores intended redraw behavior without adding configuration options or changing IPC interfaces. The scene ownership requirement is documented in `umbrielfx/README.md`.

The portal’s window-preview changes depend on this fix, but are submitted separately.
https://github.com/noctalia-dev/xdg-desktop-portal-umbriel/pull/9