### PR TITLE
feat(config): merge included arrays

### DIFF
--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -73,6 +73,21 @@ contain valid TOML.
 Files in `[include]` are applied in list order, followed by files in
 `[include.optional]`. Values in the including file override every include.
 
+A key that holds a table is merged key by key, so an include can set
+`colors.accent_primary` while your main config sets `colors.background`. A key
+that holds a list of rules (`[[window_rule]]`, `[[layer_rule]]`,
+`[[security_context_rule]]`, `[[workspace]]`, `[[input.device]]`) collects the
+entries from every file, in the order the files are applied. Every other value,
+including a plain array such as `general.autostart` or
+`output.<name>.position`, is replaced by the last file that sets it. Setting a
+rule list to `[]` replaces it too, which discards the entries earlier files
+contributed.
+
+Because rule lists are collected rather than replaced, a duplicate that is an
+error inside one file is still an error across files: two `[[input.device]]`
+entries with the same `name`, or two `[[workspace]]` entries selecting the same
+workspace, are reported and the config is rejected.
+
 `[include]` accepts `files` and the `optional` sub-table.
 `[include.optional]` accepts only `files`. Anything else is reported as an
 unknown key, in the main config and in included files alike.

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -283,7 +283,8 @@ touchpads; for a touchpad the rule overrides `[input.touchpad]` rather than
 
 Rules match every attached device with the exact name. Device overrides also
 apply when a device is connected after startup and when the configuration is
-reloaded. Duplicate rules for the same name are rejected.
+reloaded. Rules from included files are collected alongside the ones in the
+file that includes them, and duplicate rules for the same name are rejected.
 
 `scroll_wheel_step`, cursor settings, tablet settings, and focus settings remain
 compositor-wide because they are not properties of one physical input device.

--- a/docs/user/layer-rules.md
+++ b/docs/user/layer-rules.md
@@ -35,4 +35,5 @@ empty string.
 | `blur_optimized` | bool | Override `appearance.blur.optimized`. A `true` value keeps the cached background blur alive on every output even when the global switch is off. |
 
 Layer-shell blur is off by default. As with window rules, every matching rule
-contributes its settings, and later values take precedence.
+contributes its settings, and later values take precedence. Rules from included
+files come before the rules in the file that includes them.

--- a/docs/user/window-rules.md
+++ b/docs/user/window-rules.md
@@ -3,8 +3,8 @@
 Window rules can match `app_id`, title, and a client-defined XDG toplevel tag
 using ECMAScript regular expressions. They can also match a standardized
 content type or focus state. Every matching rule contributes its settings. If
-two rules set the same field, the rule that appears later in the file takes
-precedence.
+two rules set the same field, the rule that appears later takes precedence.
+Rules from included files come before the rules in the file that includes them.
 
 ```toml
 [[window_rule]]

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -16,7 +16,9 @@
 # Split large configurations into smaller files. Required files are applied in
 # list order, followed by optional files, then values in this main file.
 # Missing optional files are silently ignored and remain watched. Relative
-# paths start from the directory containing this file.
+# paths start from the directory containing this file. Rule lists such as
+# [[window_rule]] collect entries from every file; any other value is replaced
+# by the last file that sets it.
 # Documentation: https://docs.noctalia.dev/umbriel/configuration/#include
 # ────────────────────────────────────────────────────────────────────────────
 

--- a/src/config/config_merge.cpp
+++ b/src/config/config_merge.cpp
@@ -319,30 +319,19 @@ namespace umbriel::configmerge {
       return expandFile(path, std::move(parsed), visited, result);
     }
 
-  } // namespace
-
-  void deepMerge(toml::table& base, const toml::table& overlay) {
-    for (const auto& [key, value] : overlay) {
-      if (const auto* overlayTable = value.as_table()) {
-        if (auto* baseNode = base.get(key)) {
-          if (auto* baseTable = baseNode->as_table()) {
-            deepMerge(*baseTable, *overlayTable);
-            continue;
-          }
-        }
-      } else if (const auto* overlayArray = value.as_array()) {
-        if (auto* baseNode = base.get(key)) {
-          if (auto* baseArray = baseNode->as_array()) {
-            for (const auto& elem : *overlayArray) {
-              baseArray->push_back(elem);
-            }
-            continue;
-          }
+    // Whether every element is a table. That shape is exactly the rule collections (`[[window_rule]]`,
+    // `[[layer_rule]]`, `[[security_context_rule]]`, `[[workspace]]`, `[[input.device]]`); nothing else in the
+    // vocabulary holds tables in an array, so the merge cannot drift away from the readers.
+    bool holdsOnlyTables(const toml::array& array) {
+      for (const toml::node& element : array) {
+        if (!element.is_table()) {
+          return false;
         }
       }
-      base.insert_or_assign(key, value);
+      return true;
     }
-  }
+
+  } // namespace
 
   void deepMerge(toml::table& base, toml::table&& overlay) {
     for (auto&& [key, value] : overlay) {
@@ -353,14 +342,16 @@ namespace umbriel::configmerge {
             continue;
           }
         }
-      } else if (auto* overlayArray = value.as_array()) {
+      } else if (auto* overlayArray = value.as_array(); overlayArray != nullptr && !overlayArray->empty()) {
+        // Rule collections accumulate, so a rule in an include and a rule in the including file both apply, in merge
+        // order. Anything else is replaced, including an empty array: that is how a later file drops what earlier
+        // files contributed, and it keeps a fixed-arity array such as `output.<name>.position` from outgrowing it.
         if (auto* baseNode = base.get(key)) {
-          if (auto* baseArray = baseNode->as_array()) {
-            for (auto&& elem : *overlayArray) {
-              elem.visit([&](auto&& val) {
-                using T = std::decay_t<decltype(val)>;
-                baseArray->push_back(T(std::move(val)));
-              });
+          auto* baseArray = baseNode->as_array();
+          if (baseArray != nullptr && holdsOnlyTables(*baseArray) && holdsOnlyTables(*overlayArray)) {
+            baseArray->reserve(baseArray->size() + overlayArray->size());
+            for (toml::node& element : *overlayArray) {
+              baseArray->push_back(std::move(*element.as_table()));
             }
             continue;
           }

--- a/src/config/config_merge.cpp
+++ b/src/config/config_merge.cpp
@@ -330,6 +330,15 @@ namespace umbriel::configmerge {
             continue;
           }
         }
+      } else if (const auto* overlayArray = value.as_array()) {
+        if (auto* baseNode = base.get(key)) {
+          if (auto* baseArray = baseNode->as_array()) {
+            for (const auto& elem : *overlayArray) {
+              baseArray->push_back(elem);
+            }
+            continue;
+          }
+        }
       }
       base.insert_or_assign(key, value);
     }
@@ -341,6 +350,18 @@ namespace umbriel::configmerge {
         if (auto* baseNode = base.get(key)) {
           if (auto* baseTable = baseNode->as_table()) {
             deepMerge(*baseTable, std::move(*overlayTable));
+            continue;
+          }
+        }
+      } else if (auto* overlayArray = value.as_array()) {
+        if (auto* baseNode = base.get(key)) {
+          if (auto* baseArray = baseNode->as_array()) {
+            for (auto&& elem : *overlayArray) {
+              elem.visit([&](auto&& val) {
+                using T = std::decay_t<decltype(val)>;
+                baseArray->push_back(T(std::move(val)));
+              });
+            }
             continue;
           }
         }

--- a/src/config/config_merge.h
+++ b/src/config/config_merge.h
@@ -18,7 +18,6 @@ namespace umbriel::configmerge {
   };
 
   [[nodiscard]] MergeResult mergeWithIncludes(const std::filesystem::path& rootFile);
-  void deepMerge(toml::table& base, const toml::table& overlay);
   void deepMerge(toml::table& base, toml::table&& overlay);
 
 } // namespace umbriel::configmerge

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -1384,6 +1384,99 @@ files = [")"
   CHECK_EQ(store.config().colors.background[0], 34.0F / 255.0F);
 }
 
+UMBRIEL_TEST(ruleCollectionsAccumulateAcrossIncludesWhilePlainArraysReplace) {
+  // Rules are a collection every file contributes to, so an include and the including file both apply, in merge
+  // order. Every other array is one value: appending would grow a fixed-arity array past what its reader accepts and
+  // would make an overridden autostart list run the include's commands as well.
+  const TempConfigTree tree;
+  tree.write(
+      "rules.toml",
+      "[general]\nautostart = [\"from-include\"]\n"
+      "[output.DP-1]\nposition = [0, 0]\n"
+      "[[window_rule]]\nmatch.app_id = \"^from-include$\"\n"
+      "[[layer_rule]]\nmatch.namespace = \"^bar$\"\nblur = true\n"
+  );
+  tree.write(
+      "config.toml",
+      "[include]\nfiles = [\"rules.toml\"]\n"
+      "[general]\nautostart = [\"from-root\"]\n"
+      "[output.DP-1]\nposition = [3072, 0]\n"
+      "[[window_rule]]\nmatch.app_id = \"^from-root$\"\n"
+  );
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(tree.path("config.toml"), true);
+  const umbriel::ConfigReloadResult loaded = store.reload();
+
+  std::vector<std::string> patterns;
+  for (const umbriel::WindowRule& rule : store.config().windowRules) {
+    patterns.push_back(rule.appIdPattern);
+  }
+  std::vector<std::string> namespaces;
+  for (const umbriel::LayerRule& rule : store.config().layerRules) {
+    namespaces.push_back(rule.namespacePattern);
+  }
+  const std::vector<std::string> expectedPatterns{"^from-include$", "^from-root$"};
+  const std::vector<std::string> expectedNamespaces{"^bar$"};
+  const std::vector<std::string> expectedAutostart{"from-root"};
+  const std::array<int, 2> expectedPosition{3072, 0};
+  const auto output =
+      std::ranges::find_if(store.config().outputs, [](const umbriel::OutputRule& rule) { return rule.name == "DP-1"; });
+  const bool foundOutput = output != store.config().outputs.end();
+
+  CHECK(loaded.success);
+  CHECK(patterns == expectedPatterns);
+  CHECK(namespaces == expectedNamespaces);
+  CHECK(store.config().general.autostart == expectedAutostart);
+  CHECK(foundOutput && output->position.has_value());
+  CHECK(foundOutput && output->position.value_or(std::array<int, 2>{}) == expectedPosition);
+  CHECK(!containsDiagnostic(store, "position"));
+}
+
+UMBRIEL_TEST(emptyRuleArrayDropsRulesFromIncludes) {
+  const TempConfig file;
+  file.write("window_rule = []\n[include]\nfiles = [\"" + file.includeName() + "\"]\n");
+  file.writeInclude("[[window_rule]]\nmatch.app_id = \"^dropped$\"\ndefault_floating = true\n");
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+  const umbriel::ConfigReloadResult loaded = store.reload();
+
+  CHECK(loaded.success);
+  CHECK(store.config().windowRules.empty());
+}
+
+UMBRIEL_TEST(duplicateDeviceRuleAcrossIncludesIsRejected) {
+  // Device rules accumulate like any other collection, so restating one in a later file is the same duplicate the
+  // reader already rejects within a single file, and the whole reload is refused rather than silently dropping the
+  // include's other rules.
+  const TempConfigTree tree;
+  tree.write("input.toml", "[[input.device]]\nname = \"Acme Keyboard\"\nrepeat_rate = 40\n");
+  tree.write(
+      "config.toml",
+      "[include]\nfiles = [\"input.toml\"]\n"
+      "[[input.device]]\nname = \"Acme Mouse\"\nsensitivity = -0.5\n"
+  );
+
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(tree.path("config.toml"), true);
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().input.devices.size(), size_t{2});
+  CHECK(store.config().input.findDevice("Acme Keyboard") != nullptr);
+  CHECK(store.config().input.findDevice("Acme Mouse") != nullptr);
+
+  tree.write(
+      "config.toml",
+      "[include]\nfiles = [\"input.toml\"]\n"
+      "[[input.device]]\nname = \"Acme Keyboard\"\nrepeat_rate = 60\n"
+  );
+  const umbriel::ConfigReloadResult duplicate = store.reload();
+
+  CHECK(!duplicate.success);
+  CHECK(containsDiagnostic(store, "duplicates device 'Acme Keyboard'"));
+  CHECK_EQ(store.config().input.devices.size(), size_t{2});
+}
+
 UMBRIEL_TEST(activationPolicyLoadsGloballyAndPerWindow) {
   const TempConfig file;
   file.write(R"(


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

<!-- What changed and why? -->

When merging values of all included configs, array values are now concatenated.
This is particularly useful for window rules.

## Motivation

<!-- What problem does this solve? -->

Re-defining arrays over separate included config files only leaves the array values of the last applied config.

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [ ] I ran `just format`, or this PR has no C++ changes.
- [ ] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [ ] I checked for new warnings or errors.
- [ ] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [ ] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
