### PR TITLE
feat(render) add 10-bit SDR support

### DIFF
--- a/docs/user/outputs.md
+++ b/docs/user/outputs.md
@@ -84,11 +84,12 @@ output is reconfigured, so reconnecting the display or reloading the configurati
 | `mode`                                       | string                            | (native)    | Resolution and refresh rate: `"WIDTHxHEIGHT"` or `"WIDTHxHEIGHT@HZ"`. Fractional Hz allowed. Falls back to the preferred advertised mode when it cannot be applied. Ignored in nested sessions (the parent controls size). |
 | `position`                                   | `[x, y]`                          | (auto)      | Top-left corner in logical layout coordinates. Omit for automatic placement.                                                                        |
 | `scale`                                      | float                             | `1.0`       | Output scale (0.25-4.0).                                                                                                                            |
-| `vrr`                                        | string                            | `"disabled"` | Variable refresh rate policy: `"disabled"`, `"always"`, or `"fullscreen"`.                                                                          |
+| `vrr`                                        | string                            | `"disabled"` | Variable refresh rate policy: `"disabled"`, `"always"`, or `"fullscreen"`.                                                                         |
 | `tearing`                                    | bool                              | `false`     | Permit asynchronous page flips for eligible fullscreen windows on this output.                                                                      |
 | `direct_scanout`                             | bool                              | `true`      | Permit eligible client buffers to bypass composition on this output. Set to `false` to always composite.                                            |
 | `hdr`                                        | string                            | `"off"`     | HDR policy: `"off"`, `"on"`, `"auto"`, or `"fullscreen"`.                                                                                           |
 | `sdr_white`                                  | float                             | `203`       | SDR reference white in cd/m2 while the output is in HDR mode (80-1000).                                                                             |
+| `bit_depth`                                  | int                               | `8`         | Render bit depth for SDR output: `8` or `10`.                                                                                                       |
 | `workspaces`                                 | int, string array, or `"dynamic"` | `"dynamic"` | A dynamic inventory, which may include names declared by `[[workspace]]`, 1 to 64 anonymous fixed positions, or a static ordered list of 1 to 64 names. |
 | `min_workspaces`                             | int                               | `1`         | Workspace count a dynamic output never shrinks below (1-64). Rejected together with a static `workspaces` inventory.                                |
 | `workspace_axis`                             | string                            | `"vertical"` | Axis the output's workspaces are arranged along: `"vertical"` or `"horizontal"`. The scrolling strip runs perpendicular to it. See [Workspace axis](workspaces.md#workspace-axis). |
@@ -328,6 +329,24 @@ receive an SDR Gamma 2.2 view instead of PQ-encoded output pixels. This keeps
 screenshots readable in ordinary SDR viewers. Values outside the SDR capture
 range are clipped rather than tone-mapped. Raw export-DMA-BUF capture remains
 in the output's native format.
+
+### Bit depth
+
+Set `bit_depth = 10` to request a 10-bit SDR output format:
+
+```toml
+[output.DP-1]
+bit_depth = 10
+```
+
+This selects XR30 (`DRM_FORMAT_XRGB2101010`) or XB30 (`DRM_FORMAT_XBGR2101010`)
+as the render format. Blur and effects intermediate buffers are upgraded to FP16
+precision for reduced banding in gradients.
+
+If the backend rejects both 10-bit formats, Umbriel logs a warning and falls
+back to 8-bit. Run `umbriel color` to confirm the active render format.
+
+HDR always uses 10-bit independently of this setting.
 
 ## Disabling an output
 

--- a/docs/user/outputs.md
+++ b/docs/user/outputs.md
@@ -339,9 +339,12 @@ Set `bit_depth = 10` to request a 10-bit SDR compositor render format:
 bit_depth = 10
 ```
 
-This selects XR30 (`DRM_FORMAT_XRGB2101010`) or XB30 (`DRM_FORMAT_XBGR2101010`)
-as the render format. Blur and effects intermediate buffers are upgraded to FP16
-precision for reduced banding in gradients.
+Selects a 10-bit format XR30 (`DRM_FORMAT_XRGB2101010`) or
+XB30 (`DRM_FORMAT_XBGR2101010`) as the render format when the backend accepts
+it. If neither is accepted, the output falls back to 8-bit. While a 10-bit
+format is active, blur and effects intermediate buffers are upgraded to FP16
+precision, provided the renderer supports FP16 render targets. Otherwise,
+they remain 8-bit. HDR uses 10-bit independently of this setting.
 
 `bit_depth = 10` controls the compositor render format only. It does not
 guarantee that the physical display link runs at 10 bits per channel. The
@@ -351,26 +354,20 @@ compositor committed.
 
 **VRR fallback.** When VRR is also requested, the format sequence first
 attempts the 10-bit format with VRR enabled. If the backend rejects that
-combination, it retries the same 10-bit format with VRR disabled. VRR is
-silently dropped rather than falling back to 8-bit. Only when both 10-bit
-passes fail does Umbriel log a warning and fall back to 8-bit.
+combination, it retries the same 10-bit format with VRR disabled. Only
+when both fail does Umbriel log a warning and fall back to 8-bit.
 
 **Direct scanout.** Direct scanout remains enabled by the `direct_scanout`
 setting, but it is less likely to engage while 10-bit rendering is active.
 Direct scanout requires the client buffer format to exactly match what KMS
-accepts for the plane. Most clients render 8-bit buffers, which do not satisfy
-that requirement on a 10-bit output. Set `direct_scanout = false` explicitly if
-you want to suppress the condition check entirely.
+accepts for the plane. Set `direct_scanout = false` explicitly if you want
+to suppress the condition check.
 
 **Screencopy and capture.** Screencopy clients such as `grim` and Noctalia
-receive raw XR30 buffers when 10-bit SDR is active. Tools that do not handle
-10-bit formats may produce undesired output. Use a bit depth of 8 if you
-encounter issues.
-
-If the backend rejects both 10-bit formats, Umbriel logs a warning and falls
-back to 8-bit.
-
-HDR always uses 10-bit independently of this setting.
+receive raw buffers in the output's active 10-bit render format (XR30 or XB30)
+when 10-bit SDR is active. Unlike HDR capture, the pixels are not converted to
+an 8-bit SDR format first. Tools that do not handle 10-bit formats may produce
+undesired output. Use a bit depth of 8 if you encounter issues.
 
 ## Disabling an output
 

--- a/docs/user/outputs.md
+++ b/docs/user/outputs.md
@@ -332,7 +332,7 @@ in the output's native format.
 
 ### Bit depth
 
-Set `bit_depth = 10` to request a 10-bit SDR output format:
+Set `bit_depth = 10` to request a 10-bit SDR compositor render format:
 
 ```toml
 [output.DP-1]
@@ -343,8 +343,32 @@ This selects XR30 (`DRM_FORMAT_XRGB2101010`) or XB30 (`DRM_FORMAT_XBGR2101010`)
 as the render format. Blur and effects intermediate buffers are upgraded to FP16
 precision for reduced banding in gradients.
 
+`bit_depth = 10` controls the compositor render format only. It does not
+guarantee that the physical display link runs at 10 bits per channel. The
+number of bits delivered to the panel depends on the display's EDID, cable,
+and driver. Run `umbriel color` to confirm the active render format that the
+compositor committed.
+
+**VRR fallback.** When VRR is also requested, the format sequence first
+attempts the 10-bit format with VRR enabled. If the backend rejects that
+combination, it retries the same 10-bit format with VRR disabled. VRR is
+silently dropped rather than falling back to 8-bit. Only when both 10-bit
+passes fail does Umbriel log a warning and fall back to 8-bit.
+
+**Direct scanout.** Direct scanout remains enabled by the `direct_scanout`
+setting, but it is less likely to engage while 10-bit rendering is active.
+Direct scanout requires the client buffer format to exactly match what KMS
+accepts for the plane. Most clients render 8-bit buffers, which do not satisfy
+that requirement on a 10-bit output. Set `direct_scanout = false` explicitly if
+you want to suppress the condition check entirely.
+
+**Screencopy and capture.** Screencopy clients such as `grim` and Noctalia
+receive raw XR30 buffers when 10-bit SDR is active. Tools that do not handle
+10-bit formats may produce undesired output. Use a bit depth of 8 if you
+encounter issues.
+
 If the backend rejects both 10-bit formats, Umbriel logs a warning and falls
-back to 8-bit. Run `umbriel color` to confirm the active render format.
+back to 8-bit.
 
 HDR always uses 10-bit independently of this setting.
 

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -92,6 +92,7 @@ honor_restored_maximize = false                 # Honor restored maximized state
 # direct_scanout = true                         # False forces composition on this output
 # hdr = "auto"                                  # off, on, auto, or fullscreen
 # sdr_white = 203                               # SDR reference white in cd/m2 during HDR
+# bit_depth = 8                                 # SDR render bit depth: 8 or 10
 # workspaces = 5                                # Anonymous fixed positions; omit for dynamic
 # workspace_axis = "horizontal"                 # vertical or horizontal workspace arrangement
 

--- a/meson.build
+++ b/meson.build
@@ -465,6 +465,7 @@ pure_sources = files(
   'src/layout/master.cpp',
   'src/output/direction.cpp',
   'src/output/identity.cpp',
+  'src/output/format_sequence.cpp',
   'src/output/mode_selection.cpp',
   'src/server/drm_policy.cpp',
   'src/scene/cheatsheet_rows.cpp',

--- a/src/config/change.cpp
+++ b/src/config/change.cpp
@@ -49,7 +49,8 @@ namespace umbriel {
           && lhs.transform == rhs.transform
           && lhs.vrr == rhs.vrr
           && lhs.hdr == rhs.hdr
-          && lhs.sdrWhite == rhs.sdrWhite;
+          && lhs.sdrWhite == rhs.sdrWhite
+          && lhs.bitDepth == rhs.bitDepth;
     }
 
     bool sameOutputTearingPolicy(const OutputRule* before, const OutputRule* after) {

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1754,6 +1754,15 @@ namespace umbriel {
         keys.real("sdr_white", 80.0, 1000.0, sdrWhite);
         rule.sdrWhite = static_cast<float>(sdrWhite);
 
+        if (const toml::node* bitDepthNode = keys.take("bit_depth")) {
+          const auto value = bitDepthNode->value<std::int64_t>();
+          if (value && (*value == 8 || *value == 10)) {
+            rule.bitDepth = static_cast<int>(*value);
+          } else {
+            warnAt(bitDepthNode->source(), "ignoring output.{}.bit_depth (expected 8 or 10)", name);
+          }
+        }
+
         if (const toml::node* transformNode = keys.take("transform")) {
           const auto value = transformNode->value<std::string>();
           static constexpr std::pair<std::string_view, int> transforms[] = {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -214,6 +214,8 @@ namespace umbriel {
     bool directScanout = true;
     HdrMode hdr = HdrMode::Off;
     float sdrWhite = 203.0F;
+    // Render bit depth for SDR output: 8 (default) or 10 for 10-bit SDR.
+    int bitDepth = 8;
     // Explicit workspace inventory. A count creates anonymous positional
     // members, while a string list creates named members. Omitted is dynamic.
     using WorkspaceInventory = std::variant<size_t, std::vector<std::string>>;

--- a/src/output/format_sequence.cpp
+++ b/src/output/format_sequence.cpp
@@ -1,0 +1,133 @@
+#include "output/format_sequence.h"
+
+#include "config/value_parse.h"
+#include "output/hdr_format.h"
+
+#include <drm_fourcc.h>
+#include <format>
+#include <span>
+
+namespace umbriel {
+
+  namespace {
+
+    std::span<const bool> vrrPasses(bool tryVrrOn) {
+      static constexpr bool kBothPasses[] = {true, false};
+      static constexpr bool kNoVrrPass[] = {false};
+      return tryVrrOn ? std::span<const bool>(kBothPasses) : std::span<const bool>(kNoVrrPass);
+    }
+
+    // Runs the HDR -> SDR10 -> SDR8 x VRR sequence for whatever mode is currently staged.
+    // Returns true if a commit succeeded. Sets hdrFail/sdr10Fail accordingly.
+    bool runSequenceForCurrentMode(
+        const FormatSequenceParams& params, const FormatSequenceOps& ops, std::string_view& hdrFail,
+        std::string_view& sdr10Fail
+    ) {
+      // HDR.
+      const auto tryHdrFormats = [&]() -> bool {
+        if (!(params.hdrRequested && params.imageDescAvailable)) {
+          if (params.imageDescAvailable || params.hdrWasActive) {
+            ops.clearImageDescription();
+          }
+          return false;
+        }
+
+        const auto hdrFormats = hdrRenderFormatCandidates(params.currentRenderFormat);
+        bool anyTestPassed = false;
+        for (const bool vrr : vrrPasses(params.tryVrrOn)) {
+          for (const uint32_t fmt : hdrFormats) {
+            const ProbeOutcome outcome = ops.probeHdr(fmt, vrr);
+            if (outcome == ProbeOutcome::TestFailed) {
+              continue;
+            }
+            anyTestPassed = true;
+            if (outcome == ProbeOutcome::Committed) {
+              if (params.tryVrrOn && !vrr) {
+                ops.warnHdrVrrIncompatible();
+              }
+              return true;
+            }
+          }
+        }
+
+        hdrFail = anyTestPassed ? "HDR commit rejected by backend" : "backend rejected all 10-bit HDR render formats";
+        ops.clearImageDescription();
+        return false;
+      };
+
+      // SDR10.
+      const auto trySdr10Formats = [&]() -> bool {
+        if (params.bitDepth != 10) {
+          return false;
+        }
+
+        bool anyTestPassed = false;
+        for (const bool vrr : vrrPasses(params.tryVrrOn)) {
+          const auto accepted = selectSdr10RenderFormat([&](uint32_t fmt) -> bool {
+            const ProbeOutcome outcome = ops.probeSdr(fmt, vrr);
+            if (outcome == ProbeOutcome::TestFailed) {
+              return false;
+            }
+            anyTestPassed = true;
+            if (outcome == ProbeOutcome::Committed) {
+              return true;
+            }
+            return false;
+          });
+          if (accepted) {
+            return true;
+          }
+        }
+        sdr10Fail =
+            anyTestPassed ? "10-bit SDR commit rejected by backend" : "backend rejected all 10-bit SDR render formats";
+        return false;
+      };
+
+      // SDR8.
+      const auto trySdr8Formats = [&]() -> bool {
+        for (const bool vrr : vrrPasses(params.tryVrrOn)) {
+          if (ops.probeSdr(DRM_FORMAT_XRGB8888, vrr) == ProbeOutcome::Committed) {
+            return true;
+          }
+        }
+        return false;
+      };
+
+      return tryHdrFormats() || trySdr10Formats() || trySdr8Formats();
+    }
+
+  } // namespace
+
+  FormatSequenceResult runFormatSequence(const FormatSequenceParams& params, const FormatSequenceOps& ops) {
+    FormatSequenceResult result;
+    std::string_view hdrFail = params.earlyHdrFail;
+    std::string_view sdr10Fail;
+
+    result.committed = runSequenceForCurrentMode(params, ops, hdrFail, sdr10Fail);
+
+    if (!result.committed && params.configuredModeSpec != nullptr && params.preferredMode != nullptr) {
+      result.usedModeFallback = true;
+      if (!params.modeFallbackAlreadyWarned) {
+        result.modeFallbackWarnedNow = true;
+        const std::string requested = params.configuredModeSpec->refreshMHz != 0
+            ? std::format(
+                  "{}x{}@{}mHz", params.configuredModeSpec->width, params.configuredModeSpec->height,
+                  params.configuredModeSpec->refreshMHz
+              )
+            : std::format("{}x{}", params.configuredModeSpec->width, params.configuredModeSpec->height);
+        ops.warnModeFallback(requested, *params.preferredMode);
+      }
+
+      ops.stageMode(params.preferredMode);
+
+      hdrFail = params.earlyHdrFail;
+      sdr10Fail = {};
+      result.committed = runSequenceForCurrentMode(params, ops, hdrFail, sdr10Fail);
+    }
+
+    result.hdrFail = hdrFail;
+    result.sdr10Fail = sdr10Fail;
+    return result;
+  }
+
+} // namespace umbriel

--- a/src/output/format_sequence.cpp
+++ b/src/output/format_sequence.cpp
@@ -2,6 +2,7 @@
 
 #include "config/value_parse.h"
 #include "output/hdr_format.h"
+#include "output/sdr_format.h"
 
 #include <drm_fourcc.h>
 #include <format>

--- a/src/output/format_sequence.h
+++ b/src/output/format_sequence.h
@@ -22,7 +22,6 @@ namespace umbriel {
     uint32_t currentRenderFormat;
     int bitDepth;
     bool tryVrrOn;
-    wlr_output_mode* stagedMode;          // nullptr = Custom or no mode staged
     const OutputMode* configuredModeSpec; // nullptr = No mode configured
     wlr_output_mode* preferredMode;       // nullptr = No fallback available
     bool modeFallbackAlreadyWarned;

--- a/src/output/format_sequence.h
+++ b/src/output/format_sequence.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string_view>
+
+struct wlr_output_mode;
+
+namespace umbriel {
+  struct OutputMode;
+
+  enum class ProbeOutcome : uint8_t {
+    TestFailed,   // wlr_output_test_state rejected the state
+    CommitFailed, // Test passed but wlr_output_commit_state failed
+    Committed,    // Test passed and commit succeeded
+  };
+
+  struct FormatSequenceParams {
+    bool hdrRequested;
+    bool imageDescAvailable;
+    bool hdrWasActive;
+    uint32_t currentRenderFormat;
+    int bitDepth;
+    bool tryVrrOn;
+    wlr_output_mode* stagedMode;          // nullptr = Custom or no mode staged
+    const OutputMode* configuredModeSpec; // nullptr = No mode configured
+    wlr_output_mode* preferredMode;       // nullptr = No fallback available
+    bool modeFallbackAlreadyWarned;
+    std::string_view earlyHdrFail;
+  };
+
+  struct FormatSequenceOps {
+    std::function<ProbeOutcome(uint32_t format, bool vrr)> probeSdr;
+    std::function<ProbeOutcome(uint32_t format, bool vrr)> probeHdr;
+    std::function<void()> clearImageDescription;
+    std::function<void(wlr_output_mode*)> stageMode;
+    std::function<void(std::string_view requested, const wlr_output_mode& fallback)> warnModeFallback;
+    std::function<void()> warnHdrVrrIncompatible;
+  };
+
+  struct FormatSequenceResult {
+    bool committed = false;
+    bool usedModeFallback = false;
+    bool modeFallbackWarnedNow = false;
+    std::string_view hdrFail;
+    std::string_view sdr10Fail;
+  };
+
+  [[nodiscard]] FormatSequenceResult
+  runFormatSequence(const FormatSequenceParams& params, const FormatSequenceOps& ops);
+} // namespace umbriel

--- a/src/output/hdr_format.h
+++ b/src/output/hdr_format.h
@@ -8,16 +8,26 @@
 
 namespace umbriel {
 
-  template <typename Probe>
-  [[nodiscard]] std::optional<uint32_t> selectHdrRenderFormat(uint32_t currentFormat, Probe&& accepts) {
-    std::array candidates{
-        DRM_FORMAT_XRGB2101010,
-        DRM_FORMAT_XBGR2101010,
-    };
+  [[nodiscard]] inline std::array<uint32_t, 2> hdrRenderFormatCandidates(uint32_t currentFormat) {
+    std::array candidates{DRM_FORMAT_XRGB2101010, DRM_FORMAT_XBGR2101010};
     if (currentFormat == DRM_FORMAT_XBGR2101010) {
       std::swap(candidates[0], candidates[1]);
     }
-    for (const uint32_t candidate : candidates) {
+    return candidates;
+  }
+
+  template <typename Probe>
+  [[nodiscard]] std::optional<uint32_t> selectHdrRenderFormat(uint32_t currentFormat, Probe&& accepts) {
+    for (const uint32_t candidate : hdrRenderFormatCandidates(currentFormat)) {
+      if (accepts(candidate)) {
+        return candidate;
+      }
+    }
+    return std::nullopt;
+  }
+
+  template <typename Probe> [[nodiscard]] std::optional<uint32_t> selectSdr10RenderFormat(Probe&& accepts) {
+    for (const uint32_t candidate : {DRM_FORMAT_XRGB2101010, DRM_FORMAT_XBGR2101010}) {
       if (accepts(candidate)) {
         return candidate;
       }

--- a/src/output/hdr_format.h
+++ b/src/output/hdr_format.h
@@ -26,13 +26,4 @@ namespace umbriel {
     return std::nullopt;
   }
 
-  template <typename Probe> [[nodiscard]] std::optional<uint32_t> selectSdr10RenderFormat(Probe&& accepts) {
-    for (const uint32_t candidate : {DRM_FORMAT_XRGB2101010, DRM_FORMAT_XBGR2101010}) {
-      if (accepts(candidate)) {
-        return candidate;
-      }
-    }
-    return std::nullopt;
-  }
-
 } // namespace umbriel

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -26,12 +26,19 @@
 #include <ctime>
 #include <drm_fourcc.h>
 #include <format>
+#include <span>
 
 namespace umbriel {
 
   namespace {
     constexpr Logger kLog("output");
     constexpr int kFrameRetryDelayMs = 16;
+
+    std::span<const bool> vrrPasses(bool tryVrrOn) {
+      static constexpr bool kBothPasses[] = {true, false};
+      static constexpr bool kNoVrrPass[] = {false};
+      return tryVrrOn ? std::span<const bool>(kBothPasses) : std::span<const bool>(kNoVrrPass);
+    }
 
   } // namespace
 
@@ -132,9 +139,20 @@ namespace umbriel {
 
   bool Output::hdrActive() const { return m_output->image_description != nullptr; }
 
+  bool Output::tenBitSdrActive() const {
+    return m_output->enabled
+        && !hdrActive()
+        && (m_output->render_format == DRM_FORMAT_XRGB2101010 || m_output->render_format == DRM_FORMAT_XBGR2101010);
+  }
+
   float Output::configuredSdrWhite() const {
     const OutputRule* rule = findOutputRule(config(), identity());
     return rule != nullptr ? rule->sdrWhite : 203.0F;
+  }
+
+  int Output::configuredBitDepth() const {
+    const OutputRule* rule = findOutputRule(config(), identity());
+    return rule != nullptr ? rule->bitDepth : 8;
   }
 
   bool Output::configuredDirectScanoutEnabled() const {
@@ -214,6 +232,16 @@ namespace umbriel {
     }
   }
 
+  void Output::setTenBitFallbackReason(std::string_view reason) {
+    if (m_tenBitFallbackReason == reason) {
+      return;
+    }
+    m_tenBitFallbackReason = reason;
+    if (!reason.empty()) {
+      kLog.warn("output '{}': 10-bit SDR unavailable: {}", m_output->name, reason);
+    }
+  }
+
   void Output::updateSceneSdrWhite() {
     if (m_sceneOutput == nullptr) {
       return;
@@ -245,25 +273,22 @@ namespace umbriel {
     const bool hdrWasActive = hdrActive();
     const bool hdrRequested = this->hdrRequested();
     m_lastHdrRequested = hdrRequested;
-    bool hdrAttempted = false;
 
-    bool vrrRequested = false;
-    bool vrrStaged = false;
+    // Stage geometry.
     bool scaleStaged = false;
-    const OutputMode* configuredMode = nullptr;
+    const OutputMode* configuredModeSpec = nullptr;
     wlr_output_mode* stagedMode = nullptr;
     if (enabled) {
       if (rule != nullptr && rule->mode) {
         if (wlr_output_is_wl(m_output)) {
           kLog.info("output '{}': mode is ignored in nested sessions", m_output->name);
         } else {
-          const OutputMode& configured = *rule->mode;
-          configuredMode = &configured;
-          stagedMode = selectOutputMode(m_output, configured);
+          configuredModeSpec = &*rule->mode;
+          stagedMode = selectOutputMode(m_output, *rule->mode);
           if (stagedMode != nullptr) {
             wlr_output_state_set_mode(&state, stagedMode);
           } else {
-            wlr_output_state_set_custom_mode(&state, configured.width, configured.height, configured.refreshMHz);
+            wlr_output_state_set_custom_mode(&state, rule->mode->width, rule->mode->height, rule->mode->refreshMHz);
           }
         }
       } else if (!wlr_output_is_wl(m_output)) {
@@ -282,122 +307,196 @@ namespace umbriel {
       if (rule != nullptr && rule->transform) {
         wlr_output_state_set_transform(&state, static_cast<wl_output_transform>(*rule->transform));
       }
-      vrrRequested = configuredVrrEnabled();
-      if (m_output->adaptive_sync_supported) {
-        wlr_output_state_set_adaptive_sync_enabled(&state, vrrRequested);
-        vrrStaged = vrrRequested;
-      } else if (vrrRequested) {
-        kLog.warn("output '{}': VRR requested but adaptive sync is not supported", m_output->name);
-      }
+    }
 
-      std::string_view hdrFallback;
-      if (hdrRequested) {
-        if ((m_output->supported_transfer_functions & WLR_COLOR_TRANSFER_FUNCTION_ST2084_PQ) == 0) {
-          hdrFallback = "display does not advertise PQ";
-        } else if ((m_output->supported_primaries & WLR_COLOR_NAMED_PRIMARIES_BT2020) == 0) {
-          hdrFallback = "display does not advertise BT.2020 primaries";
-        } else if (!m_server->renderer()->features.output_color_transform) {
-          hdrFallback = "renderer lacks FP16 output transform";
+    // VRR variants. Try with VRR first (if requested and supported), then without.
+    const bool vrrRequested = enabled && configuredVrrEnabled();
+    const bool vrrSupported = m_output->adaptive_sync_supported;
+    if (vrrRequested && !vrrSupported) {
+      kLog.warn("output '{}': VRR requested but adaptive sync is not supported", m_output->name);
+    }
+
+    const bool tryVrrOn = vrrRequested && vrrSupported;
+
+    // HDR pre-flight.
+    std::string_view earlyHdrFail;
+    bool imageDescAvailable = false;
+    wlr_output_image_description hdrDescription{};
+    if (enabled && hdrRequested) {
+      if ((m_output->supported_transfer_functions & WLR_COLOR_TRANSFER_FUNCTION_ST2084_PQ) == 0) {
+        earlyHdrFail = "display does not advertise PQ";
+      } else if ((m_output->supported_primaries & WLR_COLOR_NAMED_PRIMARIES_BT2020) == 0) {
+        earlyHdrFail = "display does not advertise BT.2020 primaries";
+      } else if (!m_server->renderer()->features.output_color_transform) {
+        earlyHdrFail = "renderer lacks FP16 output transform";
+      } else {
+        hdrDescription = {
+            .primaries = WLR_COLOR_NAMED_PRIMARIES_BT2020,
+            .transfer_function = WLR_COLOR_TRANSFER_FUNCTION_ST2084_PQ,
+            .mastering_display_primaries = {},
+            .mastering_luminance = {},
+            .max_cll = 0,
+            .max_fall = 0,
+        };
+
+        if (!wlr_output_state_set_image_description(&state, &hdrDescription)) {
+          earlyHdrFail = "failed to stage HDR image description";
         } else {
-          const wlr_output_image_description description = {
-              .primaries = WLR_COLOR_NAMED_PRIMARIES_BT2020,
-              .transfer_function = WLR_COLOR_TRANSFER_FUNCTION_ST2084_PQ,
-              .mastering_display_primaries = {},
-              .mastering_luminance = {},
-              .max_cll = 0,
-              .max_fall = 0,
-          };
-          if (!wlr_output_state_set_image_description(&state, &description)) {
-            hdrFallback = "failed to stage HDR image description";
-          } else {
-            const wlr_drm_format_set* primaryFormats =
-                wlr_output_get_primary_formats(m_output, m_server->allocator()->buffer_caps);
-            const auto selectFormat = [&]() {
-              return selectHdrRenderFormat(m_output->render_format, [&](uint32_t format) {
-                if (primaryFormats != nullptr && wlr_drm_format_set_get(primaryFormats, format) == nullptr) {
-                  return false;
-                }
-                wlr_output_state_set_render_format(&state, format);
-                return wlr_output_test_state(m_output, &state);
-              });
-            };
-
-            std::optional<uint32_t> renderFormat = selectFormat();
-            if (!renderFormat && vrrStaged) {
-              wlr_output_state_set_adaptive_sync_enabled(&state, false);
-              vrrStaged = false;
-              renderFormat = selectFormat();
-              if (renderFormat) {
-                kLog.warn("output '{}': HDR is incompatible with VRR, keeping VRR disabled", m_output->name);
-              } else {
-                wlr_output_state_set_adaptive_sync_enabled(&state, vrrRequested);
-                vrrStaged = vrrRequested;
-              }
-            }
-            if (renderFormat) {
-              hdrAttempted = true;
-              kLog.info(
-                  "output '{}': selected HDR render format {}", m_output->name,
-                  *renderFormat == DRM_FORMAT_XRGB2101010 ? "XR30" : "XB30"
-              );
-            } else {
-              hdrFallback = "backend rejected all 10-bit HDR render formats";
-            }
-          }
+          imageDescAvailable = true;
         }
       }
-      if (!hdrFallback.empty()) {
-        setHdrFallbackReason(hdrFallback);
-      }
     }
 
-    if ((!hdrRequested && hdrWasActive) || (enabled && hdrRequested && !hdrAttempted)) {
+    const wlr_drm_format_set* primaryFormats =
+        enabled ? wlr_output_get_primary_formats(m_output, m_server->allocator()->buffer_caps) : nullptr;
+    const int bitDepth = configuredBitDepth();
+
+    std::string_view pendingHdrFail = earlyHdrFail;
+    std::string_view pendingSdr10Fail;
+    // HDR.
+    const auto tryHdrFormats = [&]() -> bool {
+      if (!(hdrRequested && imageDescAvailable)) {
+        if (imageDescAvailable || hdrWasActive) {
+          wlr_output_state_set_image_description(&state, nullptr);
+        }
+        return false;
+      }
+
+      const auto hdrFormats = hdrRenderFormatCandidates(m_output->render_format);
+      bool anyTestPassed = false;
+      bool anyCommitFailed = false;
+      for (const bool vrr : vrrPasses(tryVrrOn)) {
+        wlr_output_state_set_adaptive_sync_enabled(&state, vrr);
+        wlr_output_state_set_image_description(&state, &hdrDescription);
+        for (const uint32_t fmt : hdrFormats) {
+          if (primaryFormats != nullptr && wlr_drm_format_set_get(primaryFormats, fmt) == nullptr) {
+            continue;
+          }
+          wlr_output_state_set_render_format(&state, fmt);
+          if (!wlr_output_test_state(m_output, &state)) {
+            continue;
+          }
+          anyTestPassed = true;
+          kLog.info(
+              "output '{}': selected HDR render format {}", m_output->name,
+              fmt == DRM_FORMAT_XRGB2101010 ? "XR30" : "XB30"
+          );
+          if (wlr_output_commit_state(m_output, &state)) {
+            if (tryVrrOn && !vrr) {
+              kLog.warn("output '{}': HDR is incompatible with VRR, keeping VRR disabled", m_output->name);
+            }
+            return true;
+          }
+          anyCommitFailed = true;
+        }
+      }
+
+      if (!anyTestPassed) {
+        pendingHdrFail = "backend rejected all 10-bit HDR render formats";
+      } else if (anyCommitFailed) {
+        pendingHdrFail = "HDR commit rejected by backend";
+      }
+
       wlr_output_state_set_image_description(&state, nullptr);
-      wlr_output_state_set_render_format(&state, DRM_FORMAT_XRGB8888);
-    }
-
-    const auto commitConfiguredState = [&]() {
-      bool success = wlr_output_commit_state(m_output, &state);
-      if (!success && vrrStaged) {
-        kLog.warn("output '{}': configured state commit failed, retrying with VRR disabled", m_output->name);
-        wlr_output_state_set_adaptive_sync_enabled(&state, false);
-        vrrStaged = false;
-        success = wlr_output_commit_state(m_output, &state);
-      }
-      return success;
+      return false;
     };
 
-    bool committed = commitConfiguredState();
-    if (!committed && hdrAttempted) {
-      setHdrFallbackReason("HDR commit rejected by backend");
-      wlr_output_state_set_image_description(&state, nullptr);
-      wlr_output_state_set_render_format(&state, DRM_FORMAT_XRGB8888);
-      if (m_output->adaptive_sync_supported) {
-        wlr_output_state_set_adaptive_sync_enabled(&state, vrrRequested);
-        vrrStaged = vrrRequested;
+    // SDR10.
+    const auto trySdr10Formats = [&]() -> bool {
+      if (bitDepth != 10) {
+        return false;
       }
-      committed = commitConfiguredState();
-    }
-    bool usedModeFallback = false;
-    if (!committed && configuredMode != nullptr) {
-      if (wlr_output_mode* fallback = preferredFallbackMode(m_output, stagedMode)) {
-        usedModeFallback = true;
-        if (!m_modeFallbackWarned) {
-          m_modeFallbackWarned = true;
-          const std::string requested = configuredMode->refreshMHz != 0
-              ? std::format("{}x{}@{}mHz", configuredMode->width, configuredMode->height, configuredMode->refreshMHz)
-              : std::format("{}x{}", configuredMode->width, configuredMode->height);
-          kLog.warn(
-              "output '{}': configured mode {} could not be applied, using preferred mode {}x{}@{}mHz", m_output->name,
-              requested, fallback->width, fallback->height, fallback->refresh
+
+      bool anyTestPassed = false;
+      bool anyCommitFailed = false;
+      for (const bool vrr : vrrPasses(tryVrrOn)) {
+        wlr_output_state_set_adaptive_sync_enabled(&state, vrr);
+        const auto accepted = selectSdr10RenderFormat([&](uint32_t fmt) {
+          if (primaryFormats != nullptr && wlr_drm_format_set_get(primaryFormats, fmt) == nullptr) {
+            return false;
+          }
+          wlr_output_state_set_render_format(&state, fmt);
+          if (!wlr_output_test_state(m_output, &state)) {
+            return false;
+          }
+          anyTestPassed = true;
+          kLog.info(
+              "output '{}': selected 10-bit SDR render format {}", m_output->name,
+              fmt == DRM_FORMAT_XRGB2101010 ? "XR30" : "XB30"
           );
+          if (wlr_output_commit_state(m_output, &state)) {
+            return true;
+          }
+          anyCommitFailed = true;
+          return false;
+        });
+        if (accepted) {
+          return true;
         }
-        wlr_output_state_set_mode(&state, fallback);
-        committed = commitConfiguredState();
       }
+      if (!anyTestPassed) {
+        pendingSdr10Fail = "backend rejected all 10-bit SDR render formats";
+      } else if (anyCommitFailed) {
+        pendingSdr10Fail = "10-bit SDR commit rejected by backend";
+      }
+      return false;
+    };
+
+    // SDR8.
+    const auto trySdr8Formats = [&]() -> bool {
+      wlr_output_state_set_render_format(&state, DRM_FORMAT_XRGB8888);
+      for (const bool vrr : vrrPasses(tryVrrOn)) {
+        wlr_output_state_set_adaptive_sync_enabled(&state, vrr);
+        if (wlr_output_test_state(m_output, &state) && wlr_output_commit_state(m_output, &state)) {
+          return true;
+        }
+      }
+
+      return false;
+    };
+
+    // Runs the (HDR -> SDR10 -> SDR8) x VRR probe + commit sequence for whatever
+    // mode is currently staged in state. Returns true if any commit succeeded.
+    const auto runFormatSequence = [&]() -> bool { return tryHdrFormats() || trySdr10Formats() || trySdr8Formats(); };
+
+    // Execute: run the format sequence, retrying with the preferred mode on failure.
+    bool anyCommitted = false;
+    bool usedModeFallback = false;
+    if (enabled) {
+      anyCommitted = runFormatSequence();
+
+      if (!anyCommitted && configuredModeSpec != nullptr) {
+        if (wlr_output_mode* fallback = preferredFallbackMode(m_output, stagedMode)) {
+          usedModeFallback = true;
+          if (!m_modeFallbackWarned) {
+            m_modeFallbackWarned = true;
+            const std::string requested = configuredModeSpec->refreshMHz != 0
+                ? std::format(
+                      "{}x{}@{}mHz", configuredModeSpec->width, configuredModeSpec->height,
+                      configuredModeSpec->refreshMHz
+                  )
+                : std::format("{}x{}", configuredModeSpec->width, configuredModeSpec->height);
+            kLog.warn(
+                "output '{}': configured mode {} could not be applied, using preferred mode {}x{}@{}mHz",
+                m_output->name, requested, fallback->width, fallback->height, fallback->refresh
+            );
+          }
+
+          wlr_output_state_set_mode(&state, fallback);
+          pendingHdrFail = earlyHdrFail;
+          pendingSdr10Fail = {};
+          anyCommitted = runFormatSequence();
+        }
+      }
+    } else {
+      if (!hdrRequested && hdrWasActive) {
+        wlr_output_state_set_image_description(&state, nullptr);
+      }
+      anyCommitted = wlr_output_commit_state(m_output, &state);
     }
+
     wlr_output_state_finish(&state);
-    if (!committed) {
+    if (!anyCommitted) {
       kLog.error("output '{}': failed to commit configured state", m_output->name);
       return false;
     }
@@ -414,11 +513,19 @@ namespace umbriel {
     } else {
       if (!hdrRequested) {
         setHdrFallbackReason({});
+      } else if (enabled) {
+        setHdrFallbackReason(pendingHdrFail);
       }
       if (hdrWasActive) {
         m_gammaDirty = true;
       }
       m_hdrGammaWarningLogged = false;
+    }
+    const bool tenBitSdrIsActive = tenBitSdrActive();
+    if (tenBitSdrIsActive || hdrIsActive || bitDepth != 10) {
+      setTenBitFallbackReason({});
+    } else if (enabled) {
+      setTenBitFallbackReason(pendingSdr10Fail);
     }
     updateSceneSdrWhite();
     m_server->updateIdleInhibit();

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -7,9 +7,9 @@
 #include "layer/layer_surface.h"
 #include "output/format_sequence.h"
 #include "output/frame_schedule.h"
-#include "output/hdr_format.h"
 #include "output/identity.h"
 #include "output/mode_selection.h"
+#include "output/sdr_format.h"
 #include "overview/overview.h"
 #include "scene/cheatsheet.h"
 #include "scene/config_banner.h"
@@ -135,9 +135,7 @@ namespace umbriel {
   bool Output::hdrActive() const { return m_output->image_description != nullptr; }
 
   bool Output::tenBitSdrActive() const {
-    return m_output->enabled
-        && !hdrActive()
-        && (m_output->render_format == DRM_FORMAT_XRGB2101010 || m_output->render_format == DRM_FORMAT_XBGR2101010);
+    return deriveTenBitSdrActive(m_output->enabled, hdrActive(), m_output->render_format);
   }
 
   float Output::configuredSdrWhite() const {
@@ -395,7 +393,6 @@ namespace umbriel {
           .currentRenderFormat = m_output->render_format,
           .bitDepth = bitDepth,
           .tryVrrOn = tryVrrOn,
-          .stagedMode = stagedMode,
           .configuredModeSpec = configuredModeSpec,
           .preferredMode = preferredFallbackMode(m_output, stagedMode),
           .modeFallbackAlreadyWarned = m_modeFallbackWarned,

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -5,6 +5,7 @@
 #include "core/log.h"
 #include "input/seat.h"
 #include "layer/layer_surface.h"
+#include "output/format_sequence.h"
 #include "output/frame_schedule.h"
 #include "output/hdr_format.h"
 #include "output/identity.h"
@@ -33,12 +34,6 @@ namespace umbriel {
   namespace {
     constexpr Logger kLog("output");
     constexpr int kFrameRetryDelayMs = 16;
-
-    std::span<const bool> vrrPasses(bool tryVrrOn) {
-      static constexpr bool kBothPasses[] = {true, false};
-      static constexpr bool kNoVrrPass[] = {false};
-      return tryVrrOn ? std::span<const bool>(kBothPasses) : std::span<const bool>(kNoVrrPass);
-    }
 
   } // namespace
 
@@ -351,143 +346,87 @@ namespace umbriel {
         enabled ? wlr_output_get_primary_formats(m_output, m_server->allocator()->buffer_caps) : nullptr;
     const int bitDepth = configuredBitDepth();
 
-    std::string_view pendingHdrFail = earlyHdrFail;
-    std::string_view pendingSdr10Fail;
-    // HDR.
-    const auto tryHdrFormats = [&]() -> bool {
-      if (!(hdrRequested && imageDescAvailable)) {
-        if (imageDescAvailable || hdrWasActive) {
-          wlr_output_state_set_image_description(&state, nullptr);
+    const auto makeProbeHdr = [&](bool withImageDesc) {
+      return [&, withImageDesc](uint32_t fmt, bool vrr) -> ProbeOutcome {
+        if (primaryFormats != nullptr && wlr_drm_format_set_get(primaryFormats, fmt) == nullptr) {
+          return ProbeOutcome::TestFailed;
         }
-        return false;
-      }
-
-      const auto hdrFormats = hdrRenderFormatCandidates(m_output->render_format);
-      bool anyTestPassed = false;
-      bool anyCommitFailed = false;
-      for (const bool vrr : vrrPasses(tryVrrOn)) {
         wlr_output_state_set_adaptive_sync_enabled(&state, vrr);
-        wlr_output_state_set_image_description(&state, &hdrDescription);
-        for (const uint32_t fmt : hdrFormats) {
-          if (primaryFormats != nullptr && wlr_drm_format_set_get(primaryFormats, fmt) == nullptr) {
-            continue;
-          }
-          wlr_output_state_set_render_format(&state, fmt);
-          if (!wlr_output_test_state(m_output, &state)) {
-            continue;
-          }
-          anyTestPassed = true;
-          kLog.info(
-              "output '{}': selected HDR render format {}", m_output->name,
-              fmt == DRM_FORMAT_XRGB2101010 ? "XR30" : "XB30"
-          );
-          if (wlr_output_commit_state(m_output, &state)) {
-            if (tryVrrOn && !vrr) {
-              kLog.warn("output '{}': HDR is incompatible with VRR, keeping VRR disabled", m_output->name);
-            }
-            return true;
-          }
-          anyCommitFailed = true;
+        if (withImageDesc) {
+          wlr_output_state_set_image_description(&state, &hdrDescription);
         }
-      }
-
-      if (!anyTestPassed) {
-        pendingHdrFail = "backend rejected all 10-bit HDR render formats";
-      } else if (anyCommitFailed) {
-        pendingHdrFail = "HDR commit rejected by backend";
-      }
-
-      wlr_output_state_set_image_description(&state, nullptr);
-      return false;
+        wlr_output_state_set_render_format(&state, fmt);
+        if (!wlr_output_test_state(m_output, &state)) {
+          return ProbeOutcome::TestFailed;
+        }
+        kLog.info(
+            "output '{}': selected {} render format {}", m_output->name, withImageDesc ? "HDR" : "10-bit SDR",
+            fmt == DRM_FORMAT_XRGB2101010 ? "XR30" : "XB30"
+        );
+        return wlr_output_commit_state(m_output, &state) ? ProbeOutcome::Committed : ProbeOutcome::CommitFailed;
+      };
     };
 
-    // SDR10.
-    const auto trySdr10Formats = [&]() -> bool {
-      if (bitDepth != 10) {
-        return false;
+    const auto probeSdr = [&](uint32_t fmt, bool vrr) -> ProbeOutcome {
+      if (primaryFormats != nullptr
+          && fmt != DRM_FORMAT_XRGB8888
+          && wlr_drm_format_set_get(primaryFormats, fmt) == nullptr) {
+        return ProbeOutcome::TestFailed;
       }
-
-      bool anyTestPassed = false;
-      bool anyCommitFailed = false;
-      for (const bool vrr : vrrPasses(tryVrrOn)) {
-        wlr_output_state_set_adaptive_sync_enabled(&state, vrr);
-        const auto accepted = selectSdr10RenderFormat([&](uint32_t fmt) {
-          if (primaryFormats != nullptr && wlr_drm_format_set_get(primaryFormats, fmt) == nullptr) {
-            return false;
-          }
-          wlr_output_state_set_render_format(&state, fmt);
-          if (!wlr_output_test_state(m_output, &state)) {
-            return false;
-          }
-          anyTestPassed = true;
-          kLog.info(
-              "output '{}': selected 10-bit SDR render format {}", m_output->name,
-              fmt == DRM_FORMAT_XRGB2101010 ? "XR30" : "XB30"
-          );
-          if (wlr_output_commit_state(m_output, &state)) {
-            return true;
-          }
-          anyCommitFailed = true;
-          return false;
-        });
-        if (accepted) {
-          return true;
-        }
+      wlr_output_state_set_adaptive_sync_enabled(&state, vrr);
+      wlr_output_state_set_render_format(&state, fmt);
+      if (!wlr_output_test_state(m_output, &state)) {
+        return ProbeOutcome::TestFailed;
       }
-      if (!anyTestPassed) {
-        pendingSdr10Fail = "backend rejected all 10-bit SDR render formats";
-      } else if (anyCommitFailed) {
-        pendingSdr10Fail = "10-bit SDR commit rejected by backend";
-      }
-      return false;
+      return wlr_output_commit_state(m_output, &state) ? ProbeOutcome::Committed : ProbeOutcome::CommitFailed;
     };
 
-    // SDR8.
-    const auto trySdr8Formats = [&]() -> bool {
-      wlr_output_state_set_render_format(&state, DRM_FORMAT_XRGB8888);
-      for (const bool vrr : vrrPasses(tryVrrOn)) {
-        wlr_output_state_set_adaptive_sync_enabled(&state, vrr);
-        if (wlr_output_test_state(m_output, &state) && wlr_output_commit_state(m_output, &state)) {
-          return true;
-        }
-      }
-
-      return false;
-    };
-
-    // Runs the (HDR -> SDR10 -> SDR8) x VRR probe + commit sequence for whatever
-    // mode is currently staged in state. Returns true if any commit succeeded.
-    const auto runFormatSequence = [&]() -> bool { return tryHdrFormats() || trySdr10Formats() || trySdr8Formats(); };
-
-    // Execute: run the format sequence, retrying with the preferred mode on failure.
+    // Run the format sequence, retrying with the preferred mode on failure.
     bool anyCommitted = false;
     bool usedModeFallback = false;
+    std::string_view pendingHdrFail = earlyHdrFail;
+    std::string_view pendingSdr10Fail;
+
     if (enabled) {
-      anyCommitted = runFormatSequence();
+      const FormatSequenceParams seqParams{
+          .hdrRequested = hdrRequested,
+          .imageDescAvailable = imageDescAvailable,
+          .hdrWasActive = hdrWasActive,
+          .currentRenderFormat = m_output->render_format,
+          .bitDepth = bitDepth,
+          .tryVrrOn = tryVrrOn,
+          .stagedMode = stagedMode,
+          .configuredModeSpec = configuredModeSpec,
+          .preferredMode = preferredFallbackMode(m_output, stagedMode),
+          .modeFallbackAlreadyWarned = m_modeFallbackWarned,
+          .earlyHdrFail = earlyHdrFail,
+      };
 
-      if (!anyCommitted && configuredModeSpec != nullptr) {
-        if (wlr_output_mode* fallback = preferredFallbackMode(m_output, stagedMode)) {
-          usedModeFallback = true;
-          if (!m_modeFallbackWarned) {
-            m_modeFallbackWarned = true;
-            const std::string requested = configuredModeSpec->refreshMHz != 0
-                ? std::format(
-                      "{}x{}@{}mHz", configuredModeSpec->width, configuredModeSpec->height,
-                      configuredModeSpec->refreshMHz
-                  )
-                : std::format("{}x{}", configuredModeSpec->width, configuredModeSpec->height);
-            kLog.warn(
-                "output '{}': configured mode {} could not be applied, using preferred mode {}x{}@{}mHz",
-                m_output->name, requested, fallback->width, fallback->height, fallback->refresh
-            );
-          }
+      const FormatSequenceOps seqOps{
+          .probeSdr = probeSdr,
+          .probeHdr = makeProbeHdr(true),
+          .clearImageDescription = [&] { wlr_output_state_set_image_description(&state, nullptr); },
+          .stageMode = [&](wlr_output_mode* mode) { wlr_output_state_set_mode(&state, mode); },
+          .warnModeFallback =
+              [&](std::string_view requested, const wlr_output_mode& fallback) {
+                kLog.warn(
+                    "output '{}': configured mode {} could not be applied, using preferred mode "
+                    "{}x{}@{}mHz",
+                    m_output->name, requested, fallback.width, fallback.height, fallback.refresh
+                );
+              },
+          .warnHdrVrrIncompatible =
+              [&] { kLog.warn("output '{}': HDR is incompatible with VRR, keeping VRR disabled", m_output->name); },
+      };
 
-          wlr_output_state_set_mode(&state, fallback);
-          pendingHdrFail = earlyHdrFail;
-          pendingSdr10Fail = {};
-          anyCommitted = runFormatSequence();
-        }
+      const FormatSequenceResult seq = runFormatSequence(seqParams, seqOps);
+      anyCommitted = seq.committed;
+      usedModeFallback = seq.usedModeFallback;
+      if (seq.modeFallbackWarnedNow) {
+        m_modeFallbackWarned = true;
       }
+      pendingHdrFail = seq.hdrFail;
+      pendingSdr10Fail = seq.sdr10Fail;
     } else {
       if (!hdrRequested && hdrWasActive) {
         wlr_output_state_set_image_description(&state, nullptr);

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -13,6 +13,7 @@
 struct wlr_gamma_control_v1;
 struct wlr_output;
 struct wlr_output_layout_output;
+struct wlr_output_state;
 struct wlr_scene_output;
 struct wlr_scene_optimized_blur;
 struct wlr_scene_tree;
@@ -75,8 +76,11 @@ namespace umbriel {
     [[nodiscard]] HdrMode hdrMode() const;
     [[nodiscard]] bool hdrRequested() const;
     [[nodiscard]] bool hdrActive() const;
+    [[nodiscard]] bool tenBitSdrActive() const;
     [[nodiscard]] const std::string& hdrFallbackReason() const { return m_hdrFallbackReason; }
     [[nodiscard]] float configuredSdrWhite() const;
+    [[nodiscard]] int configuredBitDepth() const;
+    [[nodiscard]] const std::string& tenBitSdrFallbackReason() const { return m_tenBitFallbackReason; }
     [[nodiscard]] bool configuredDirectScanoutEnabled() const;
     [[nodiscard]] bool configuredTearingAllowed() const;
     [[nodiscard]] bool tearingRequested() const;
@@ -127,6 +131,7 @@ namespace umbriel {
     [[nodiscard]] View* findAutoHdrCandidate() const;
     [[nodiscard]] bool configuredVrrEnabled() const;
     void setHdrFallbackReason(std::string_view reason);
+    void setTenBitFallbackReason(std::string_view reason);
     void updateSceneSdrWhite();
     void rejectGammaControl(wlr_gamma_control_v1* control);
     void armFrameRetry();
@@ -156,17 +161,18 @@ namespace umbriel {
     bool m_softwareCursorLocked = false;
     bool m_animationRenderLocked = false;
     bool m_dpmsOff = false;
-    bool m_hdrGammaWarningLogged = false;
+    bool m_appliedConfiguredScale = false;
     bool m_modeFallbackWarned = false;
+    bool m_hdrGammaWarningLogged = false;
     bool m_fullscreenHdrRequested = false;
     bool m_lastHdrRequested = false;
     bool m_lastCommitTearing = false;
     bool m_trackingPresentation = false;
-    bool m_appliedConfiguredScale = false;
     wl_event_source* m_frameRetryTimer = nullptr;
     View* m_autoHdrOwner = nullptr;
     std::string m_hdrFallbackReason;
     std::string m_tearingFallbackReason;
+    std::string m_tenBitFallbackReason;
     std::optional<bool> m_lastPresentationPresented;
     std::optional<uint32_t> m_lastPresentationFlags;
     uint32_t m_trackedPresentationCommitSeq = 0;

--- a/src/output/sdr_format.h
+++ b/src/output/sdr_format.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+#include <drm_fourcc.h>
+#include <optional>
+
+namespace umbriel {
+
+  template <typename Probe> [[nodiscard]] std::optional<uint32_t> selectSdr10RenderFormat(Probe&& accepts) {
+    for (const uint32_t candidate : {DRM_FORMAT_XRGB2101010, DRM_FORMAT_XBGR2101010}) {
+      if (accepts(candidate)) {
+        return candidate;
+      }
+    }
+    return std::nullopt;
+  }
+
+  [[nodiscard]] inline bool deriveTenBitSdrActive(bool enabled, bool hdrActive, uint32_t renderFormat) {
+    return enabled && !hdrActive && (renderFormat == DRM_FORMAT_XRGB2101010 || renderFormat == DRM_FORMAT_XBGR2101010);
+  }
+
+} // namespace umbriel

--- a/src/server/ipc_commands.cpp
+++ b/src/server/ipc_commands.cpp
@@ -267,15 +267,26 @@ namespace umbriel {
       for (const auto& output : ok.at("outputs")) {
         const std::string fallback = output.value("fallback_reason", "");
         std::println(
-            "output {}: HDR mode {}, requested {}, active {}, format {}, {}, {}, SDR white {} cd/m2",
+            "output {}: HDR mode {}, requested {}, active {}, format {}, {}, {}, SDR white {} cd/m2, SDR depth {}",
             output.value("name", ""), output.value("hdr_mode", "off"),
             output.value("hdr_requested", false) ? "yes" : "no", output.value("hdr_active", false) ? "yes" : "no",
             output.value("render_format", "invalid"), output.value("transfer_function", "none"),
-            output.value("primaries", "none"), output.value("sdr_white", 0.0)
+            output.value("primaries", "none"), output.value("sdr_white", 0.0), output.value("bit_depth", 8)
         );
+
         if (!fallback.empty()) {
           std::println("  fallback: {}", fallback);
         }
+
+        if (const int bitDepth = output.value("bit_depth", 8); bitDepth != 8) {
+          const std::string bitFallback = output.value("bit_depth_fallback_reason", "");
+          if (!bitFallback.empty()) {
+            std::println("  10-bit SDR unavailable: {}", bitFallback);
+          } else if (output.value("sdr10_active", false)) {
+            std::println("  10-bit SDR: active");
+          }
+        }
+
         std::println(
             "  supported transfer functions: {}; primaries: {}", joinNames(output.at("supported_transfer_functions")),
             joinNames(output.at("supported_primaries"))
@@ -448,6 +459,9 @@ namespace umbriel {
           {"transfer_function", description != nullptr ? transferFunctionName(description->transfer_function) : "none"},
           {"primaries", description != nullptr ? primariesName(description->primaries) : "none"},
           {"sdr_white", output->configuredSdrWhite()},
+          {"bit_depth", output->configuredBitDepth()},
+          {"sdr10_active", output->tenBitSdrActive()},
+          {"bit_depth_fallback_reason", output->tenBitSdrFallbackReason()},
           {"supported_transfer_functions", supportedTransferFunctions(wlrOutput->supported_transfer_functions)},
           {"supported_primaries", supportedPrimaries(wlrOutput->supported_primaries)},
       });

--- a/src/server/ipc_commands.cpp
+++ b/src/server/ipc_commands.cpp
@@ -451,6 +451,8 @@ namespace umbriel {
       const wlr_output_image_description* description = wlrOutput->image_description;
       outputs.push_back({
           {"name", wlrOutput->name},
+          {"enabled", output->configuredEnabled()},
+          {"dpms_off", output->dpmsOff()},
           {"hdr_mode", hdrModeName(output->hdrMode())},
           {"hdr_requested", output->hdrRequested()},
           {"hdr_active", output->hdrActive()},

--- a/tests/harness/checks/641_sdr10.sh
+++ b/tests/harness/checks/641_sdr10.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # 10-bit SDR format selection.
 #   0. umbrielfx rendering phase: corner_radius + optimized blur active when the
-#      bit-depth switches. Exercises fx_pass.c and the FP16 offscreen buffer path.
+#      bit-depth switches in both directions. Exercises fx_pass.c, the FP16
+#      offscreen buffer path, and confirms the blur cache survives the full
+#      SDR8 -> SDR10 -> SDR8 round-trip.
 #   1. SDR8 -> SDR10: Probe succeeds, output commits to XR30 or XB30, no fallback reason.
 #   2. HDR (unavailable) -> SDR10: HDR reason clears when HDR is no longer
 #      requested; SDR10 independently selects XR30 or XB30.
@@ -102,6 +104,41 @@ if (( luma_sdr10 == 0 )); then
   exit 1
 fi
 echo "phase0: SDR10 frame rendered correctly after format switch (luma=${luma_sdr10})"
+
+# Switch back to SDR8 while FX effects remain live: the blur cache and
+# corner-radius geometry must survive the SDR10 -> SDR8 transition too.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[colors]
+backdrop = "#1e1e2eff"
+
+[appearance]
+corner_radius = 32
+
+[appearance.blur]
+enabled = true
+optimized = true
+passes = 2
+radius = 8
+noise = 0.0
+brightness = 1.0
+contrast = 1.0
+saturation = 1.0
+
+[[window_rule]]
+blur = true
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+sleep 0.3
+readonly SCREENSHOT_SDR8_RETURN="$UMBRIEL_RUNTIME_DIR/sdr10-luma-sdr8-return.png"
+grim "$SCREENSHOT_SDR8_RETURN"
+luma_sdr8_return=$(magick "$SCREENSHOT_SDR8_RETURN" -alpha off -colorspace gray -format '%[fx:round(255*mean)]' info:)
+if (( luma_sdr8_return == 0 )); then
+  echo "phase0: SDR8 screenshot after SDR10->SDR8 transition is all-black (mean luma=${luma_sdr8_return})"
+  exit 1
+fi
+echo "phase0: SDR8 frame rendered correctly after SDR10->SDR8 back-transition (luma=${luma_sdr8_return})"
 
 
 # Headless accepts XR30 or XB30 via wlr_output_test_state (XR30 is tried first),

--- a/tests/harness/checks/641_sdr10.sh
+++ b/tests/harness/checks/641_sdr10.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# 10-bit SDR format selection.
+#   0. umbrielfx rendering phase: corner_radius + optimized blur active when the
+#      bit-depth switches. Exercises fx_pass.c and the FP16 offscreen buffer path.
+#   1. SDR8 -> SDR10: Probe succeeds, output commits to XR30 or XB30, no fallback reason.
+#   2. HDR (unavailable) -> SDR10: HDR reason clears when HDR is no longer
+#      requested; SDR10 independently selects XR30 or XB30.
+#   3. HDR unavailable + SDR10 configured: The HDR reason stays set while SDR10
+#      commits XR30 or XB30 successfully.
+#   4. SDR10 -> SDR8: No fallback reason, output returns to XR24.
+set -euo pipefail
+
+readonly SCREENSHOT_SDR8="$UMBRIEL_RUNTIME_DIR/sdr10-luma-sdr8.png"
+readonly SCREENSHOT_SDR10="$UMBRIEL_RUNTIME_DIR/sdr10-luma-sdr10.png"
+
+BASELINE=$(< "$UMBRIEL_CONFIG")
+CLIENT_PID=
+
+# -- Phase 0: umbrielfx rendering ---------------------------------------------
+# Enable corner_radius and optimized blur so that the FX renderer populates the
+# per-output blur cache and the corner-radius clip geometry in SDR8, then switch
+# to bit_depth=10 while the window and effects are live. This exercises the
+# fx_pass.c SDR10 render path and the FP16 offscreen buffer selection.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[colors]
+backdrop = "#1e1e2eff"
+
+[appearance]
+corner_radius = 32
+
+[appearance.blur]
+enabled = true
+optimized = true
+passes = 2
+radius = 8
+noise = 0.0
+brightness = 1.0
+contrast = 1.0
+saturation = 1.0
+
+[[window_rule]]
+blur = true
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+foot --config=/dev/null sh -c 'while :; do sleep 1; done' > /dev/null 2>&1 &
+CLIENT_PID=$!
+for _ in $(seq 60); do
+  [[ $("$UMBRIEL" windows --json | jq 'length') -ge 1 ]] && break
+  sleep 0.1
+done
+if [[ $("$UMBRIEL" windows --json | jq 'length') -lt 1 ]]; then
+  echo "phase0: foot window never mapped"
+  exit 1
+fi
+
+# Let two frames render with the FX effects active to populate the blur cache.
+sleep 0.3
+grim "$SCREENSHOT_SDR8"
+luma_sdr8=$(magick "$SCREENSHOT_SDR8" -alpha off -colorspace gray -format '%[fx:round(255*mean)]' info:)
+if (( luma_sdr8 == 0 )); then
+  echo "phase0: SDR8 screenshot is all-black (mean luma=${luma_sdr8})"
+  exit 1
+fi
+echo "phase0: SDR8 frame rendered with blur/corner_radius active (luma=${luma_sdr8})"
+
+# Switch to SDR10 while the FX-active window is live: the blur cache and
+# corner-radius geometry must survive the format transition.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[colors]
+backdrop = "#1e1e2eff"
+
+[appearance]
+corner_radius = 32
+
+[appearance.blur]
+enabled = true
+optimized = true
+passes = 2
+radius = 8
+noise = 0.0
+brightness = 1.0
+contrast = 1.0
+saturation = 1.0
+
+[[window_rule]]
+blur = true
+
+[output.HEADLESS-1]
+bit_depth = 10
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+sleep 0.3
+grim "$SCREENSHOT_SDR10"
+luma_sdr10=$(magick "$SCREENSHOT_SDR10" -alpha off -colorspace gray -format '%[fx:round(255*mean)]' info:)
+if (( luma_sdr10 == 0 )); then
+  echo "phase0: SDR10 screenshot is all-black after format switch (mean luma=${luma_sdr10})"
+  exit 1
+fi
+echo "phase0: SDR10 frame rendered correctly after format switch (luma=${luma_sdr10})"
+
+
+# Headless accepts XR30 or XB30 via wlr_output_test_state (XR30 is tried first),
+# so the probe succeeds and the output commits to 10-bit without a fallback reason.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+printf '\n[output.HEADLESS-1]\nbit_depth = 10\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].bit_depth == 10
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and .outputs[0].sdr10_active == true
+  and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
+' <<< "$color" > /dev/null; then
+  echo "sdr8-to-sdr10: unexpected color state: $color"
+  exit 1
+fi
+
+color_human=$("$UMBRIEL" color)
+if ! grep -F "10-bit SDR: active" <<< "$color_human" > /dev/null; then
+  echo "sdr8-to-sdr10: missing 10-bit SDR active line in human output: $color_human"
+  exit 1
+fi
+
+echo "sdr8-to-sdr10: probe succeeded, output committed to 10-bit SDR"
+
+# -- Phase 2: HDR (unavailable) -> SDR10 ---------------------------------------
+# Configure HDR first (fails on headless). Then switch to bit_depth=10 without
+# HDR. The HDR reason must clear and the output must select XR30 or XB30.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+printf '\n[output.HEADLESS-1]\nhdr = "on"\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].hdr_requested == true
+  and .outputs[0].hdr_active == false
+  and (.outputs[0].fallback_reason | length) > 0
+  and .outputs[0].render_format == "XR24"
+' <<< "$color" > /dev/null; then
+  echo "hdr-to-sdr10 setup: unexpected color state: $color"
+  exit 1
+fi
+
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+printf '\n[output.HEADLESS-1]\nbit_depth = 10\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].hdr_requested == false
+  and .outputs[0].hdr_active == false
+  and .outputs[0].fallback_reason == ""
+  and .outputs[0].bit_depth == 10
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and .outputs[0].sdr10_active == true
+  and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
+  and .outputs[0].transfer_function == "none"
+  and .outputs[0].primaries == "none"
+' <<< "$color" > /dev/null; then
+  echo "hdr-to-sdr10: unexpected color state: $color"
+  exit 1
+fi
+
+echo "hdr-to-sdr10: HDR reason cleared, SDR10 probe succeeded after transition"
+
+# -- Phase 3: HDR unavailable + SDR10 configured -------------------------------
+# When HDR and bit_depth=10 are both configured, the HDR probe fails first
+# (headless does not advertise PQ or BT.2020), then the SDR10 probe runs
+# independently and succeeds. The HDR fallback reason is set, the SDR10 reason is not.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+printf '\n[output.HEADLESS-1]\nhdr = "on"\nbit_depth = 10\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].hdr_requested == true
+  and .outputs[0].hdr_active == false
+  and (.outputs[0].fallback_reason | length) > 0
+  and .outputs[0].bit_depth == 10
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and .outputs[0].sdr10_active == true
+  and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
+' <<< "$color" > /dev/null; then
+  echo "hdr-unavailable-with-sdr10: unexpected color state: $color"
+  exit 1
+fi
+
+color_human=$("$UMBRIEL" color)
+if ! grep -F "10-bit SDR: active" <<< "$color_human" > /dev/null; then
+  echo "hdr-unavailable-with-sdr10: missing 10-bit SDR active line in human output: $color_human"
+  exit 1
+fi
+
+echo "hdr-unavailable-with-sdr10: HDR reason set, SDR10 probe succeeded independently"
+
+# -- Phase 4: SDR10 -> SDR8 ----------------------------------------------------
+# Reverting to the default config (no bit_depth override) must return the
+# output to XR24 with no bit_depth_fallback_reason.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].bit_depth == 8
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and .outputs[0].sdr10_active == false
+  and .outputs[0].render_format == "XR24"
+' <<< "$color" > /dev/null; then
+  echo "sdr10-to-sdr8: unexpected color state: $color"
+  exit 1
+fi
+
+echo "sdr10-to-sdr8: output returned to XR24, no bit_depth_fallback_reason"
+

--- a/tests/harness/checks/641_sdr10.sh
+++ b/tests/harness/checks/641_sdr10.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 # 10-bit SDR format selection.
-#   0. umbrielfx rendering phase: corner_radius + optimized blur active when the
-#      bit-depth switches in both directions. Exercises fx_pass.c, the FP16
-#      offscreen buffer path, and confirms the blur cache survives the full
-#      SDR8 -> SDR10 -> SDR8 round-trip.
-#   1. SDR8 -> SDR10: Probe succeeds, output commits to XR30 or XB30, no fallback reason.
-#   2. HDR (unavailable) -> SDR10: HDR reason clears when HDR is no longer
+#   1. umbrielfx rendering smoke test: corner_radius + optimized blur active on a
+#      live window while the bit-depth switches in both directions.
+#   2. SDR8 -> SDR10: Probe succeeds, output commits to XR30 or XB30, no fallback reason.
+#   3. HDR (unavailable) -> SDR10: HDR reason clears when HDR is no longer
 #      requested; SDR10 independently selects XR30 or XB30.
-#   3. HDR unavailable + SDR10 configured: The HDR reason stays set while SDR10
+#   4. HDR unavailable + SDR10 configured: The HDR reason stays set while SDR10
 #      commits XR30 or XB30 successfully.
-#   4. SDR10 -> SDR8: No fallback reason, output returns to XR24.
+#   5. SDR10 -> SDR8: No fallback reason, output returns to XR24.
 set -euo pipefail
 
 readonly SCREENSHOT_SDR8="$UMBRIEL_RUNTIME_DIR/sdr10-luma-sdr8.png"
@@ -18,11 +16,12 @@ readonly SCREENSHOT_SDR10="$UMBRIEL_RUNTIME_DIR/sdr10-luma-sdr10.png"
 BASELINE=$(< "$UMBRIEL_CONFIG")
 CLIENT_PID=
 
-# -- Phase 0: umbrielfx rendering ---------------------------------------------
-# Enable corner_radius and optimized blur so that the FX renderer populates the
-# per-output blur cache and the corner-radius clip geometry in SDR8, then switch
-# to bit_depth=10 while the window and effects are live. This exercises the
-# fx_pass.c SDR10 render path and the FP16 offscreen buffer selection.
+# -- Phase 1: umbrielfx rendering ---------------------------------------------
+# Enable corner_radius and optimized blur on a live window, then switch
+# bit_depth in both directions. This is a smoke test that the real FX render
+# pipeline survives a live format transition: each capture only asserts the
+# frame is non-black. Cache-format correctness is verified separately by the
+# umbrielfx unit test `color-optimized-blur-format-cache`.
 printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
 cat >> "$UMBRIEL_CONFIG" <<'EOF'
 
@@ -54,7 +53,7 @@ for _ in $(seq 60); do
   sleep 0.1
 done
 if [[ $("$UMBRIEL" windows --json | jq 'length') -lt 1 ]]; then
-  echo "phase0: foot window never mapped"
+  echo "phase1: foot window never mapped"
   exit 1
 fi
 
@@ -63,13 +62,13 @@ sleep 0.3
 grim "$SCREENSHOT_SDR8"
 luma_sdr8=$(magick "$SCREENSHOT_SDR8" -alpha off -colorspace gray -format '%[fx:round(255*mean)]' info:)
 if (( luma_sdr8 == 0 )); then
-  echo "phase0: SDR8 screenshot is all-black (mean luma=${luma_sdr8})"
+  echo "phase1: SDR8 screenshot is all-black (mean luma=${luma_sdr8})"
   exit 1
 fi
-echo "phase0: SDR8 frame rendered with blur/corner_radius active (luma=${luma_sdr8})"
+echo "phase1: SDR8 frame rendered with blur/corner_radius active (luma=${luma_sdr8})"
 
-# Switch to SDR10 while the FX-active window is live: the blur cache and
-# corner-radius geometry must survive the format transition.
+# Switch to SDR10 while the FX-active window is live: the render pipeline must
+# produce a non-black frame across the format transition.
 printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
 cat >> "$UMBRIEL_CONFIG" <<'EOF'
 
@@ -100,13 +99,13 @@ sleep 0.3
 grim "$SCREENSHOT_SDR10"
 luma_sdr10=$(magick "$SCREENSHOT_SDR10" -alpha off -colorspace gray -format '%[fx:round(255*mean)]' info:)
 if (( luma_sdr10 == 0 )); then
-  echo "phase0: SDR10 screenshot is all-black after format switch (mean luma=${luma_sdr10})"
+  echo "phase1: SDR10 screenshot is all-black after format switch (mean luma=${luma_sdr10})"
   exit 1
 fi
-echo "phase0: SDR10 frame rendered correctly after format switch (luma=${luma_sdr10})"
+echo "phase1: SDR10 frame rendered correctly after format switch (luma=${luma_sdr10})"
 
-# Switch back to SDR8 while FX effects remain live: the blur cache and
-# corner-radius geometry must survive the SDR10 -> SDR8 transition too.
+# Switch back to SDR8 while FX effects remain live: the render pipeline must
+# produce a non-black frame across the SDR10 -> SDR8 transition too.
 printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
 cat >> "$UMBRIEL_CONFIG" <<'EOF'
 
@@ -135,12 +134,13 @@ readonly SCREENSHOT_SDR8_RETURN="$UMBRIEL_RUNTIME_DIR/sdr10-luma-sdr8-return.png
 grim "$SCREENSHOT_SDR8_RETURN"
 luma_sdr8_return=$(magick "$SCREENSHOT_SDR8_RETURN" -alpha off -colorspace gray -format '%[fx:round(255*mean)]' info:)
 if (( luma_sdr8_return == 0 )); then
-  echo "phase0: SDR8 screenshot after SDR10->SDR8 transition is all-black (mean luma=${luma_sdr8_return})"
+  echo "phase1: SDR8 screenshot after SDR10->SDR8 transition is all-black (mean luma=${luma_sdr8_return})"
   exit 1
 fi
-echo "phase0: SDR8 frame rendered correctly after SDR10->SDR8 back-transition (luma=${luma_sdr8_return})"
+echo "phase1: SDR8 frame rendered correctly after SDR10->SDR8 back-transition (luma=${luma_sdr8_return})"
 
 
+# -- Phase 2: SDR8 -> SDR10 ---------------------------------------------------
 # Headless accepts XR30 or XB30 via wlr_output_test_state (XR30 is tried first),
 # so the probe succeeds and the output commits to 10-bit without a fallback reason.
 printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
@@ -166,7 +166,7 @@ fi
 
 echo "sdr8-to-sdr10: probe succeeded, output committed to 10-bit SDR"
 
-# -- Phase 2: HDR (unavailable) -> SDR10 ---------------------------------------
+# -- Phase 3: HDR (unavailable) -> SDR10 ---------------------------------------
 # Configure HDR first (fails on headless). Then switch to bit_depth=10 without
 # HDR. The HDR reason must clear and the output must select XR30 or XB30.
 printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
@@ -206,7 +206,7 @@ fi
 
 echo "hdr-to-sdr10: HDR reason cleared, SDR10 probe succeeded after transition"
 
-# -- Phase 3: HDR unavailable + SDR10 configured -------------------------------
+# -- Phase 4: HDR unavailable + SDR10 configured -------------------------------
 # When HDR and bit_depth=10 are both configured, the HDR probe fails first
 # (headless does not advertise PQ or BT.2020), then the SDR10 probe runs
 # independently and succeeds. The HDR fallback reason is set, the SDR10 reason is not.
@@ -236,7 +236,7 @@ fi
 
 echo "hdr-unavailable-with-sdr10: HDR reason set, SDR10 probe succeeded independently"
 
-# -- Phase 4: SDR10 -> SDR8 ----------------------------------------------------
+# -- Phase 5: SDR10 -> SDR8 ----------------------------------------------------
 # Reverting to the default config (no bit_depth override) must return the
 # output to XR24 with no bit_depth_fallback_reason.
 printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"

--- a/tests/harness/checks/643_sdr10_format_sequence.sh
+++ b/tests/harness/checks/643_sdr10_format_sequence.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# SDR10 format-sequence integration coverage.
+#   1. VRR + SDR10: VRR is unsupported on headless. Compositor warns and commits XR30.
+#   2. VRR off with SDR10 active: Removing VRR config while SDR10 is live keeps XR30/XB30.
+#   3. DPMS cycle: Powering off then on while bit_depth=10 is configured re-selects XR30/XB30.
+#   4. HDR failure: SDR10 with a live window: HDR fails (no PQ on headless), SDR10 then
+#      commits XR30/XB30 independently.
+#   5. Preferred-mode restart with SDR10: A bad configured mode falls back to the output's
+#      preferred mode. SDR10 must be selected on the preferred mode, not reported as unsupported.
+set -euo pipefail
+
+BASELINE=$(< "$UMBRIEL_CONFIG")
+CLIENT_PID=
+
+# -- Phase 1: VRR + SDR10 ------------------------------------------------------
+# Headless does not set adaptive_sync_supported, so the compositor logs the VRR
+# warning and proceeds without VRR. SDR10 must still commit XR30 or XB30.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+printf '\n[output.HEADLESS-1]\nbit_depth = 10\nvrr = "always"\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+if ! grep -F "output 'HEADLESS-1': VRR requested but adaptive sync is not supported" "$UMBRIEL_LOG" > /dev/null; then
+  echo "vrr-sdr10: missing expected VRR-not-supported warning in log"
+  exit 1
+fi
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].bit_depth == 10
+  and .outputs[0].sdr10_active == true
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
+' <<< "$color" > /dev/null; then
+  echo "vrr-sdr10: unexpected color state: $color"
+  exit 1
+fi
+echo "vrr-sdr10: VRR warning logged, SDR10 committed to $("$UMBRIEL" color --json | jq -r '.outputs[0].render_format')"
+
+# -- Phase 2: VRR off while SDR10 active ---------------------------------------
+# Removing vrr = "always" (reverts to disabled) while bit_depth=10 stays active.
+# The output must stay on XR30/XB30 with no bit_depth fallback reason.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+printf '\n[output.HEADLESS-1]\nbit_depth = 10\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].bit_depth == 10
+  and .outputs[0].sdr10_active == true
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
+' <<< "$color" > /dev/null; then
+  echo "vrr-off-sdr10: unexpected color state after VRR removal: $color"
+  exit 1
+fi
+echo "vrr-off-sdr10: output retained XR30/XB30 after VRR disabled"
+
+# -- Phase 3: DPMS cycle re-selects SDR10 format -------------------------------
+# Power the output off and back on while bit_depth=10 is still configured.
+# configure() must run on re-enable and select XR30/XB30 again.
+"$UMBRIEL" msg dpms-off > /dev/null
+sleep 0.1
+"$UMBRIEL" msg dpms-on > /dev/null
+sleep 0.2
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].bit_depth == 10
+  and .outputs[0].sdr10_active == true
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
+' <<< "$color" > /dev/null; then
+  echo "dpms-cycle: output did not reselect XR30/XB30 after DPMS cycle: $color"
+  exit 1
+fi
+echo "dpms-cycle: XR30/XB30 re-selected after DPMS off/on"
+
+# -- Phase 4: HDR failure -> SDR10 with a live window -------------------------
+# Open a foot window so the render pipeline is warm (blur/corner_radius geometry
+# is live), then configure hdr+bit_depth=10. HDR fails on headless (no PQ), the
+# SDR10 probe runs next and commits XR30/XB30. The FX render path must survive
+# the composite HDR-fail + SDR10-commit sequence.
+foot --config=/dev/null sh -c 'while :; do sleep 1; done' > /dev/null 2>&1 &
+CLIENT_PID=$!
+for _ in $(seq 60); do
+  [[ $("$UMBRIEL" windows --json | jq 'length') -ge 1 ]] && break
+  sleep 0.1
+done
+if [[ $("$UMBRIEL" windows --json | jq 'length') -lt 1 ]]; then
+  echo "hdr-fail-sdr10: foot window never mapped"
+  exit 1
+fi
+
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+printf '\n[output.HEADLESS-1]\nhdr = "on"\nbit_depth = 10\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].hdr_requested == true
+  and .outputs[0].hdr_active == false
+  and (.outputs[0].fallback_reason | length) > 0
+  and .outputs[0].bit_depth == 10
+  and .outputs[0].sdr10_active == true
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
+' <<< "$color" > /dev/null; then
+  echo "hdr-fail-sdr10: unexpected color state with live window: $color"
+  exit 1
+fi
+echo "hdr-fail-sdr10: HDR fallback set, SDR10 committed while render pipeline was warm"
+
+kill "$CLIENT_PID" 2>/dev/null || true
+CLIENT_PID=
+
+# -- Phase 5: Preferred-mode restart with SDR10 --------------------------------
+# Configure an impossible mode. configure() must:
+#   - Fail all format candidates for the impossible mode.
+#   - Fall back to the preferred mode.
+#   - Re-run the HDR -> SDR10 -> SDR8 sequence, which selects XR30/XB30.
+# The log must contain the "configured mode ... could not be applied" warning and
+# sdr10_active must be true with no bit_depth_fallback_reason.
+printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
+printf '\n[output.HEADLESS-1]\nbit_depth = 10\nmode = "9999x9999@999"\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+
+if ! grep -F "output 'HEADLESS-1': configured mode 9999x9999@999mHz could not be applied" "$UMBRIEL_LOG" > /dev/null; then
+  echo "mode-fallback-sdr10: missing expected mode-fallback warning in log"
+  exit 1
+fi
+
+color=$("$UMBRIEL" color --json)
+if ! jq -e '
+  .outputs[0].bit_depth == 10
+  and .outputs[0].sdr10_active == true
+  and .outputs[0].bit_depth_fallback_reason == ""
+  and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
+' <<< "$color" > /dev/null; then
+  echo "mode-fallback-sdr10: unexpected color state after preferred-mode restart: $color"
+  exit 1
+fi
+echo "mode-fallback-sdr10: SDR10 committed on preferred mode after impossible mode rejected"

--- a/tests/harness/checks/643_sdr10_format_sequence.sh
+++ b/tests/harness/checks/643_sdr10_format_sequence.sh
@@ -5,8 +5,8 @@
 #   3. DPMS cycle: Powering off then on while bit_depth=10 is configured re-selects XR30/XB30.
 #   4. HDR failure: SDR10 with a live window: HDR fails (no PQ on headless), SDR10 then
 #      commits XR30/XB30 independently.
-#   5. Preferred-mode restart with SDR10: A bad configured mode falls back to the output's
-#      preferred mode. SDR10 must be selected on the preferred mode, not reported as unsupported.
+#   5. Mode + SDR10: Configuring a mode alongside bit_depth=10 does not suppress SDR10
+#      selection (headless accepts the mode as a custom commit).
 set -euo pipefail
 
 BASELINE=$(< "$UMBRIEL_CONFIG")
@@ -113,21 +113,15 @@ echo "hdr-fail-sdr10: HDR fallback set, SDR10 committed while render pipeline wa
 kill "$CLIENT_PID" 2>/dev/null || true
 CLIENT_PID=
 
-# -- Phase 5: Preferred-mode restart with SDR10 --------------------------------
-# Configure an impossible mode. configure() must:
-#   - Fail all format candidates for the impossible mode.
-#   - Fall back to the preferred mode.
-#   - Re-run the HDR -> SDR10 -> SDR8 sequence, which selects XR30/XB30.
-# The log must contain the "configured mode ... could not be applied" warning and
-# sdr10_active must be true with no bit_depth_fallback_reason.
+# -- Phase 5: SDR10 with a configured mode ------------------------------------
+# Configure bit_depth=10 alongside a mode spec. On headless the mode is committed
+# as a custom mode (headless has no fixed mode list), so no mode-fallback warning
+# is emitted. SDR10 is still selected and there is no bit_depth_fallback_reason.
+# i.e. the format sequence runs correctly regardless of whether the mode came
+# from the mode list or a custom commit.
 printf '%s\n' "$BASELINE" > "$UMBRIEL_CONFIG"
 printf '\n[output.HEADLESS-1]\nbit_depth = 10\nmode = "9999x9999@999"\n' >> "$UMBRIEL_CONFIG"
 "$UMBRIEL" msg config-reload > /dev/null
-
-if ! grep -F "output 'HEADLESS-1': configured mode 9999x9999@999mHz could not be applied" "$UMBRIEL_LOG" > /dev/null; then
-  echo "mode-fallback-sdr10: missing expected mode-fallback warning in log"
-  exit 1
-fi
 
 color=$("$UMBRIEL" color --json)
 if ! jq -e '
@@ -136,7 +130,7 @@ if ! jq -e '
   and .outputs[0].bit_depth_fallback_reason == ""
   and (.outputs[0].render_format == "XR30" or .outputs[0].render_format == "XB30")
 ' <<< "$color" > /dev/null; then
-  echo "mode-fallback-sdr10: unexpected color state after preferred-mode restart: $color"
+  echo "mode-with-sdr10: unexpected color state with mode+bit_depth configured: $color"
   exit 1
 fi
-echo "mode-fallback-sdr10: SDR10 committed on preferred mode after impossible mode rejected"
+echo "mode-with-sdr10: SDR10 committed correctly alongside a configured mode"

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -18,6 +18,7 @@ unit_tests = [
   ['output-identity', ['unit/output_identity.cpp'], []],
   ['output-mode-selection', ['unit/output_mode_selection.cpp'], []],
   ['output-frame-schedule', ['unit/output_frame_schedule.cpp'], []],
+  ['output-format-sequence', ['unit/output_format_sequence.cpp'], []],
   ['hdr-format', ['unit/hdr_format.cpp'], []],
   ['layout-struts', ['unit/layout_struts.cpp'], []],
   ['scrolling-layout', ['unit/scrolling_layout.cpp'], []],

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -20,6 +20,7 @@ unit_tests = [
   ['output-frame-schedule', ['unit/output_frame_schedule.cpp'], []],
   ['output-format-sequence', ['unit/output_format_sequence.cpp'], []],
   ['hdr-format', ['unit/hdr_format.cpp'], []],
+  ['sdr-format', ['unit/sdr_format.cpp'], []],
   ['layout-struts', ['unit/layout_struts.cpp'], []],
   ['scrolling-layout', ['unit/scrolling_layout.cpp'], []],
   ['dwindle-layout', ['unit/dwindle_layout.cpp'], []],

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -1226,6 +1226,35 @@ UMBRIEL_TEST(outputHdrPolicyAndSdrWhiteLoad) {
   CHECK(containsDiagnostic(store, "ignoring output.DP-1.hdr"));
 }
 
+UMBRIEL_TEST(outputBitDepthLoadsAndDefaults8) {
+  const TempConfig file;
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  file.write("[output.DP-1]\n");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().outputs.size(), size_t{1});
+  CHECK_EQ(store.config().outputs[0].bitDepth, 8);
+
+  file.write("[output.DP-1]\nbit_depth = 10\n");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().outputs[0].bitDepth, 10);
+
+  file.write("[output.DP-1]\nbit_depth = 8\n");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().outputs[0].bitDepth, 8);
+
+  file.write("[output.DP-1]\nbit_depth = 12\n");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().outputs[0].bitDepth, 8);
+  CHECK(containsDiagnostic(store, "ignoring output.DP-1.bit_depth"));
+
+  file.write("[output.DP-1]\nbit_depth = \"ten\"\n");
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().outputs[0].bitDepth, 8);
+  CHECK(containsDiagnostic(store, "ignoring output.DP-1.bit_depth"));
+}
+
 UMBRIEL_TEST(windowOutputPoliciesLoadAndRejectInvalidValues) {
   const TempConfig file;
   ConfigStore& store = umbriel::configStore();

--- a/tests/unit/hdr_format.cpp
+++ b/tests/unit/hdr_format.cpp
@@ -5,7 +5,21 @@
 #include <optional>
 #include <vector>
 
+using umbriel::hdrRenderFormatCandidates;
 using umbriel::selectHdrRenderFormat;
+using umbriel::selectSdr10RenderFormat;
+
+UMBRIEL_TEST(candidatesNonXbgrCurrentYieldsXrgbFirst) {
+  const auto candidates = hdrRenderFormatCandidates(DRM_FORMAT_XRGB8888);
+  CHECK_EQ(candidates[0], uint32_t{DRM_FORMAT_XRGB2101010});
+  CHECK_EQ(candidates[1], uint32_t{DRM_FORMAT_XBGR2101010});
+}
+
+UMBRIEL_TEST(candidatesXbgrCurrentYieldsXbgrFirst) {
+  const auto candidates = hdrRenderFormatCandidates(DRM_FORMAT_XBGR2101010);
+  CHECK_EQ(candidates[0], uint32_t{DRM_FORMAT_XBGR2101010});
+  CHECK_EQ(candidates[1], uint32_t{DRM_FORMAT_XRGB2101010});
+}
 
 UMBRIEL_TEST(rejectedXrgbFallsBackToXbgr) {
   std::vector<uint32_t> probed;
@@ -51,6 +65,44 @@ UMBRIEL_TEST(rejectedTenBitFormatsReturnNothing) {
 
   CHECK_EQ(selected, std::optional<uint32_t>{});
   CHECK_EQ(probed.size(), size_t{2});
+}
+
+UMBRIEL_TEST(sdr10XR30AcceptedShortCircuits) {
+  std::vector<uint32_t> probed;
+  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
+    probed.push_back(format);
+    return true;
+  });
+
+  CHECK_EQ(selected, std::optional<uint32_t>{DRM_FORMAT_XRGB2101010});
+  CHECK_EQ(probed.size(), size_t{1});
+  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
+}
+
+UMBRIEL_TEST(sdr10XR30RejectedFallsBackToXB30) {
+  std::vector<uint32_t> probed;
+  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
+    probed.push_back(format);
+    return format == DRM_FORMAT_XBGR2101010;
+  });
+
+  CHECK_EQ(selected, std::optional<uint32_t>{DRM_FORMAT_XBGR2101010});
+  CHECK_EQ(probed.size(), size_t{2});
+  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
+  CHECK_EQ(probed[1], uint32_t{DRM_FORMAT_XBGR2101010});
+}
+
+UMBRIEL_TEST(sdr10BothRejectedReturnsNothing) {
+  std::vector<uint32_t> probed;
+  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
+    probed.push_back(format);
+    return false;
+  });
+
+  CHECK_EQ(selected, std::optional<uint32_t>{});
+  CHECK_EQ(probed.size(), size_t{2});
+  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
+  CHECK_EQ(probed[1], uint32_t{DRM_FORMAT_XBGR2101010});
 }
 
 int main() { return RUN_TESTS(); }

--- a/tests/unit/hdr_format.cpp
+++ b/tests/unit/hdr_format.cpp
@@ -7,7 +7,6 @@
 
 using umbriel::hdrRenderFormatCandidates;
 using umbriel::selectHdrRenderFormat;
-using umbriel::selectSdr10RenderFormat;
 
 UMBRIEL_TEST(candidatesNonXbgrCurrentYieldsXrgbFirst) {
   const auto candidates = hdrRenderFormatCandidates(DRM_FORMAT_XRGB8888);
@@ -65,44 +64,6 @@ UMBRIEL_TEST(rejectedTenBitFormatsReturnNothing) {
 
   CHECK_EQ(selected, std::optional<uint32_t>{});
   CHECK_EQ(probed.size(), size_t{2});
-}
-
-UMBRIEL_TEST(sdr10XR30AcceptedShortCircuits) {
-  std::vector<uint32_t> probed;
-  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
-    probed.push_back(format);
-    return true;
-  });
-
-  CHECK_EQ(selected, std::optional<uint32_t>{DRM_FORMAT_XRGB2101010});
-  CHECK_EQ(probed.size(), size_t{1});
-  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
-}
-
-UMBRIEL_TEST(sdr10XR30RejectedFallsBackToXB30) {
-  std::vector<uint32_t> probed;
-  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
-    probed.push_back(format);
-    return format == DRM_FORMAT_XBGR2101010;
-  });
-
-  CHECK_EQ(selected, std::optional<uint32_t>{DRM_FORMAT_XBGR2101010});
-  CHECK_EQ(probed.size(), size_t{2});
-  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
-  CHECK_EQ(probed[1], uint32_t{DRM_FORMAT_XBGR2101010});
-}
-
-UMBRIEL_TEST(sdr10BothRejectedReturnsNothing) {
-  std::vector<uint32_t> probed;
-  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
-    probed.push_back(format);
-    return false;
-  });
-
-  CHECK_EQ(selected, std::optional<uint32_t>{});
-  CHECK_EQ(probed.size(), size_t{2});
-  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
-  CHECK_EQ(probed[1], uint32_t{DRM_FORMAT_XBGR2101010});
 }
 
 int main() { return RUN_TESTS(); }

--- a/tests/unit/ipc_commands.cpp
+++ b/tests/unit/ipc_commands.cpp
@@ -42,6 +42,8 @@ namespace {
   nlohmann::json colorPayload(nlohmann::json outputOverrides) {
     nlohmann::json output = {
         {"name", "HEADLESS-1"},
+        {"enabled", true},
+        {"dpms_off", false},
         {"hdr_mode", "off"},
         {"hdr_requested", false},
         {"hdr_active", false},
@@ -201,6 +203,71 @@ UMBRIEL_TEST(colorHumanHdrFallbackWithSdr10Active) {
   );
   CHECK(out.contains("fallback: display does not advertise PQ"));
   CHECK(out.contains("10-bit SDR: active"));
+}
+
+UMBRIEL_TEST(colorJsonEnabledFieldPresent) {
+  const nlohmann::json payload = colorPayload(nlohmann::json::object());
+  CHECK(payload["outputs"][0].contains("enabled"));
+  CHECK(payload["outputs"][0]["enabled"] == true);
+}
+
+UMBRIEL_TEST(colorJsonDisabledOutput) {
+  const nlohmann::json payload = colorPayload({{"enabled", false}});
+  CHECK(payload["outputs"][0]["enabled"] == false);
+}
+
+UMBRIEL_TEST(colorJsonDpmsOffFieldPresent) {
+  const nlohmann::json payload = colorPayload({{"dpms_off", true}});
+  CHECK(payload["outputs"][0].contains("dpms_off"));
+  CHECK(payload["outputs"][0]["dpms_off"] == true);
+}
+
+UMBRIEL_TEST(colorJsonSdr10XR30Fields) {
+  const nlohmann::json payload = colorPayload({
+      {"bit_depth", 10},
+      {"sdr10_active", true},
+      {"render_format", "XR30"},
+      {"bit_depth_fallback_reason", ""},
+  });
+  CHECK(payload["outputs"][0]["sdr10_active"] == true);
+  CHECK(payload["outputs"][0]["render_format"] == "XR30");
+  CHECK(payload["outputs"][0]["bit_depth_fallback_reason"] == "");
+}
+
+UMBRIEL_TEST(colorJsonSdr10XB30Fields) {
+  const nlohmann::json payload = colorPayload({
+      {"bit_depth", 10},
+      {"sdr10_active", true},
+      {"render_format", "XB30"},
+      {"bit_depth_fallback_reason", ""},
+  });
+  CHECK(payload["outputs"][0]["sdr10_active"] == true);
+  CHECK(payload["outputs"][0]["render_format"] == "XB30");
+}
+
+UMBRIEL_TEST(colorJsonXr24FallbackFields) {
+  const nlohmann::json payload = colorPayload({
+      {"bit_depth", 10},
+      {"sdr10_active", false},
+      {"render_format", "XR24"},
+      {"bit_depth_fallback_reason", "backend rejected all 10-bit SDR render formats"},
+  });
+  CHECK(payload["outputs"][0]["sdr10_active"] == false);
+  CHECK(payload["outputs"][0]["render_format"] == "XR24");
+  CHECK(payload["outputs"][0]["bit_depth_fallback_reason"] == "backend rejected all 10-bit SDR render formats");
+}
+
+UMBRIEL_TEST(colorJsonHdrActiveFields) {
+  const nlohmann::json payload = colorPayload({
+      {"hdr_active", true},
+      {"hdr_requested", true},
+      {"render_format", "XR30"},
+      {"transfer_function", "st2084_pq"},
+      {"primaries", "bt2020"},
+  });
+  CHECK(payload["outputs"][0]["hdr_active"] == true);
+  CHECK(payload["outputs"][0]["transfer_function"] == "st2084_pq");
+  CHECK(payload["outputs"][0]["primaries"] == "bt2020");
 }
 
 int main() { return RUN_TESTS(); }

--- a/tests/unit/ipc_commands.cpp
+++ b/tests/unit/ipc_commands.cpp
@@ -38,6 +38,38 @@ namespace {
     return text;
   }
 
+  // Builds a minimal color IPC payload for a single output.
+  nlohmann::json colorPayload(nlohmann::json outputOverrides) {
+    nlohmann::json output = {
+        {"name", "HEADLESS-1"},
+        {"hdr_mode", "off"},
+        {"hdr_requested", false},
+        {"hdr_active", false},
+        {"fallback_reason", ""},
+        {"render_format", "XR24"},
+        {"transfer_function", "none"},
+        {"primaries", "none"},
+        {"sdr_white", 203.0},
+        {"bit_depth", 8},
+        {"sdr10_active", false},
+        {"bit_depth_fallback_reason", ""},
+        {"supported_transfer_functions", nlohmann::json::array()},
+        {"supported_primaries", nlohmann::json::array()},
+    };
+    output.merge_patch(outputOverrides);
+    return {
+        {"color_manager", false},
+        {"renderer",
+         {
+             {"input_color_transform", false},
+             {"output_color_transform", false},
+             {"timeline", false},
+         }},
+        {"outputs", nlohmann::json::array({output})},
+        {"surfaces", nlohmann::json::array()},
+    };
+  }
+
 } // namespace
 
 UMBRIEL_TEST(keyboardLayoutsHumanOutputListsAndMarksCurrentLayout) {
@@ -57,6 +89,118 @@ UMBRIEL_TEST(keyboardLayoutsHumanOutputListsAndMarksCurrentLayout) {
       {"current_index", 1},
   };
   CHECK_EQ(captureHumanOutput(*spec, layouts), "  English (US)\n* German\n");
+}
+
+UMBRIEL_TEST(colorHumanSdr8OutputOmits10BitLine) {
+  const umbriel::IpcCommandSpec* spec = umbriel::findIpcCommand("color");
+  CHECK(spec != nullptr && spec->printHuman != nullptr);
+  if (spec == nullptr || spec->printHuman == nullptr) {
+    return;
+  }
+
+  const std::string out = captureHumanOutput(*spec, colorPayload({{"bit_depth", 8}}));
+  CHECK(!out.contains("10-bit SDR"));
+}
+
+UMBRIEL_TEST(colorHumanSdr10XR30ShowsActive) {
+  const umbriel::IpcCommandSpec* spec = umbriel::findIpcCommand("color");
+  CHECK(spec != nullptr && spec->printHuman != nullptr);
+  if (spec == nullptr || spec->printHuman == nullptr) {
+    return;
+  }
+
+  const std::string out = captureHumanOutput(
+      *spec,
+      colorPayload({
+          {"bit_depth", 10},
+          {"sdr10_active", true},
+          {"render_format", "XR30"},
+      })
+  );
+  CHECK(out.contains("10-bit SDR: active"));
+}
+
+UMBRIEL_TEST(colorHumanSdr10XB30ShowsActive) {
+  const umbriel::IpcCommandSpec* spec = umbriel::findIpcCommand("color");
+  CHECK(spec != nullptr && spec->printHuman != nullptr);
+  if (spec == nullptr || spec->printHuman == nullptr) {
+    return;
+  }
+
+  const std::string out = captureHumanOutput(
+      *spec,
+      colorPayload({
+          {"bit_depth", 10},
+          {"sdr10_active", true},
+          {"render_format", "XB30"},
+      })
+  );
+  CHECK(out.contains("10-bit SDR: active"));
+}
+
+UMBRIEL_TEST(colorHumanSdr10FallbackShowsReason) {
+  const umbriel::IpcCommandSpec* spec = umbriel::findIpcCommand("color");
+  CHECK(spec != nullptr && spec->printHuman != nullptr);
+  if (spec == nullptr || spec->printHuman == nullptr) {
+    return;
+  }
+
+  const std::string out = captureHumanOutput(
+      *spec,
+      colorPayload({
+          {"bit_depth", 10},
+          {"sdr10_active", false},
+          {"bit_depth_fallback_reason", "backend rejected all 10-bit SDR render formats"},
+      })
+  );
+  CHECK(out.contains("10-bit SDR unavailable: backend rejected all 10-bit SDR render formats"));
+}
+
+UMBRIEL_TEST(colorHumanHdrActiveOutput) {
+  const umbriel::IpcCommandSpec* spec = umbriel::findIpcCommand("color");
+  CHECK(spec != nullptr && spec->printHuman != nullptr);
+  if (spec == nullptr || spec->printHuman == nullptr) {
+    return;
+  }
+
+  const std::string out = captureHumanOutput(
+      *spec,
+      colorPayload({
+          {"hdr_mode", "on"},
+          {"hdr_requested", true},
+          {"hdr_active", true},
+          {"render_format", "XR30"},
+          {"transfer_function", "st2084_pq"},
+          {"primaries", "bt2020"},
+      })
+  );
+  // Human line: "output ...: HDR mode on, requested yes, active yes, ..."
+  CHECK(out.contains("active yes"));
+  CHECK(!out.contains("10-bit SDR"));
+}
+
+UMBRIEL_TEST(colorHumanHdrFallbackWithSdr10Active) {
+  const umbriel::IpcCommandSpec* spec = umbriel::findIpcCommand("color");
+  CHECK(spec != nullptr && spec->printHuman != nullptr);
+  if (spec == nullptr || spec->printHuman == nullptr) {
+    return;
+  }
+
+  // HDR was requested, failed (headless: no PQ), but bit_depth=10 independently committed XR30.
+  const std::string out = captureHumanOutput(
+      *spec,
+      colorPayload({
+          {"hdr_mode", "on"},
+          {"hdr_requested", true},
+          {"hdr_active", false},
+          {"fallback_reason", "display does not advertise PQ"},
+          {"render_format", "XR30"},
+          {"bit_depth", 10},
+          {"sdr10_active", true},
+      })
+  );
+  CHECK(out.contains("fallback: display does not advertise PQ"));
+  CHECK(out.contains("10-bit SDR: active"));
 }
 
 int main() { return RUN_TESTS(); }

--- a/tests/unit/ipc_commands.cpp
+++ b/tests/unit/ipc_commands.cpp
@@ -120,6 +120,7 @@ UMBRIEL_TEST(colorHumanSdr10XR30ShowsActive) {
       })
   );
   CHECK(out.contains("10-bit SDR: active"));
+  CHECK(out.contains("format XR30"));
 }
 
 UMBRIEL_TEST(colorHumanSdr10XB30ShowsActive) {
@@ -138,6 +139,7 @@ UMBRIEL_TEST(colorHumanSdr10XB30ShowsActive) {
       })
   );
   CHECK(out.contains("10-bit SDR: active"));
+  CHECK(out.contains("format XB30"));
 }
 
 UMBRIEL_TEST(colorHumanSdr10FallbackShowsReason) {
@@ -203,71 +205,6 @@ UMBRIEL_TEST(colorHumanHdrFallbackWithSdr10Active) {
   );
   CHECK(out.contains("fallback: display does not advertise PQ"));
   CHECK(out.contains("10-bit SDR: active"));
-}
-
-UMBRIEL_TEST(colorJsonEnabledFieldPresent) {
-  const nlohmann::json payload = colorPayload(nlohmann::json::object());
-  CHECK(payload["outputs"][0].contains("enabled"));
-  CHECK(payload["outputs"][0]["enabled"] == true);
-}
-
-UMBRIEL_TEST(colorJsonDisabledOutput) {
-  const nlohmann::json payload = colorPayload({{"enabled", false}});
-  CHECK(payload["outputs"][0]["enabled"] == false);
-}
-
-UMBRIEL_TEST(colorJsonDpmsOffFieldPresent) {
-  const nlohmann::json payload = colorPayload({{"dpms_off", true}});
-  CHECK(payload["outputs"][0].contains("dpms_off"));
-  CHECK(payload["outputs"][0]["dpms_off"] == true);
-}
-
-UMBRIEL_TEST(colorJsonSdr10XR30Fields) {
-  const nlohmann::json payload = colorPayload({
-      {"bit_depth", 10},
-      {"sdr10_active", true},
-      {"render_format", "XR30"},
-      {"bit_depth_fallback_reason", ""},
-  });
-  CHECK(payload["outputs"][0]["sdr10_active"] == true);
-  CHECK(payload["outputs"][0]["render_format"] == "XR30");
-  CHECK(payload["outputs"][0]["bit_depth_fallback_reason"] == "");
-}
-
-UMBRIEL_TEST(colorJsonSdr10XB30Fields) {
-  const nlohmann::json payload = colorPayload({
-      {"bit_depth", 10},
-      {"sdr10_active", true},
-      {"render_format", "XB30"},
-      {"bit_depth_fallback_reason", ""},
-  });
-  CHECK(payload["outputs"][0]["sdr10_active"] == true);
-  CHECK(payload["outputs"][0]["render_format"] == "XB30");
-}
-
-UMBRIEL_TEST(colorJsonXr24FallbackFields) {
-  const nlohmann::json payload = colorPayload({
-      {"bit_depth", 10},
-      {"sdr10_active", false},
-      {"render_format", "XR24"},
-      {"bit_depth_fallback_reason", "backend rejected all 10-bit SDR render formats"},
-  });
-  CHECK(payload["outputs"][0]["sdr10_active"] == false);
-  CHECK(payload["outputs"][0]["render_format"] == "XR24");
-  CHECK(payload["outputs"][0]["bit_depth_fallback_reason"] == "backend rejected all 10-bit SDR render formats");
-}
-
-UMBRIEL_TEST(colorJsonHdrActiveFields) {
-  const nlohmann::json payload = colorPayload({
-      {"hdr_active", true},
-      {"hdr_requested", true},
-      {"render_format", "XR30"},
-      {"transfer_function", "st2084_pq"},
-      {"primaries", "bt2020"},
-  });
-  CHECK(payload["outputs"][0]["hdr_active"] == true);
-  CHECK(payload["outputs"][0]["transfer_function"] == "st2084_pq");
-  CHECK(payload["outputs"][0]["primaries"] == "bt2020");
 }
 
 int main() { return RUN_TESTS(); }

--- a/tests/unit/output_format_sequence.cpp
+++ b/tests/unit/output_format_sequence.cpp
@@ -29,7 +29,6 @@ namespace {
         .currentRenderFormat = DRM_FORMAT_XRGB8888,
         .bitDepth = 8,
         .tryVrrOn = false,
-        .stagedMode = nullptr,
         .configuredModeSpec = nullptr,
         .preferredMode = nullptr,
         .modeFallbackAlreadyWarned = false,
@@ -223,6 +222,108 @@ UMBRIEL_TEST(modeFallbackRetriesOnPreferredMode) {
   CHECK(r.modeFallbackWarnedNow);
   CHECK(m.modeFallbackWarned);
   CHECK(m.stagedMode == &preferred);
+}
+
+// Mode fallback reruns the complete HDR -> SDR10 -> SDR8 sequence on the
+// preferred mode, and the reasons produced by the first mode do not leak into
+// the result. First mode: HDR rejected, SDR10 rejected, SDR8 rejected (no
+// commit). Preferred mode: HDR rejected, SDR10 commits (XB30), so the
+// committed result carries a fresh HDR reason and an empty SDR10 reason.
+UMBRIEL_TEST(modeFallbackRerunsFullSequenceAndResetsReasons) {
+  static wlr_output_mode preferred{};
+
+  MockOps m;
+  // 2 HDR probes per mode (XR30, XB30), both modes reject HDR entirely.
+  m.hdrOutcomes = {
+      ProbeOutcome::TestFailed, // Mode 1: HDR XR30
+      ProbeOutcome::TestFailed, // Mode 1: HDR XB30
+      ProbeOutcome::TestFailed, // Mode 2: HDR XR30
+      ProbeOutcome::TestFailed, // Mode 2: HDR XB30
+  };
+  m.sdrOutcomes = {
+      ProbeOutcome::TestFailed, // Mode 1: SDR10 XR30
+      ProbeOutcome::TestFailed, // Mode 1: SDR10 XB30
+      ProbeOutcome::TestFailed, // Mode 1: SDR8 XR24  -> Mode 1 uncommitted
+      ProbeOutcome::TestFailed, // Mode 2: SDR10 XR30
+      ProbeOutcome::Committed,  // Mode 2: SDR10 XB30 -> Commits
+  };
+
+  static const umbriel::OutputMode spec{1280, 720, 60000};
+  FormatSequenceParams p = sdr8Params();
+  p.hdrRequested = true;
+  p.imageDescAvailable = true;
+  p.bitDepth = 10;
+  p.configuredModeSpec = &spec;
+  p.preferredMode = &preferred;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(r.committed);
+  CHECK(r.usedModeFallback);
+  CHECK(r.modeFallbackWarnedNow);
+  CHECK(m.modeFallbackWarned);
+  CHECK(m.stagedMode == &preferred);
+  CHECK(m.imageDescCleared);
+
+  // The committed second mode reruns the whole sequence. HDR still failed, so a
+  // fresh HDR reason survives, while SDR10 succeeded, so its reason is cleared
+  // and does not retain the first mode's "backend rejected all" text.
+  CHECK_EQ(r.hdrFail, std::string_view{"backend rejected all 10-bit HDR render formats"});
+  CHECK(r.sdr10Fail.empty());
+
+  // Both modes ran the full HDR -> SDR10 -> SDR8 sequence. 4 HDR probes total
+  // (2 per mode) and 5 SDR probes (XR30, XB30, XR24 in mode 1; XR30, XB30 in
+  // mode 2).
+  size_t hdrCalls = 0;
+  size_t sdrCalls = 0;
+  for (const auto& c : m.calls) {
+    if (c.hdr) {
+      ++hdrCalls;
+    } else {
+      ++sdrCalls;
+    }
+  }
+  CHECK_EQ(hdrCalls, size_t{4});
+  CHECK_EQ(sdrCalls, size_t{5});
+}
+
+// Mode fallback clears a first-mode SDR10 reason when the preferred mode
+// commits SDR10 without HDR configured. The first mode rejects SDR10 and SDR8.
+// The preferred mode commits SDR10 (XR30) on the first probe, so the result
+// must carry no SDR10 fallback reason at all.
+UMBRIEL_TEST(modeFallbackClearsSdr10ReasonOnPreferredCommit) {
+  static wlr_output_mode preferred{};
+
+  MockOps m;
+  m.sdrOutcomes = {
+      ProbeOutcome::TestFailed, // Mode 1: SDR10 XR30
+      ProbeOutcome::TestFailed, // Mode 1: SDR10 XB30 -> Sets sdr10Fail
+      ProbeOutcome::TestFailed, // Mode 1: SDR8 XR24  -> Mode 1 uncommitted
+      ProbeOutcome::Committed,  // Mode 2: SDR10 XR30 -> Commits immediately
+  };
+
+  static const umbriel::OutputMode spec{1280, 720, 60000};
+  FormatSequenceParams p = sdr8Params();
+  p.bitDepth = 10;
+  p.configuredModeSpec = &spec;
+  p.preferredMode = &preferred;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(r.committed);
+  CHECK(r.usedModeFallback);
+  CHECK(m.stagedMode == &preferred);
+  CHECK(r.hdrFail.empty());
+  CHECK(r.sdr10Fail.empty());
+
+  // Mode 1: XR30, XB30, XR24. Mode 2: XR30 (commits) = 4 SDR probes, no HDR.
+  size_t sdrCalls = 0;
+  for (const auto& c : m.calls) {
+    if (!c.hdr) {
+      ++sdrCalls;
+    }
+  }
+  CHECK_EQ(sdrCalls, size_t{4});
 }
 
 // No preferred mode (headless): All formats fail, no fallback, uncommitted.

--- a/tests/unit/output_format_sequence.cpp
+++ b/tests/unit/output_format_sequence.cpp
@@ -1,0 +1,244 @@
+#include "check.h"
+#include "config/value_parse.h"
+#include "output/format_sequence.h"
+
+#include <cmath>
+#include <drm_fourcc.h>
+#include <vector>
+
+extern "C" {
+#define static
+#include <wlr/types/wlr_output.h>
+#undef static
+}
+
+using umbriel::FormatSequenceOps;
+using umbriel::FormatSequenceParams;
+using umbriel::FormatSequenceResult;
+using umbriel::ProbeOutcome;
+using umbriel::runFormatSequence;
+
+namespace {
+
+  // Minimal params. SDR8 only, no HDR, no mode override.
+  FormatSequenceParams sdr8Params() {
+    return FormatSequenceParams{
+        .hdrRequested = false,
+        .imageDescAvailable = false,
+        .hdrWasActive = false,
+        .currentRenderFormat = DRM_FORMAT_XRGB8888,
+        .bitDepth = 8,
+        .tryVrrOn = false,
+        .stagedMode = nullptr,
+        .configuredModeSpec = nullptr,
+        .preferredMode = nullptr,
+        .modeFallbackAlreadyWarned = false,
+        .earlyHdrFail = {},
+    };
+  }
+
+  // Scripted probe dispatcher. SDR and HDR probes consume outcomes in call order.
+  // The last entry repeats if the list is exhausted.
+  struct MockOps {
+    struct Call {
+      uint32_t format;
+      bool vrr;
+      bool hdr;
+    };
+
+    std::vector<Call> calls;
+    std::vector<ProbeOutcome> sdrOutcomes;
+    std::vector<ProbeOutcome> hdrOutcomes;
+    bool imageDescCleared = false;
+    bool modeFallbackWarned = false;
+    bool hdrVrrWarned = false;
+    wlr_output_mode* stagedMode = nullptr;
+
+    ProbeOutcome dispatchSdr(uint32_t fmt, bool vrr) {
+      calls.push_back({fmt, vrr, false});
+      size_t idx = 0;
+      for (const auto& c : calls) {
+        if (!c.hdr) {
+          ++idx;
+        }
+      }
+      --idx;
+      if (sdrOutcomes.empty()) {
+        return ProbeOutcome::TestFailed;
+      }
+      return sdrOutcomes[std::min(idx, sdrOutcomes.size() - 1)];
+    }
+
+    ProbeOutcome dispatchHdr(uint32_t fmt, bool vrr) {
+      calls.push_back({fmt, vrr, true});
+      size_t idx = 0;
+      for (const auto& c : calls) {
+        if (c.hdr) {
+          ++idx;
+        }
+      }
+      --idx;
+      if (hdrOutcomes.empty()) {
+        return ProbeOutcome::TestFailed;
+      }
+      return hdrOutcomes[std::min(idx, hdrOutcomes.size() - 1)];
+    }
+
+    FormatSequenceOps ops() {
+      return FormatSequenceOps{
+          .probeSdr = [this](uint32_t fmt, bool vrr) { return dispatchSdr(fmt, vrr); },
+          .probeHdr = [this](uint32_t fmt, bool vrr) { return dispatchHdr(fmt, vrr); },
+          .clearImageDescription = [this] { imageDescCleared = true; },
+          .stageMode = [this](wlr_output_mode* m) { stagedMode = m; },
+          .warnModeFallback = [this](std::string_view, const wlr_output_mode&) { modeFallbackWarned = true; },
+          .warnHdrVrrIncompatible = [this] { hdrVrrWarned = true; },
+      };
+    }
+  };
+
+} // namespace
+
+// SDR8 baseline: Single XR24 probe committed.
+UMBRIEL_TEST(sdr8CommitsXr24) {
+  MockOps m;
+  m.sdrOutcomes = {ProbeOutcome::Committed};
+
+  const FormatSequenceResult r = runFormatSequence(sdr8Params(), m.ops());
+
+  CHECK(r.committed);
+  CHECK(!r.usedModeFallback);
+  CHECK_EQ(m.calls.size(), size_t{1});
+  CHECK_EQ(m.calls[0].format, uint32_t{DRM_FORMAT_XRGB8888});
+}
+
+// SDR10: XR30 test-fails, XB30 commits.
+UMBRIEL_TEST(sdr10XR30TestFailedFallsBackToXB30) {
+  MockOps m;
+  m.sdrOutcomes = {ProbeOutcome::TestFailed, ProbeOutcome::Committed};
+
+  FormatSequenceParams p = sdr8Params();
+  p.bitDepth = 10;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(r.committed);
+  CHECK(r.sdr10Fail.empty());
+  // Two SDR probes: XR30 then XB30.
+  size_t sdrCalls = 0;
+  for (const auto& c : m.calls) {
+    if (!c.hdr) {
+      ++sdrCalls;
+    }
+  }
+  CHECK_EQ(sdrCalls, size_t{2});
+}
+
+// SDR10: Both XR30 and XB30 test-fail -> reason set, falls through to XR24.
+UMBRIEL_TEST(sdr10BothRejectedSetsFallbackReasonAndCommitsSdr8) {
+  MockOps m;
+  m.sdrOutcomes = {
+      ProbeOutcome::TestFailed, // XR30
+      ProbeOutcome::TestFailed, // XB30
+      ProbeOutcome::Committed,  // XR24 SDR8 fallback
+  };
+
+  FormatSequenceParams p = sdr8Params();
+  p.bitDepth = 10;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(r.committed);
+  CHECK_EQ(r.sdr10Fail, std::string_view{"backend rejected all 10-bit SDR render formats"});
+}
+
+// VRR retry: XR24 commit-fails with vrr=true, succeeds with vrr=false.
+UMBRIEL_TEST(vrrRetryCommitsWithoutVrr) {
+  MockOps m;
+  m.sdrOutcomes = {ProbeOutcome::CommitFailed, ProbeOutcome::Committed};
+
+  FormatSequenceParams p = sdr8Params();
+  p.tryVrrOn = true;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(r.committed);
+  CHECK_EQ(m.calls.size(), size_t{2});
+  CHECK(m.calls[0].vrr == true);
+  CHECK(m.calls[1].vrr == false);
+}
+
+// Commit failure: XR30 and XB30 test-pass but commit-fail, XR24 succeeds.
+UMBRIEL_TEST(sdr10CommitFailureFallsThroughToSdr8) {
+  MockOps m;
+  m.sdrOutcomes = {
+      ProbeOutcome::CommitFailed, // XR30
+      ProbeOutcome::CommitFailed, // XB30
+      ProbeOutcome::Committed,    // XR24
+  };
+
+  FormatSequenceParams p = sdr8Params();
+  p.bitDepth = 10;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(r.committed);
+  CHECK_EQ(r.sdr10Fail, std::string_view{"10-bit SDR commit rejected by backend"});
+}
+
+// HDR fail -> SDR10: All HDR formats test-fail, XB30 SDR10 commits.
+UMBRIEL_TEST(hdrFailFollowedBySdr10Success) {
+  MockOps m;
+  m.hdrOutcomes = {ProbeOutcome::TestFailed, ProbeOutcome::TestFailed}; // XR30, XB30 HDR
+  m.sdrOutcomes = {ProbeOutcome::TestFailed, ProbeOutcome::Committed};  // XR30 test-fail, XB30 ok
+
+  FormatSequenceParams p = sdr8Params();
+  p.hdrRequested = true;
+  p.imageDescAvailable = true;
+  p.bitDepth = 10;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(r.committed);
+  CHECK(!r.hdrFail.empty());
+  CHECK(r.sdr10Fail.empty());
+  CHECK(m.imageDescCleared);
+}
+
+// Mode fallback: All formats fail for the staged mode, preferred mode retry succeeds.
+UMBRIEL_TEST(modeFallbackRetriesOnPreferredMode) {
+  static wlr_output_mode preferred{};
+
+  MockOps m;
+  m.sdrOutcomes = {ProbeOutcome::TestFailed, ProbeOutcome::Committed};
+
+  static const umbriel::OutputMode spec{1280, 720, 60000};
+  FormatSequenceParams p = sdr8Params();
+  p.configuredModeSpec = &spec;
+  p.preferredMode = &preferred;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(r.committed);
+  CHECK(r.usedModeFallback);
+  CHECK(r.modeFallbackWarnedNow);
+  CHECK(m.modeFallbackWarned);
+  CHECK(m.stagedMode == &preferred);
+}
+
+// No preferred mode (headless): All formats fail, no fallback, uncommitted.
+UMBRIEL_TEST(noPreferredModeYieldsUncommitted) {
+  MockOps m;
+  m.sdrOutcomes = {ProbeOutcome::TestFailed};
+
+  static const umbriel::OutputMode spec{1280, 720, 60000};
+  FormatSequenceParams p = sdr8Params();
+  p.configuredModeSpec = &spec;
+  p.preferredMode = nullptr;
+
+  const FormatSequenceResult r = runFormatSequence(p, m.ops());
+
+  CHECK(!r.committed);
+  CHECK(!r.usedModeFallback);
+}
+
+int main() { return RUN_TESTS(); }

--- a/tests/unit/sdr_format.cpp
+++ b/tests/unit/sdr_format.cpp
@@ -1,0 +1,84 @@
+#include "output/sdr_format.h"
+
+#include "check.h"
+
+#include <optional>
+#include <vector>
+
+using umbriel::deriveTenBitSdrActive;
+using umbriel::selectSdr10RenderFormat;
+
+UMBRIEL_TEST(sdr10XR30AcceptedShortCircuits) {
+  std::vector<uint32_t> probed;
+  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
+    probed.push_back(format);
+    return true;
+  });
+
+  CHECK_EQ(selected, std::optional<uint32_t>{DRM_FORMAT_XRGB2101010});
+  CHECK_EQ(probed.size(), size_t{1});
+  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
+}
+
+UMBRIEL_TEST(sdr10XR30RejectedFallsBackToXB30) {
+  std::vector<uint32_t> probed;
+  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
+    probed.push_back(format);
+    return format == DRM_FORMAT_XBGR2101010;
+  });
+
+  CHECK_EQ(selected, std::optional<uint32_t>{DRM_FORMAT_XBGR2101010});
+  CHECK_EQ(probed.size(), size_t{2});
+  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
+  CHECK_EQ(probed[1], uint32_t{DRM_FORMAT_XBGR2101010});
+}
+
+UMBRIEL_TEST(sdr10BothRejectedReturnsNothing) {
+  std::vector<uint32_t> probed;
+  const auto selected = selectSdr10RenderFormat([&](uint32_t format) {
+    probed.push_back(format);
+    return false;
+  });
+
+  CHECK_EQ(selected, std::optional<uint32_t>{});
+  CHECK_EQ(probed.size(), size_t{2});
+  CHECK_EQ(probed[0], uint32_t{DRM_FORMAT_XRGB2101010});
+  CHECK_EQ(probed[1], uint32_t{DRM_FORMAT_XBGR2101010});
+}
+
+// XR30 (DRM_FORMAT_XRGB2101010) on an enabled, non-HDR output is active SDR10.
+UMBRIEL_TEST(deriveEnabledXr30IsActive) { CHECK(deriveTenBitSdrActive(true, false, DRM_FORMAT_XRGB2101010)); }
+
+// XB30 (DRM_FORMAT_XBGR2101010) on an enabled, non-HDR output is active SDR10.
+UMBRIEL_TEST(deriveEnabledXb30IsActive) { CHECK(deriveTenBitSdrActive(true, false, DRM_FORMAT_XBGR2101010)); }
+
+// The 8-bit SDR fallback format is never reported as 10-bit SDR active.
+UMBRIEL_TEST(deriveSdr8FallbackIsNotActive) { CHECK(!deriveTenBitSdrActive(true, false, DRM_FORMAT_XRGB8888)); }
+
+// An 8-bit alpha format (e.g. a nested/wl backend target) is not SDR10 either.
+UMBRIEL_TEST(deriveSdr8AlphaFormatIsNotActive) { CHECK(!deriveTenBitSdrActive(true, false, DRM_FORMAT_ARGB8888)); }
+
+// HDR also commits a 10-bit render format, but an HDR-active output must not be
+// misreported as 10-bit SDR: the HDR pipeline owns the format.
+UMBRIEL_TEST(deriveHdrActiveTenBitFormatIsNotSdr10) {
+  CHECK(!deriveTenBitSdrActive(true, true, DRM_FORMAT_XRGB2101010));
+  CHECK(!deriveTenBitSdrActive(true, true, DRM_FORMAT_XBGR2101010));
+}
+
+// A disabled output reports no active SDR10 even if the last committed format
+// was 10-bit. A DPMS-off output is disabled at the wlr_output level, so it
+// takes this same path.
+UMBRIEL_TEST(deriveDisabledOutputIsNotActive) {
+  CHECK(!deriveTenBitSdrActive(false, false, DRM_FORMAT_XRGB2101010));
+  CHECK(!deriveTenBitSdrActive(false, false, DRM_FORMAT_XBGR2101010));
+  CHECK(!deriveTenBitSdrActive(false, false, DRM_FORMAT_XRGB8888));
+}
+
+// The disabled check dominates the format check: even a disabled + HDR + 10-bit
+// combination is not SDR10.
+UMBRIEL_TEST(deriveDisabledHdrTenBitIsNotActive) { CHECK(!deriveTenBitSdrActive(false, true, DRM_FORMAT_XRGB2101010)); }
+
+// An invalid/uninitialized render format is not SDR10.
+UMBRIEL_TEST(deriveInvalidFormatIsNotActive) { CHECK(!deriveTenBitSdrActive(true, false, DRM_FORMAT_INVALID)); }
+
+int main() { return RUN_TESTS(); }

--- a/umbrielfx/internal/render/fx_renderer/fx_renderer.h
+++ b/umbrielfx/internal/render/fx_renderer/fx_renderer.h
@@ -185,6 +185,7 @@ struct fx_renderer {
 		bool OES_egl_image;
 		bool EXT_texture_type_2_10_10_10_REV;
 		bool OES_texture_half_float_linear;
+		bool fp16_linear_filter;
 		bool EXT_texture_norm16;
 		bool EXT_disjoint_timer_query;
 	} exts;

--- a/umbrielfx/internal/render/fx_renderer/fx_renderer.h
+++ b/umbrielfx/internal/render/fx_renderer/fx_renderer.h
@@ -32,7 +32,8 @@ bool is_fx_pixel_format_supported(const struct fx_renderer *renderer, const stru
 const struct fx_pixel_format *get_fx_format_from_drm(uint32_t fmt);
 const struct fx_pixel_format *get_fx_format_from_gl(GLint gl_format, GLint gl_type, bool alpha);
 void get_fx_shm_formats(const struct fx_renderer *renderer, struct wlr_drm_format_set *out);
-
+GLenum fx_resolve_gl_type(const struct fx_renderer *renderer, GLenum gl_type);
+GLint fx_resolve_internal_format(const struct fx_renderer *renderer, const struct fx_pixel_format *fmt);
 GLuint fx_framebuffer_get_fbo(struct fx_framebuffer *buffer);
 
 /**
@@ -177,6 +178,8 @@ struct fx_renderer {
 
 	struct wlr_drm_format_set shm_texture_formats;
 
+	bool is_gles3;
+
 	const char *exts_str;
 	struct {
 		bool EXT_read_format_bgra;
@@ -184,8 +187,10 @@ struct fx_renderer {
 		bool OES_egl_image_external;
 		bool OES_egl_image;
 		bool EXT_texture_type_2_10_10_10_REV;
+		bool OES_texture_half_float;
 		bool OES_texture_half_float_linear;
-		bool fp16_linear_filter;
+		bool half_float_renderable;
+		bool half_float_linear;
 		bool EXT_texture_norm16;
 		bool EXT_disjoint_timer_query;
 	} exts;

--- a/umbrielfx/meson.build
+++ b/umbrielfx/meson.build
@@ -201,6 +201,7 @@ if build_tests
     'fp16-blur',
     'fp16-blur-effects',
     'fp16-save-restore',
+    'optimized-blur-format-cache',
     'shared-output-buffers',
     'output-lut-cache',
     'shared-sdr-capture',

--- a/umbrielfx/render/fx_renderer/fx_pass.c
+++ b/umbrielfx/render/fx_renderer/fx_pass.c
@@ -85,7 +85,7 @@ static uint32_t offscreen_buffer_format(const struct fx_gles_render_pass *pass,
 	const bool use_fp16 = pass->has_color_transform
 		|| (ten_bit_output
 			&& renderer->wlr_renderer.features.output_color_transform
-			&& renderer->exts.fp16_linear_filter);
+			&& renderer->exts.half_float_renderable);
 
 	if (use_fp16) {
 		return DRM_FORMAT_ABGR16161616F;
@@ -495,7 +495,7 @@ static void draw_animation_texture(struct fx_gles_render_pass *pass,
 	glUseProgram(shader->program);
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, texture->tex);
-	const GLint filter = pass->has_color_transform && !pass->buffer->renderer->exts.fp16_linear_filter
+	const GLint filter = pass->has_color_transform && !pass->buffer->renderer->exts.half_float_linear
 		? GL_NEAREST : GL_LINEAR;
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
@@ -637,7 +637,7 @@ bool fx_render_pass_end_animation_shadow(struct fx_gles_render_pass *pass,
 	pop_animation_capture(pass);
 	glUseProgram(vertical->program);
 	glUniform1i(glGetUniformLocation(vertical->program, "shadow_nearest"),
-		pass->has_color_transform && !renderer->exts.fp16_linear_filter);
+		pass->has_color_transform && !renderer->exts.half_float_linear);
 	glUniform2f(glGetUniformLocation(vertical->program, "shadow_step"),
 		0, softness / (8.0f * full.height));
 	glUniform2f(glGetUniformLocation(vertical->program, "shadow_offset"),

--- a/umbrielfx/render/fx_renderer/fx_pass.c
+++ b/umbrielfx/render/fx_renderer/fx_pass.c
@@ -73,23 +73,43 @@ bool fx_render_pass_init_offscreen_buffers(struct wlr_render_pass *render_pass,
 	return true;
 }
 
+// Returns the DRM format that offscreen effect buffers should use for the
+// current pass.
+static uint32_t offscreen_buffer_format(const struct fx_gles_render_pass *pass,
+		bool alpha) {
+	struct fx_renderer *renderer = pass->buffer->renderer;
+	const bool ten_bit_output = pass->output_buffer != NULL
+		&& (pass->output_buffer->drm_format == DRM_FORMAT_XRGB2101010
+			|| pass->output_buffer->drm_format == DRM_FORMAT_XBGR2101010);
+
+	const bool use_fp16 = pass->has_color_transform
+		|| (ten_bit_output
+			&& renderer->wlr_renderer.features.output_color_transform
+			&& renderer->exts.fp16_linear_filter);
+
+	if (use_fp16) {
+		return DRM_FORMAT_ABGR16161616F;
+	}
+
+	return alpha ? DRM_FORMAT_ABGR8888 : DRM_FORMAT_XBGR8888;
+}
+
 // Allocates the offscreen buffer in *slot on first use, matching the pass
-// target's size and its FP16 format under a color transform. Rebinds the pass
-// target. Returns NULL when the buffer could not be allocated.
+// target's size and the format returned by offscreen_buffer_format. Rebinds
+// the pass target on return. Returns NULL when the buffer could not be
+// allocated.
 static struct fx_framebuffer *ensure_offscreen_buffer(struct fx_gles_render_pass *pass,
 		struct fx_framebuffer **slot, bool alpha) {
 	struct fx_offscreen_buffers *fbos = pass->fx_offscreen_buffers;
 	if (fbos == NULL) {
 		return NULL;
 	}
-	uint32_t format;
-	if (pass->has_color_transform) {
-		format = DRM_FORMAT_ABGR16161616F;
-	} else {
-		format = alpha ? DRM_FORMAT_ABGR8888 : DRM_FORMAT_XBGR8888;
-	}
+
+	struct fx_renderer *renderer = pass->buffer->renderer;
+	const uint32_t format = offscreen_buffer_format(pass, alpha);
+
 	bool failed = false;
-	fx_framebuffer_get_or_create_custom(pass->buffer->renderer, fbos->allocator,
+	fx_framebuffer_get_or_create_custom(renderer, fbos->allocator,
 		pass->buffer->buffer->width, pass->buffer->buffer->height, format,
 		slot, &failed);
 	fx_framebuffer_bind(pass->buffer);
@@ -475,7 +495,7 @@ static void draw_animation_texture(struct fx_gles_render_pass *pass,
 	glUseProgram(shader->program);
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, texture->tex);
-	const GLint filter = pass->has_color_transform && !pass->buffer->renderer->exts.OES_texture_half_float_linear
+	const GLint filter = pass->has_color_transform && !pass->buffer->renderer->exts.fp16_linear_filter
 		? GL_NEAREST : GL_LINEAR;
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, filter);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, filter);
@@ -617,7 +637,7 @@ bool fx_render_pass_end_animation_shadow(struct fx_gles_render_pass *pass,
 	pop_animation_capture(pass);
 	glUseProgram(vertical->program);
 	glUniform1i(glGetUniformLocation(vertical->program, "shadow_nearest"),
-		pass->has_color_transform && !renderer->exts.OES_texture_half_float_linear);
+		pass->has_color_transform && !renderer->exts.fp16_linear_filter);
 	glUniform2f(glGetUniformLocation(vertical->program, "shadow_step"),
 		0, softness / (8.0f * full.height));
 	glUniform2f(glGetUniformLocation(vertical->program, "shadow_offset"),
@@ -1868,7 +1888,8 @@ static bool optimized_buffer_ready(const struct fx_gles_render_pass *pass,
 		const struct fx_framebuffer *buffer) {
 	return buffer != NULL
 		&& buffer->buffer->width == pass->buffer->buffer->width
-		&& buffer->buffer->height == pass->buffer->buffer->height;
+		&& buffer->buffer->height == pass->buffer->buffer->height
+		&& buffer->drm_format == offscreen_buffer_format(pass, false);
 }
 
 void fx_render_pass_add_blur(struct fx_gles_render_pass *pass,

--- a/umbrielfx/render/fx_renderer/fx_renderer.c
+++ b/umbrielfx/render/fx_renderer/fx_renderer.c
@@ -625,6 +625,8 @@ struct wlr_renderer *fx_renderer_create_egl(struct wlr_egl *egl) {
 
 	renderer->exts.OES_texture_half_float_linear =
 		check_gl_ext(exts_str, "GL_OES_texture_half_float_linear");
+	renderer->exts.fp16_linear_filter =
+		is_gles3 || renderer->exts.OES_texture_half_float_linear;
 
 	renderer->exts.EXT_texture_norm16 =
 		check_gl_ext(exts_str, "GL_EXT_texture_norm16");

--- a/umbrielfx/render/fx_renderer/fx_renderer.c
+++ b/umbrielfx/render/fx_renderer/fx_renderer.c
@@ -596,6 +596,7 @@ struct wlr_renderer *fx_renderer_create_egl(struct wlr_egl *egl) {
 	const bool is_gles3 = gl_version != NULL &&
 		sscanf(gl_version, "OpenGL ES %d", &gles_major) == 1 &&
 		gles_major >= 3;
+	renderer->is_gles3 = is_gles3;
 	wlr_log(WLR_INFO, "GL vendor: %s", glGetString(GL_VENDOR));
 	wlr_log(WLR_INFO, "GL renderer: %s", glGetString(GL_RENDERER));
 	wlr_log(WLR_INFO, "Supported FX extensions: %s", exts_str);
@@ -623,9 +624,13 @@ struct wlr_renderer *fx_renderer_create_egl(struct wlr_egl *egl) {
 		is_gles3 ||
 		check_gl_ext(exts_str, "GL_EXT_texture_type_2_10_10_10_REV");
 
+	renderer->exts.OES_texture_half_float =
+		check_gl_ext(exts_str, "GL_OES_texture_half_float");
 	renderer->exts.OES_texture_half_float_linear =
 		check_gl_ext(exts_str, "GL_OES_texture_half_float_linear");
-	renderer->exts.fp16_linear_filter =
+	renderer->exts.half_float_renderable =
+		is_gles3 || renderer->exts.OES_texture_half_float;
+	renderer->exts.half_float_linear =
 		is_gles3 || renderer->exts.OES_texture_half_float_linear;
 
 	renderer->exts.EXT_texture_norm16 =

--- a/umbrielfx/render/fx_renderer/fx_texture.c
+++ b/umbrielfx/render/fx_renderer/fx_texture.c
@@ -83,7 +83,7 @@ static bool fx_texture_update_from_buffer(struct wlr_texture *wlr_texture,
 		int width = rect.x2 - rect.x1;
 		int height = rect.y2 - rect.y1;
 		glTexSubImage2D(GL_TEXTURE_2D, 0, rect.x1, rect.y1, width, height,
-			fmt->gl_format, fmt->gl_type, data);
+			fmt->gl_format, fx_resolve_gl_type(texture->fx_renderer, fmt->gl_type), data);
 	}
 
 	glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0);
@@ -195,12 +195,14 @@ static bool fx_texture_read_pixels(struct wlr_texture *wlr_texture,
 		goto out;
 	}
 
+	const GLenum read_gl_type = fx_resolve_gl_type(texture->fx_renderer, fmt->gl_type);
+
 	if (!is_fx_pixel_format_supported(texture->fx_renderer, fmt)) {
 		GLint read_format = 0, read_type = 0;
 		glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &read_format);
 		glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &read_type);
 		// Readback can support a format without its texture-upload extension.
-		if (read_format != fmt->gl_format || read_type != fmt->gl_type) {
+		if (read_format != fmt->gl_format || (GLenum)read_type != read_gl_type) {
 			wlr_log(WLR_ERROR, "Cannot read pixels: unsupported pixel format 0x%"PRIX32,
 				options->format);
 			goto out;
@@ -220,14 +222,14 @@ static bool fx_texture_read_pixels(struct wlr_texture *wlr_texture,
 		// Under these particular conditions, we can read the pixels with only
 		// one glReadPixels call
 
-		glReadPixels(src.x, src.y, src.width, src.height, fmt->gl_format, fmt->gl_type, p);
+		glReadPixels(src.x, src.y, src.width, src.height, fmt->gl_format, read_gl_type, p);
 	} else {
 		// Unfortunately GLES2 doesn't support GL_PACK_ROW_LENGTH, so we have to read
 		// the lines out row by row
 		for (int32_t i = 0; i < src.height; ++i) {
 			uint32_t y = src.y + i;
 			glReadPixels(src.x, y, src.width, 1, fmt->gl_format,
-				fmt->gl_type, p + i * options->stride);
+				read_gl_type, p + i * options->stride);
 		}
 	}
 
@@ -347,10 +349,7 @@ static struct wlr_texture *fx_texture_from_pixels(
 	texture->has_alpha = pixel_format_has_alpha(fmt->drm_format);
 	texture->drm_format = fmt->drm_format;
 
-	GLint internal_format = fmt->gl_internalformat;
-	if (!internal_format) {
-		internal_format = fmt->gl_format;
-	}
+	GLint internal_format = fx_resolve_internal_format(renderer, fmt);
 
 	struct wlr_egl_context prev_ctx;
 	wlr_egl_make_current(renderer->egl, &prev_ctx);
@@ -364,7 +363,7 @@ static struct wlr_texture *fx_texture_from_pixels(
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride / drm_fmt->bytes_per_block);
 	glTexImage2D(GL_TEXTURE_2D, 0, internal_format, width, height, 0,
-		fmt->gl_format, fmt->gl_type, data);
+		fmt->gl_format, fx_resolve_gl_type(renderer, fmt->gl_type), data);
 	glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0);
 
 	glBindTexture(GL_TEXTURE_2D, 0);

--- a/umbrielfx/render/fx_renderer/pixel_format.c
+++ b/umbrielfx/render/fx_renderer/pixel_format.c
@@ -120,7 +120,7 @@ bool is_fx_pixel_format_supported(const struct fx_renderer *renderer,
 		return false;
 	}
 	if (format->gl_type == GL_HALF_FLOAT_OES
-			&& !renderer->exts.OES_texture_half_float_linear) {
+			&& !renderer->exts.fp16_linear_filter) {
 		return false;
 	}
 	if (format->gl_type == GL_UNSIGNED_SHORT

--- a/umbrielfx/render/fx_renderer/pixel_format.c
+++ b/umbrielfx/render/fx_renderer/pixel_format.c
@@ -5,6 +5,18 @@
 #include "render/fx_renderer/fx_renderer.h"
 #include "render/pixel_format.h"
 
+#ifndef GL_HALF_FLOAT
+#define GL_HALF_FLOAT 0x140B
+#endif
+
+#ifndef GL_RGBA16F
+#define GL_RGBA16F 0x881A
+#endif
+
+#ifndef GL_RGB16F
+#define GL_RGB16F 0x881B
+#endif
+
 /*
  * The DRM formats are little endian while the GL formats are big endian,
  * so DRM_FORMAT_ARGB8888 is actually compatible with GL_BGRA_EXT.
@@ -120,7 +132,7 @@ bool is_fx_pixel_format_supported(const struct fx_renderer *renderer,
 		return false;
 	}
 	if (format->gl_type == GL_HALF_FLOAT_OES
-			&& !renderer->exts.fp16_linear_filter) {
+			&& !renderer->exts.half_float_renderable) {
 		return false;
 	}
 	if (format->gl_type == GL_UNSIGNED_SHORT
@@ -136,6 +148,26 @@ bool is_fx_pixel_format_supported(const struct fx_renderer *renderer,
 	return true;
 }
 
+GLenum fx_resolve_gl_type(const struct fx_renderer *renderer, GLenum gl_type) {
+	if (gl_type == GL_HALF_FLOAT_OES && renderer->is_gles3) {
+		return GL_HALF_FLOAT;
+	}
+	return gl_type;
+}
+
+GLint fx_resolve_internal_format(const struct fx_renderer *renderer,
+		const struct fx_pixel_format *fmt) {
+	// GLES3 core pairs GL_HALF_FLOAT with a sized internal format. The unsized
+	// gl_format fallback below is only legal with GL_HALF_FLOAT_OES on GLES2.
+	if (fmt->gl_type == GL_HALF_FLOAT_OES && renderer->is_gles3) {
+		return fmt->gl_format == GL_RGB ? GL_RGB16F : GL_RGBA16F;
+	}
+	if (fmt->gl_internalformat) {
+		return fmt->gl_internalformat;
+	}
+	return fmt->gl_format;
+}
+
 const struct fx_pixel_format *get_fx_format_from_drm(uint32_t fmt) {
 	for (size_t i = 0; i < sizeof(formats) / sizeof(*formats); ++i) {
 		if (formats[i].drm_format == fmt) {
@@ -147,6 +179,10 @@ const struct fx_pixel_format *get_fx_format_from_drm(uint32_t fmt) {
 
 const struct fx_pixel_format *get_fx_format_from_gl(
 		GLint gl_format, GLint gl_type, bool alpha) {
+	if (gl_type == GL_HALF_FLOAT) {
+		gl_type = GL_HALF_FLOAT_OES;
+	}
+
 	for (size_t i = 0; i < sizeof(formats) / sizeof(*formats); ++i) {
 		if (formats[i].gl_format != gl_format ||
 				formats[i].gl_type != gl_type) {

--- a/umbrielfx/tests/color.c
+++ b/umbrielfx/tests/color.c
@@ -1212,6 +1212,190 @@ out:
 	return ok;
 }
 
+// Populates the output's optimized-blur cache with a solid backdrop by running
+// an optimized-blur pass into an 8-bit SDR target. The cache buffers are
+// output-local, so they survive into a later pass on the same output. Returns
+// the DRM format the cache buffers were allocated with, or DRM_FORMAT_INVALID.
+static uint32_t prime_optimized_blur_cache(struct fixture *fixture,
+		float backdrop_red, struct blur_data *blur_data) {
+	struct wlr_buffer *target = create_output_buffer(fixture,
+		DRM_FORMAT_XBGR8888, TEST_WIDTH, TEST_HEIGHT);
+	if (!check(target != NULL, "allocate SDR8 optimized-blur target")) {
+		return DRM_FORMAT_INVALID;
+	}
+
+	// Create the stale 8-bit format we want cached.
+	struct wlr_render_pass *pass = wlr_renderer_begin_buffer_pass(
+		fixture->renderer, target, &(struct wlr_buffer_pass_options) {0});
+	if (!check(pass != NULL, "begin optimized-blur producer pass")) {
+		wlr_buffer_drop(target);
+		return DRM_FORMAT_INVALID;
+	}
+	struct fx_gles_render_pass *fx_pass = fx_get_render_pass(pass);
+
+	struct wlr_box box = { .width = TEST_WIDTH, .height = TEST_HEIGHT };
+	wlr_render_pass_add_rect(pass, &(struct wlr_render_rect_options) {
+		.box = box,
+		.color = { .r = backdrop_red, .g = 0.25f, .b = 0.5f, .a = 1.0f },
+		.blend_mode = WLR_RENDER_BLEND_MODE_NONE,
+	});
+
+	pixman_region32_t region;
+	pixman_region32_init_rect(&region, 0, 0, TEST_WIDTH, TEST_HEIGHT);
+
+	uint32_t cache_format = DRM_FORMAT_INVALID;
+	bool ok = check(fx_render_pass_init_offscreen_buffers(pass, fixture->output),
+		"init producer offscreen buffers");
+	if (ok) {
+		struct fx_render_blur_pass_options blur_options = {
+			.tex_options = {
+				.base = {
+					.dst_box = box,
+					.clip = &region,
+					.transform = WL_OUTPUT_TRANSFORM_NORMAL,
+					.filter_mode = WLR_SCALE_FILTER_BILINEAR,
+					.blend_mode = WLR_RENDER_BLEND_MODE_NONE,
+				},
+				.clip_box = &box,
+			},
+			.blur_data = blur_data,
+			.blur_strength = 1.0f,
+		};
+		ok = check(fx_render_pass_add_optimized_blur(fx_pass, &blur_options),
+			"populate optimized-blur cache");
+		if (ok) {
+			struct fx_offscreen_buffers *fbos = fx_pass->fx_offscreen_buffers;
+			ok = check(fbos != NULL && fbos->optimized_blur_buffer != NULL,
+				"optimized-blur cache exists");
+			if (ok) {
+				cache_format = fbos->optimized_blur_buffer->drm_format;
+			}
+		}
+	}
+	pixman_region32_fini(&region);
+	ok = wlr_render_pass_submit(pass) && ok;
+	wlr_buffer_drop(target);
+	return ok ? cache_format : DRM_FORMAT_INVALID;
+}
+
+// A stale-format optimized-blur cache must not be reused after the output's
+// render format changes. The offscreen effect buffers are output-local, so a
+// cache primed while the output was 8-bit SDR can survive into a 10-bit pass 
+// whose effect buffers are FP16.
+static bool test_optimized_blur_format_cache(struct fixture *fixture) {
+	uint32_t format = select_10bit_format(fixture);
+	if (!check(format != DRM_FORMAT_INVALID, "find 10-bit output format")) {
+		return false;
+	}
+
+	struct blur_data blur_data = {
+		.num_passes = 1,
+		.radius = 1.0f,
+		.brightness = 1.0f,
+		.contrast = 1.0f,
+		.saturation = 1.0f,
+	};
+
+	// Prime the cache with a bright-red backdrop while the output is 8-bit.
+	const float stale_red = 0.9f;
+	uint32_t cache_format = prime_optimized_blur_cache(
+		fixture, stale_red, &blur_data);
+	if (!check(cache_format != DRM_FORMAT_INVALID, "prime optimized-blur cache")) {
+		return false;
+	}
+	if (!check(cache_format == DRM_FORMAT_XBGR8888,
+			"cache primed at 8-bit SDR format")) {
+		return false;
+	}
+
+	// Now render a consumer blur pass into a 10-bit target with a color
+	// transform, so its effect buffers want FP16. The live backdrop is a
+	// dark red, different from the cached bright red.
+	const float live_red = 0.1f;
+	struct wlr_buffer *target = create_output_buffer(
+		fixture, format, TEST_WIDTH, TEST_HEIGHT);
+	if (!check(target != NULL, "allocate 10-bit consumer target")) {
+		return false;
+	}
+	struct wlr_color_transform *transform =
+		wlr_color_transform_init_linear_to_inverse_eotf(
+			WLR_COLOR_TRANSFER_FUNCTION_SRGB);
+	if (!check(transform != NULL, "create consumer output transform")) {
+		wlr_buffer_drop(target);
+		return false;
+	}
+
+	uint32_t output[TEST_WIDTH * TEST_HEIGHT] = {0};
+	struct wlr_render_pass *pass = wlr_renderer_begin_buffer_pass(
+		fixture->renderer, target, &(struct wlr_buffer_pass_options) {
+			.color_transform = transform,
+		});
+	bool ok = check(pass != NULL, "begin consumer blur pass");
+	if (ok) {
+		struct fx_gles_render_pass *fx_pass = fx_get_render_pass(pass);
+		struct wlr_box box = { .width = TEST_WIDTH, .height = TEST_HEIGHT };
+		pixman_region32_t region;
+		pixman_region32_init_rect(&region, 0, 0, TEST_WIDTH, TEST_HEIGHT);
+
+		wlr_render_pass_add_rect(pass, &(struct wlr_render_rect_options) {
+			.box = box,
+			.color = { .r = live_red, .g = 0.25f, .b = 0.5f, .a = 1.0f },
+			.blend_mode = WLR_RENDER_BLEND_MODE_NONE,
+		});
+
+		ok = check(fx_render_pass_init_offscreen_buffers(pass, fixture->output),
+			"init consumer offscreen buffers") && ok;
+		// The cache from the producer pass should still be present and stale.
+		struct fx_offscreen_buffers *fbos = fx_pass->fx_offscreen_buffers;
+		ok = check(fbos != NULL && fbos->optimized_blur_buffer != NULL &&
+			fbos->optimized_blur_buffer->drm_format == DRM_FORMAT_XBGR8888,
+			"consumer sees the stale 8-bit optimized-blur cache") && ok;
+
+		const float opacity = 1.0f;
+		struct fx_render_blur_pass_options blur_options = {
+			.tex_options = {
+				.base = {
+					.dst_box = box,
+					.clip = &region,
+					.transform = WL_OUTPUT_TRANSFORM_NORMAL,
+					.filter_mode = WLR_SCALE_FILTER_BILINEAR,
+					.blend_mode = WLR_RENDER_BLEND_MODE_NONE,
+					.alpha = &opacity,
+				},
+				.clip_box = &box,
+			},
+			// Request the optimized path.
+			.use_optimized_blur = true,
+			.blur_data = &blur_data,
+			.blur_strength = 1.0f,
+		};
+		fx_render_pass_add_blur(fx_pass, &blur_options);
+		pixman_region32_fini(&region);
+
+		ok = check(wlr_render_pass_submit(pass), "submit consumer blur pass") && ok;
+	}
+
+	if (ok) {
+		ok = check(read_buffer(fixture, target, format,
+			TEST_WIDTH * sizeof(uint32_t), output), "read consumer output");
+	}
+
+	wlr_color_transform_unref(transform);
+	wlr_buffer_drop(target);
+	if (!ok) {
+		return false;
+	}
+
+	uint32_t pixel = output[(TEST_HEIGHT / 2) * TEST_WIDTH + TEST_WIDTH / 2];
+	int actual = pixel & 0x3FF;
+	int expected = lroundf(live_red * 1023.0f);
+	int stale = lroundf(stale_red * 1023.0f);
+	fprintf(stderr, "INFO: red actual=%d expected(live)=%d stale(cache)=%d\n",
+		actual, expected, stale);
+	return check(abs(actual - expected) <= 24,
+		"format-mismatched optimized-blur cache is not reused");
+}
+
 int main(int argc, char *argv[]) {
 	if (argc != 2) {
 		fprintf(stderr, "usage: %s CASE\n", argv[0]);
@@ -1242,6 +1426,8 @@ int main(int argc, char *argv[]) {
 		ok = test_fp16_blur_effects(&fixture);
 	} else if (strcmp(argv[1], "fp16-save-restore") == 0) {
 		ok = test_fp16_save_restore(&fixture);
+	} else if (strcmp(argv[1], "optimized-blur-format-cache") == 0) {
+		ok = test_optimized_blur_format_cache(&fixture);
 	} else if (strcmp(argv[1], "shared-output-buffers") == 0) {
 		ok = test_shared_output_buffers(&fixture);
 	} else if (strcmp(argv[1], "output-lut-cache") == 0) {


### PR DESCRIPTION
## Summary
Add support for 10-bit SDR output

## Motivation
Some monitors support bit depths higher than 8. When using semi-transparent windows with background blur, banding can become a problem, especially with dark gradients on OLED. 10-bit output makes these gradients smooth

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

## Testing

Ran in a native session. Confirmed changing bit_depth from 8 to 10 improves color quality and reduces banding

## Manual Coverage
- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

## Checklist
- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes
