### PR TITLE
fix(render): always use highp precision in border shaders

### DIFF
--- a/umbrielfx/render/fx_renderer/shaders/border.frag
+++ b/umbrielfx/render/fx_renderer/shaders/border.frag
@@ -1,10 +1,6 @@
 #extension GL_OES_standard_derivatives : enable
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
 varying vec4 v_color;
 varying vec2 v_texcoord;

--- a/umbrielfx/render/fx_renderer/shaders/box_shadow.frag
+++ b/umbrielfx/render/fx_renderer/shaders/box_shadow.frag
@@ -1,10 +1,6 @@
 // Writeup: https://madebyevan.com/shaders/fast-rounded-rectangle-shadows/
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
 varying vec4 v_color;
 varying vec2 v_texcoord;

--- a/umbrielfx/render/fx_renderer/shaders/quad_round.frag
+++ b/umbrielfx/render/fx_renderer/shaders/quad_round.frag
@@ -1,8 +1,4 @@
-#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
-#else
-precision mediump float;
-#endif
 
 varying vec4 v_color;
 varying vec2 v_texcoord;


### PR DESCRIPTION
## Summary
Remove mediump branch from border shaders

## Motivation
Fixes pixellated borders on Nvidia drivers

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue
Closes #170 

## Testing
Confirmed borders are smooth after this change (see image below)

## Manual Coverage
- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos
<img width="77" height="69" alt="screenshot_20260907_021446-region" src="https://github.com/user-attachments/assets/169b8bbc-c127-4f19-b85f-20ad8faa3ee4" />

## Checklist
- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes
