### PR TITLE
fix(nix): read version from VERSION file

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,12 +27,7 @@
   makeBinaryWrapper,
 }:
 let
-  inherit (builtins)
-    head
-    match
-    readFile
-    ;
-  version = head (match ".*\n  version: '([0-9][^']+)'.*" (readFile ../meson.build));
+  version = lib.trim (builtins.readFile ../VERSION);
 in
 stdenv.mkDerivation {
   pname = "umbriel";


### PR DESCRIPTION
## Summary

Read the package version from `VERSION` instead of parsing `meson.build` with a regex. `meson.build` now declares the version with `files('VERSION')`, so the old regex never matches and package evaluation fails.

## Motivation

On current main, evaluating `packages.x86_64-linux.default` fails with `expected a list but found null`. That breaks every flake consumer, including the NixOS and home-manager modules which default to that package. This fix restores evaluation with no change to the built compositor.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Build / packaging
- [ ] Documentation

## Testing

Ran in the repo root:

- `nix eval .#packages.x86_64-linux.default.version --raw` gives `0.1.0`
- `nix eval .#packages.x86_64-linux.default.name --raw` gives `umbriel-0.1.0`

Did not run a full build because this only changes where the version string comes from. No C++ changes, so `just format` does not apply.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
