### PR TITLE
Added new window rule match criteria

### DIFF
--- a/docs/user/window-rules.md
+++ b/docs/user/window-rules.md
@@ -2,9 +2,10 @@
 
 Window rules can match `app_id`, title, and a client-defined XDG toplevel tag
 using ECMAScript regular expressions. They can also match a standardized
-content type or focus state. Every matching rule contributes its settings. If
-two rules set the same field, the rule that appears later takes precedence.
-Rules from included files come before the rules in the file that includes them.
+content type or the window's current state. Every matching rule contributes its
+settings. If two rules set the same field, the rule that appears later takes
+precedence. Rules from included files come before the rules in the file that
+includes them.
 
 ```toml
 [[window_rule]]
@@ -56,6 +57,14 @@ priority `game`, `video`, `photo`, then `none`. This also covers Proton and Wine
 games that publish the hint on a child surface. `none` includes windows that do
 not publish a content hint. Client changes refresh settings from the dynamic
 table below, but never replay the opening settings.
+
+`is_focused`, `is_floating`, `is_pinned`, and `is_scratchpad` match the window's
+current state, and every one of those transitions refreshes the settings from
+the dynamic table below. Pinned and scratchpad windows are floating, so
+`is_floating = true` also matches them. Opening settings resolve against the
+state the window opens with, before `default_floating` and `default_pinned`
+apply, so a rule that sets one of those cannot also select on the state it
+produces.
 
 ## Settings applied when a window opens
 

--- a/docs/user/window-rules.md
+++ b/docs/user/window-rules.md
@@ -22,6 +22,9 @@ default_floating = true
 | `match.xdg_tag` | regex | Match the client-defined XDG toplevel tag. |
 | `match.content_type` | string | Match `"none"`, `"photo"`, `"video"`, or `"game"`. |
 | `match.is_focused` | bool | Match the window's focused state dynamically. |
+| `match.is_floating` | bool | Match the window's floating state dynamically. |
+| `match.is_pinned` | bool | Match the window's pinned state dynamically. |
+| `match.is_scratchpad` | bool | Match the window's scratchpad state dynamically. |
 | `match.at_startup` | bool | Match `true` during the first 60 seconds after starting umbriel and `false` afterward. |
 
 Every selector is optional. A rule without selectors matches every window.
@@ -331,4 +334,17 @@ opacity = 0.85
 [[window_rule]]
 match.is_focused = true
 opacity = 1.0
+
+# Disable blur for floating windows, but not scratchpad windows
+[[window_rule]]
+match.is_floating = true
+match.is_scratchpad = false
+blur = false
+
+# Dim them even further
+[[window_rule]]
+match.is_focused = false
+match.is_floating = true
+match.is_scratchpad = false
+opacity = 0.4
 ```

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -611,7 +611,8 @@ default_pinned = true
 # default_scrolling_column = "browsers"
 # default_scrolling_column_order = 10
 
-# Focus-aware rules update as focus changes.
+# State-aware rules update as focus, floating, pinned, and scratchpad state
+# change. Pinned and scratchpad windows are floating too.
 
 # [[window_rule]]
 # match.is_focused = false
@@ -620,6 +621,11 @@ default_pinned = true
 # [[window_rule]]
 # match.is_focused = true
 # opacity = 1.0
+
+# [[window_rule]]
+# match.is_floating = true
+# match.is_scratchpad = false
+# blur = false
 
 # ────────────────────────────── Layer Rules ─────────────────────────────────
 # Match layer-shell surfaces such as panels, launchers, notifications, and

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1906,6 +1906,30 @@ namespace umbriel {
                 valid = false;
               }
             }
+            if (const toml::node* floatingNode = matchKeys.take("is_floating")) {
+              if (floatingNode->is_boolean()) {
+                rule.matchFloating = floatingNode->value<bool>();
+              } else {
+                warnAt(floatingNode->source(), "ignoring window_rule.match.is_floating (expected boolean)");
+                valid = false;
+              }
+            }
+            if (const toml::node* pinnedNode = matchKeys.take("is_pinned")) {
+              if (pinnedNode->is_boolean()) {
+                rule.matchPinned = pinnedNode->value<bool>();
+              } else {
+                warnAt(pinnedNode->source(), "ignoring window_rule.match.is_pinned (expected boolean)");
+                valid = false;
+              }
+            }
+            if (const toml::node* scratchpadNode = matchKeys.take("is_scratchpad")) {
+              if (scratchpadNode->is_boolean()) {
+                rule.matchScratchpad = scratchpadNode->value<bool>();
+              } else {
+                warnAt(scratchpadNode->source(), "ignoring window_rule.match.is_scratchpad (expected boolean)");
+                valid = false;
+              }
+            }
             if (const toml::node* atStartupNode = matchKeys.take("at_startup")) {
               if (atStartupNode->is_boolean()) {
                 rule.matchAtStartup = atStartupNode->value<bool>();

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -284,6 +284,9 @@ namespace umbriel {
     std::regex xdgTagRegex;
     std::optional<ContentType> matchContentType;
     std::optional<bool> matchFocused;
+    std::optional<bool> matchFloating;
+    std::optional<bool> matchPinned;
+    std::optional<bool> matchScratchpad;
     std::optional<bool> matchAtStartup;
     std::optional<std::string> defaultOutput;
     std::optional<bool> defaultFloating;
@@ -319,6 +322,9 @@ namespace umbriel {
           && xdgTagPattern == other.xdgTagPattern
           && matchContentType == other.matchContentType
           && matchFocused == other.matchFocused
+          && matchFloating == other.matchFloating
+          && matchPinned == other.matchPinned
+          && matchScratchpad == other.matchScratchpad
           && matchAtStartup == other.matchAtStartup
           && defaultOutput == other.defaultOutput
           && defaultFloating == other.defaultFloating

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -275,6 +275,17 @@ namespace umbriel {
     return "none";
   }
 
+  // Window state the `match.is_*` selectors test. Every field is a live
+  // property, so a change to any of them re-selects a window's rules.
+  struct WindowRuleState {
+    bool focused = false;
+    bool floating = false;
+    bool pinned = false;
+    bool scratchpad = false;
+
+    [[nodiscard]] bool operator==(const WindowRuleState& other) const = default;
+  };
+
   struct WindowRule {
     std::string appIdPattern;
     std::string titlePattern;

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -189,8 +189,7 @@ namespace umbriel {
 
   ResolvedWindowRule resolveWindowRules(
       const Config& config, std::optional<std::string_view> appId, std::optional<std::string_view> title,
-      std::optional<std::string_view> xdgTag, ContentType contentType, bool focused, bool floating, bool pinned,
-      bool scratchpad, uint64_t uptimeMs
+      std::optional<std::string_view> xdgTag, ContentType contentType, const WindowRuleState& state, uint64_t uptimeMs
   ) {
     ResolvedWindowRule resolved;
 
@@ -203,16 +202,16 @@ namespace umbriel {
       if (rule.matchContentType && *rule.matchContentType != contentType) {
         continue;
       }
-      if (rule.matchFocused && *rule.matchFocused != focused) {
+      if (rule.matchFocused && *rule.matchFocused != state.focused) {
         continue;
       }
-      if (rule.matchFloating && *rule.matchFloating != floating) {
+      if (rule.matchFloating && *rule.matchFloating != state.floating) {
         continue;
       }
-      if (rule.matchPinned && *rule.matchPinned != pinned) {
+      if (rule.matchPinned && *rule.matchPinned != state.pinned) {
         continue;
       }
-      if (rule.matchScratchpad && *rule.matchScratchpad != scratchpad) {
+      if (rule.matchScratchpad && *rule.matchScratchpad != state.scratchpad) {
         continue;
       }
       if (rule.matchAtStartup && *rule.matchAtStartup != (uptimeMs < kStartupWindowRuleDurationMs)) {

--- a/src/config/resolve.cpp
+++ b/src/config/resolve.cpp
@@ -189,7 +189,8 @@ namespace umbriel {
 
   ResolvedWindowRule resolveWindowRules(
       const Config& config, std::optional<std::string_view> appId, std::optional<std::string_view> title,
-      std::optional<std::string_view> xdgTag, ContentType contentType, bool focused, uint64_t uptimeMs
+      std::optional<std::string_view> xdgTag, ContentType contentType, bool focused, bool floating, bool pinned,
+      bool scratchpad, uint64_t uptimeMs
   ) {
     ResolvedWindowRule resolved;
 
@@ -203,6 +204,15 @@ namespace umbriel {
         continue;
       }
       if (rule.matchFocused && *rule.matchFocused != focused) {
+        continue;
+      }
+      if (rule.matchFloating && *rule.matchFloating != floating) {
+        continue;
+      }
+      if (rule.matchPinned && *rule.matchPinned != pinned) {
+        continue;
+      }
+      if (rule.matchScratchpad && *rule.matchScratchpad != scratchpad) {
         continue;
       }
       if (rule.matchAtStartup && *rule.matchAtStartup != (uptimeMs < kStartupWindowRuleDurationMs)) {

--- a/src/config/resolve.h
+++ b/src/config/resolve.h
@@ -22,7 +22,8 @@ namespace umbriel {
 
   [[nodiscard]] ResolvedWindowRule resolveWindowRules(
       const Config& config, std::optional<std::string_view> appId, std::optional<std::string_view> title,
-      std::optional<std::string_view> xdgTag, ContentType contentType, bool focused, uint64_t uptimeMs
+      std::optional<std::string_view> xdgTag, ContentType contentType, bool focused, bool floating, bool pinned,
+      bool scratchpad, uint64_t uptimeMs
   );
   [[nodiscard]] ResolvedLayerRule
   resolveLayerRules(const Config& config, std::optional<std::string_view> layerNamespace);

--- a/src/config/resolve.h
+++ b/src/config/resolve.h
@@ -22,8 +22,7 @@ namespace umbriel {
 
   [[nodiscard]] ResolvedWindowRule resolveWindowRules(
       const Config& config, std::optional<std::string_view> appId, std::optional<std::string_view> title,
-      std::optional<std::string_view> xdgTag, ContentType contentType, bool focused, bool floating, bool pinned,
-      bool scratchpad, uint64_t uptimeMs
+      std::optional<std::string_view> xdgTag, ContentType contentType, const WindowRuleState& state, uint64_t uptimeMs
   );
   [[nodiscard]] ResolvedLayerRule
   resolveLayerRules(const Config& config, std::optional<std::string_view> layerNamespace);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -3028,7 +3028,7 @@ namespace umbriel {
     // hints changed after map must not select new one-shot behavior.
     const ResolvedWindowRule rule = resolveWindowRules(
         config(), ruleText(m_toplevel->app_id), ruleText(m_toplevel->title), m_initialRulesXdgTag,
-        m_initialRulesContentType, m_borderFocusedState, m_server->uptimeMs()
+        m_initialRulesContentType, m_borderFocusedState, !m_tiled, m_pinned, m_scratchpadBorder, m_server->uptimeMs()
     );
 
     const bool namedScrollingColumnNameChanged = rule.defaultScrollingColumn.has_value()
@@ -3174,6 +3174,9 @@ namespace umbriel {
     // empty string, so a client that replaces a missing title with an empty one must re-resolve.
     if (m_rulesGeneration == generation
         && m_rulesFocused == m_borderFocusedState
+        && m_rulesFloating == !m_tiled
+        && m_rulesPinned == m_pinned
+        && m_rulesScratchpad == m_scratchpadBorder
         && m_rulesAppId == appId
         && m_rulesTitle == title
         && m_rulesXdgTag == m_xdgTag
@@ -3181,10 +3184,15 @@ namespace umbriel {
       return m_rules;
     }
 
-    m_rules =
-        resolveWindowRules(config(), appId, title, m_xdgTag, m_contentType, m_borderFocusedState, m_server->uptimeMs());
+    m_rules = resolveWindowRules(
+        config(), appId, title, m_xdgTag, m_contentType, m_borderFocusedState, !m_tiled, m_pinned, m_scratchpadBorder,
+        m_server->uptimeMs()
+    );
     m_rulesGeneration = generation;
     m_rulesFocused = m_borderFocusedState;
+    m_rulesFloating = !m_tiled;
+    m_rulesPinned = m_pinned;
+    m_rulesScratchpad = m_scratchpadBorder;
     m_rulesAppId = appId;
     m_rulesTitle = title;
     m_rulesXdgTag = m_xdgTag;

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -463,6 +463,7 @@ namespace umbriel {
     }
     m_scratchpadBorder = scratchpad;
     setBorderFocused(m_borderFocusedState);
+    refreshStateRuleEffects();
   }
 
   void View::reparentShadow(wlr_scene_tree* shadowLayer) {
@@ -2058,6 +2059,9 @@ namespace umbriel {
       // Replay their shared structure now that this member is visible again.
       m_server->scheduleDisplacedViewRestore();
     }
+    // Opening rules resolve before default_floating and default_pinned move the window, so the state selectors may
+    // pick a different set of dynamic effects than the ones applied above.
+    applyDynamicRules();
   }
 
   void View::handleUnmap() {
@@ -2137,6 +2141,7 @@ namespace umbriel {
     m_namedScrollingColumnOrder.reset();
     m_ownsNamedScrollingColumnWidth = false;
     m_ruleOpacity = 1.0F;
+    m_appliedRuleState = {};
     m_hasMaximizeRestoreBox = false;
     m_floating.clearSizeRequest();
     if (m_displacedHome) {
@@ -2727,6 +2732,7 @@ namespace umbriel {
       if (focus) {
         m_server->focusView(this);
       }
+      refreshStateRuleEffects();
       return;
     }
 
@@ -2751,6 +2757,7 @@ namespace umbriel {
     if (Overview* overview = m_server->overview(); overview != nullptr && overview->active()) {
       overview->onViewPinnedChanged(this);
     }
+    refreshStateRuleEffects();
   }
 
   void View::setFloating(bool floating, bool focus, TilePlacement placement) {
@@ -2853,6 +2860,7 @@ namespace umbriel {
         m_server->focusView(this);
       }
       updateForeignState();
+      refreshStateRuleEffects();
       return;
     }
 
@@ -2903,6 +2911,7 @@ namespace umbriel {
         overview->onViewPinnedChanged(this);
       }
     }
+    refreshStateRuleEffects();
   }
 
   void View::setFullscreen(bool fullscreen, FullscreenExitLayout exitLayout) {
@@ -3018,6 +3027,7 @@ namespace umbriel {
         overview->onViewPinnedChanged(this);
       }
     }
+    refreshStateRuleEffects();
   }
 
   void View::applyWindowRules(const ResolvedWindowRule& initiallyApplied) {
@@ -3028,7 +3038,7 @@ namespace umbriel {
     // hints changed after map must not select new one-shot behavior.
     const ResolvedWindowRule rule = resolveWindowRules(
         config(), ruleText(m_toplevel->app_id), ruleText(m_toplevel->title), m_initialRulesXdgTag,
-        m_initialRulesContentType, m_borderFocusedState, !m_tiled, m_pinned, m_scratchpadBorder, m_server->uptimeMs()
+        m_initialRulesContentType, ruleState(), m_server->uptimeMs()
     );
 
     const bool namedScrollingColumnNameChanged = rule.defaultScrollingColumn.has_value()
@@ -3165,18 +3175,31 @@ namespace umbriel {
     }
   }
 
+  void View::refreshStateRuleEffects() {
+    if (m_mapped && m_appliedRuleState != ruleState()) {
+      applyDynamicRules();
+    }
+  }
+
+  WindowRuleState View::ruleState() const {
+    return {
+        .focused = m_borderFocusedState,
+        .floating = !m_tiled,
+        .pinned = m_pinned,
+        .scratchpad = m_scratchpadBorder,
+    };
+  }
+
   const ResolvedWindowRule& View::resolvedRules() {
     const std::optional<std::string_view> appId = ruleText(m_toplevel->app_id);
     const std::optional<std::string_view> title = ruleText(m_toplevel->title);
     const uint64_t generation = configStore().generation();
+    const WindowRuleState state = ruleState();
 
     // An unset identity string is a distinct key from an empty one: only the latter matches a pattern accepting the
     // empty string, so a client that replaces a missing title with an empty one must re-resolve.
     if (m_rulesGeneration == generation
-        && m_rulesFocused == m_borderFocusedState
-        && m_rulesFloating == !m_tiled
-        && m_rulesPinned == m_pinned
-        && m_rulesScratchpad == m_scratchpadBorder
+        && m_rulesState == state
         && m_rulesAppId == appId
         && m_rulesTitle == title
         && m_rulesXdgTag == m_xdgTag
@@ -3184,15 +3207,9 @@ namespace umbriel {
       return m_rules;
     }
 
-    m_rules = resolveWindowRules(
-        config(), appId, title, m_xdgTag, m_contentType, m_borderFocusedState, !m_tiled, m_pinned, m_scratchpadBorder,
-        m_server->uptimeMs()
-    );
+    m_rules = resolveWindowRules(config(), appId, title, m_xdgTag, m_contentType, state, m_server->uptimeMs());
     m_rulesGeneration = generation;
-    m_rulesFocused = m_borderFocusedState;
-    m_rulesFloating = !m_tiled;
-    m_rulesPinned = m_pinned;
-    m_rulesScratchpad = m_scratchpadBorder;
+    m_rulesState = state;
     m_rulesAppId = appId;
     m_rulesTitle = title;
     m_rulesXdgTag = m_xdgTag;
@@ -3202,6 +3219,7 @@ namespace umbriel {
 
   void View::applyDynamicRules(const ResolvedWindowRule* resolved) {
     const ResolvedWindowRule& rule = resolved != nullptr ? *resolved : resolvedRules();
+    m_appliedRuleState = ruleState();
     m_decoration.applyRule(rule);
     const float newOpacity = rule.opacity ? static_cast<float>(*rule.opacity) : 1.0F;
     if (newOpacity != m_ruleOpacity) {

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -415,10 +415,16 @@ namespace umbriel {
     // is work a terminal that retitles per command pays repeatedly.
     void applyDynamicRules(const ResolvedWindowRule* resolved = nullptr);
     void refreshStartupRuleEffects();
-    // Window rules, resolved at most once per (config, app-id, title, XDG tag, content type, focus). Resolution runs
-    // every rule's regexes, and it is reached on focus changes and on every identity change; a terminal that retitles
-    // per command would otherwise pay the whole rule set on each one. Every input is part of the key:
-    // `match.is_focused` makes focus a matching criterion, not just a consumer of the result.
+    // Re-applies dynamic effects after a float, pin, or scratchpad transition, because those states select rules.
+    // A transition that also moved focus has already refreshed them, so this is a no-op there.
+    void refreshStateRuleEffects();
+    // The live window state the `match.is_*` selectors test.
+    [[nodiscard]] WindowRuleState ruleState() const;
+    // Window rules, resolved at most once per (config, app-id, title, XDG tag, content type, window state).
+    // Resolution runs every rule's regexes, and it is reached on focus changes and on every identity change; a
+    // terminal that retitles per command would otherwise pay the whole rule set on each one. Window state is part of
+    // the key because `match.is_focused` and its siblings make it a matching criterion, not just a consumer of the
+    // result.
     [[nodiscard]] const ResolvedWindowRule& resolvedRules();
 
     // Cache for resolvedRules(); m_rulesGeneration 0 means never resolved.
@@ -428,10 +434,10 @@ namespace umbriel {
     std::optional<std::string> m_rulesTitle;
     std::optional<std::string> m_rulesXdgTag;
     ContentType m_rulesContentType = ContentType::None;
-    bool m_rulesFocused = false;
-    bool m_rulesFloating = false;
-    bool m_rulesPinned = false;
-    bool m_rulesScratchpad = false;
+    WindowRuleState m_rulesState;
+    // The state applyDynamicRules last applied effects for. Any resolvedRules() caller refreshes the cache above, so
+    // only this tells a transition whether the effects on screen still match the window's state.
+    WindowRuleState m_appliedRuleState;
     // One-shot effects already applied at map. Late identity resolution only
     // reapplies a field when its resolved value changes.
     ResolvedWindowRule m_initialRules;

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -429,6 +429,9 @@ namespace umbriel {
     std::optional<std::string> m_rulesXdgTag;
     ContentType m_rulesContentType = ContentType::None;
     bool m_rulesFocused = false;
+    bool m_rulesFloating = false;
+    bool m_rulesPinned = false;
+    bool m_rulesScratchpad = false;
     // One-shot effects already applied at map. Late identity resolution only
     // reapplies a field when its resolved value changes.
     ResolvedWindowRule m_initialRules;

--- a/tests/harness/checks/736_rule_state_transitions.sh
+++ b/tests/harness/checks/736_rule_state_transitions.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# A float or pin transition re-selects window rules, so `match.is_floating` and
+# `match.is_pinned` effects must land on the toggle itself. Nothing here moves
+# focus or identity, so no other rule refresh can produce the effect.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_SUBSURFACE_CLIENT:-./build-debug/tests/subsurface-client}"
+readonly SCREENSHOT="$UMBRIEL_RUNTIME_DIR/rule-state-transitions.png"
+
+if [[ ! -x $CLIENT ]]; then
+  echo "subsurface client not built at $CLIENT"
+  exit 1
+fi
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[animation]
+enabled = false
+
+[colors]
+backdrop = "#00FF00FF"
+
+[appearance]
+border_width = 0
+corner_radius = 0
+
+[[window_rule]]
+match.title = "^state-rules$"
+match.is_floating = true
+opacity = 0.5
+
+[[window_rule]]
+match.title = "^state-rules$"
+match.is_pinned = true
+opacity = 0.5
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+field_of() {
+  "$UMBRIEL" windows --json | jq -r --arg field "$1" '.[] | select(.title == "state-rules") | .[$field]'
+}
+
+wait_for_field() {
+  local field=$1 expected=$2 actual=
+  for _ in $(seq 80); do
+    actual=$(field_of "$field")
+    [[ $actual == "$expected" ]] && return 0
+    sleep 0.1
+  done
+  echo "expected window field '$field' to be '$expected', got '$actual'"
+  exit 1
+}
+
+# The client's blue child surface covers the window centre. Opaque it encodes as
+# blue 255; at rule opacity 0.5 the green backdrop shows through and drops it to
+# roughly 128.
+sample_blue() {
+  local x y w h
+  read -r x y w h <<< "$(
+    "$UMBRIEL" windows --json | jq -r '.[] | select(.title == "state-rules") | "\(.x) \(.y) \(.w) \(.h)"'
+  )"
+  grim "$SCREENSHOT"
+  magick "$SCREENSHOT" -crop "20x20+$((x + w / 2 - 10))+$((y + h / 2 - 10))" \
+    -format '%[fx:round(255*mean.b)]' info:
+}
+
+# Failures go to stderr: the caller captures stdout to report the samples it saw.
+expect_state() {
+  local label=$1 want=$2 blue=
+  sleep 0.3
+  blue=$(sample_blue)
+  if [[ $want == applied ]] && ((blue > 200)); then
+    echo "$label: state rule was not applied (blue=$blue)" >&2
+    exit 1
+  fi
+  if [[ $want == absent ]] && ((blue < 240)); then
+    echo "$label: state rule stayed applied (blue=$blue)" >&2
+    exit 1
+  fi
+  echo "$label blue=$blue"
+}
+
+"$CLIENT" state-rules 640 480 > "$UMBRIEL_RUNTIME_DIR/state-rules.log" 2>&1 &
+wait_for_field floating false
+tiled=$(expect_state "tiled" absent)
+
+"$UMBRIEL" msg window-toggle-floating > /dev/null
+wait_for_field floating true
+floated=$(expect_state "floating" applied)
+
+"$UMBRIEL" msg window-toggle-floating > /dev/null
+wait_for_field floating false
+retiled=$(expect_state "re-tiled" absent)
+
+"$UMBRIEL" msg window-toggle-pinned > /dev/null
+wait_for_field floating true
+pinned=$(expect_state "pinned" applied)
+
+"$UMBRIEL" msg window-toggle-pinned > /dev/null
+wait_for_field floating false
+unpinned=$(expect_state "unpinned" absent)
+
+echo "float and pin transitions re-apply state rules: $tiled, $floated, $retiled, $pinned, $unpinned"

--- a/tests/unit/config_load.cpp
+++ b/tests/unit/config_load.cpp
@@ -1408,6 +1408,32 @@ UMBRIEL_TEST(windowStartupMatcherLoadsBoolean) {
   CHECK(!containsDiagnostic(store, "unknown key window_rule.opacity"));
 }
 
+UMBRIEL_TEST(windowStateMatchersLoadBooleans) {
+  const TempConfig file;
+  ConfigStore& store = umbriel::configStore();
+  store.setRootPath(file.path(), true);
+
+  file.write(
+      "[[window_rule]]\nmatch.is_floating = true\nmatch.is_pinned = false\nmatch.is_scratchpad = true\nopacity = "
+      "0.9\n"
+  );
+  CHECK(store.reload().success);
+  CHECK_EQ(store.config().windowRules.size(), size_t{1});
+  CHECK(store.config().windowRules[0].matchFloating == true);
+  CHECK(store.config().windowRules[0].matchPinned == false);
+  CHECK(store.config().windowRules[0].matchScratchpad == true);
+
+  file.write("[[window_rule]]\nmatch.is_floating = \"yes\"\nmatch.is_pinned = 1\nmatch.is_scratchpad = 0.5\n");
+  CHECK(store.reload().success);
+  CHECK(store.config().windowRules.empty());
+  CHECK(containsDiagnostic(store, "ignoring window_rule.match.is_floating (expected boolean)"));
+  CHECK(containsDiagnostic(store, "ignoring window_rule.match.is_pinned (expected boolean)"));
+  CHECK(containsDiagnostic(store, "ignoring window_rule.match.is_scratchpad (expected boolean)"));
+  CHECK(!containsDiagnostic(store, "unknown key window_rule.match.is_floating"));
+  CHECK(!containsDiagnostic(store, "unknown key window_rule.match.is_pinned"));
+  CHECK(!containsDiagnostic(store, "unknown key window_rule.match.is_scratchpad"));
+}
+
 UMBRIEL_TEST(windowXdgTagMatcherLoadsRegexAndRejectsInvalidValues) {
   const TempConfig file;
   ConfigStore& store = umbriel::configStore();

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -443,9 +443,8 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   unfocused.defaultFloating = true;
   config.windowRules.push_back(std::move(unfocused));
 
-  const auto resolved = umbriel::resolveWindowRules(
-      config, "foot", "project shell", std::nullopt, ContentType::None, false, false, false, false, 0
-  );
+  const auto resolved =
+      umbriel::resolveWindowRules(config, "foot", "project shell", std::nullopt, ContentType::None, {}, 0);
   CHECK(resolved.opacity && *resolved.opacity == 0.8);
   CHECK(resolved.blur && *resolved.blur);
   CHECK(resolved.defaultFloating && *resolved.defaultFloating);
@@ -462,9 +461,7 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   CHECK(resolved.allowTearing && *resolved.allowTearing);
   CHECK(resolved.hdr == umbriel::HdrMode::On);
 
-  const auto appOnly = umbriel::resolveWindowRules(
-      config, "foot", "editor", std::nullopt, ContentType::None, false, false, false, false, 0
-  );
+  const auto appOnly = umbriel::resolveWindowRules(config, "foot", "editor", std::nullopt, ContentType::None, {}, 0);
   CHECK(appOnly.defaultPinned && *appOnly.defaultPinned);
   CHECK(appOnly.defaultScrollingColumn && *appOnly.defaultScrollingColumn == "browser-stack");
   CHECK(appOnly.defaultScrollingColumnOrder && *appOnly.defaultScrollingColumnOrder == 20);
@@ -473,7 +470,7 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   CHECK(appOnly.hdr == umbriel::HdrMode::Off);
 
   const auto focused = umbriel::resolveWindowRules(
-      config, "foot", "project shell", std::nullopt, ContentType::None, true, false, false, false, 0
+      config, "foot", "project shell", std::nullopt, ContentType::None, {.focused = true}, 0
   );
   CHECK(focused.opacity && *focused.opacity == 0.8);
   CHECK(!focused.defaultFloating);
@@ -495,13 +492,13 @@ UMBRIEL_TEST(windowRulesMergeWorkspaceTargetsAcrossSelectorKinds) {
   title.defaultWorkspace = umbriel::WorkspaceTarget{std::string{"2"}};
   config.windowRules.push_back(std::move(title));
 
-  const auto appOnly = umbriel::resolveWindowRules(config, "foot", "editor", std::nullopt, ContentType::None, false, 0);
+  const auto appOnly = umbriel::resolveWindowRules(config, "foot", "editor", std::nullopt, ContentType::None, {}, 0);
   const auto* position = appOnly.defaultWorkspace ? std::get_if<int>(&*appOnly.defaultWorkspace) : nullptr;
   CHECK(position != nullptr);
   CHECK(position != nullptr && *position == 2);
 
   const auto merged =
-      umbriel::resolveWindowRules(config, "foot", "project chat", std::nullopt, ContentType::None, false, 0);
+      umbriel::resolveWindowRules(config, "foot", "project chat", std::nullopt, ContentType::None, {}, 0);
   const auto* name = merged.defaultWorkspace ? std::get_if<std::string>(&*merged.defaultWorkspace) : nullptr;
   CHECK(name != nullptr);
   CHECK(name != nullptr && *name == "2");
@@ -524,9 +521,8 @@ UMBRIEL_TEST(windowRulesMergeFractionSizingLastWriterWins) {
   second.defaultWidth = 0.75;
   config.windowRules.push_back(std::move(second));
 
-  const auto resolved = umbriel::resolveWindowRules(
-      config, "utility", std::nullopt, std::nullopt, ContentType::None, false, false, false, false, 0
-  );
+  const auto resolved =
+      umbriel::resolveWindowRules(config, "utility", std::nullopt, std::nullopt, ContentType::None, {}, 0);
   CHECK(resolved.defaultFloating && *resolved.defaultFloating);
   // Later rules overwrite only the fields they set.
   CHECK(resolved.defaultWidth && *resolved.defaultWidth == 0.75);
@@ -563,46 +559,80 @@ UMBRIEL_TEST(windowRulesMatchContentTypesAndComposeSelectors) {
   none.defaultFloating = true;
   config.windowRules.push_back(std::move(none));
 
-  const auto matchingGame = umbriel::resolveWindowRules(
-      config, "runner", "now playing", std::nullopt, ContentType::Game, false, false, false, false, 0
-  );
+  const auto matchingGame =
+      umbriel::resolveWindowRules(config, "runner", "now playing", std::nullopt, ContentType::Game, {}, 0);
   CHECK(matchingGame.opacity && *matchingGame.opacity == 0.75);
   CHECK(!matchingGame.defaultFloating);
 
-  const auto wrongApp = umbriel::resolveWindowRules(
-      config, "launcher", "now playing", std::nullopt, ContentType::Game, false, false, false, false, 0
-  );
+  const auto wrongApp =
+      umbriel::resolveWindowRules(config, "launcher", "now playing", std::nullopt, ContentType::Game, {}, 0);
   CHECK(!wrongApp.opacity);
-  const auto wrongTitle = umbriel::resolveWindowRules(
-      config, "runner", "paused", std::nullopt, ContentType::Game, false, false, false, false, 0
-  );
+  const auto wrongTitle =
+      umbriel::resolveWindowRules(config, "runner", "paused", std::nullopt, ContentType::Game, {}, 0);
   CHECK(!wrongTitle.opacity);
   const auto wrongFocus = umbriel::resolveWindowRules(
-      config, "runner", "now playing", std::nullopt, ContentType::Game, true, false, false, false, 0
+      config, "runner", "now playing", std::nullopt, ContentType::Game, {.focused = true}, 0
   );
   CHECK(!wrongFocus.opacity);
   const auto afterStartupRule = umbriel::resolveWindowRules(
-      config, "runner", "now playing", std::nullopt, ContentType::Game, false, false, false, false,
-      umbriel::kStartupWindowRuleDurationMs
+      config, "runner", "now playing", std::nullopt, ContentType::Game, {}, umbriel::kStartupWindowRuleDurationMs
   );
   CHECK(!afterStartupRule.opacity);
   CHECK(afterStartupRule.defaultFloating && *afterStartupRule.defaultFloating);
 
-  const auto matchingPhoto = umbriel::resolveWindowRules(
-      config, "viewer", "photo", std::nullopt, ContentType::Photo, false, false, false, false, 0
-  );
+  const auto matchingPhoto =
+      umbriel::resolveWindowRules(config, "viewer", "photo", std::nullopt, ContentType::Photo, {}, 0);
   CHECK(matchingPhoto.opacity && *matchingPhoto.opacity == 0.25);
 
-  const auto matchingNone = umbriel::resolveWindowRules(
-      config, "terminal", "shell", std::nullopt, ContentType::None, false, false, false, false, 0
-  );
+  const auto matchingNone =
+      umbriel::resolveWindowRules(config, "terminal", "shell", std::nullopt, ContentType::None, {}, 0);
   CHECK(matchingNone.defaultFloating && *matchingNone.defaultFloating);
 
-  const auto video = umbriel::resolveWindowRules(
-      config, "viewer", "video", std::nullopt, ContentType::Video, false, false, false, false, 0
-  );
+  const auto video = umbriel::resolveWindowRules(config, "viewer", "video", std::nullopt, ContentType::Video, {}, 0);
   CHECK(!video.opacity);
   CHECK(!video.defaultFloating);
+}
+
+UMBRIEL_TEST(windowRulesMatchWindowStateSelectors) {
+  Config config;
+
+  WindowRule floatingRule;
+  floatingRule.matchFloating = true;
+  floatingRule.matchScratchpad = false;
+  floatingRule.opacity = 0.4;
+  config.windowRules.push_back(std::move(floatingRule));
+
+  WindowRule pinnedRule;
+  pinnedRule.matchPinned = true;
+  pinnedRule.blur = false;
+  config.windowRules.push_back(std::move(pinnedRule));
+
+  WindowRule scratchpadRule;
+  scratchpadRule.matchScratchpad = true;
+  scratchpadRule.opacity = 0.9;
+  config.windowRules.push_back(std::move(scratchpadRule));
+
+  const auto tiled = umbriel::resolveWindowRules(config, "foot", "shell", std::nullopt, ContentType::None, {}, 0);
+  CHECK(!tiled.opacity);
+  CHECK(!tiled.blur);
+
+  const auto floating =
+      umbriel::resolveWindowRules(config, "foot", "shell", std::nullopt, ContentType::None, {.floating = true}, 0);
+  CHECK(floating.opacity && *floating.opacity == 0.4);
+  CHECK(!floating.blur);
+
+  // A pinned window is floating too, so both selectors hold at once.
+  const auto pinned = umbriel::resolveWindowRules(
+      config, "foot", "shell", std::nullopt, ContentType::None, {.floating = true, .pinned = true}, 0
+  );
+  CHECK(pinned.opacity && *pinned.opacity == 0.4);
+  CHECK(pinned.blur && !*pinned.blur);
+
+  // is_scratchpad = false excludes the floating rule; the scratchpad rule wins the opacity.
+  const auto scratchpad = umbriel::resolveWindowRules(
+      config, "foot", "shell", std::nullopt, ContentType::None, {.floating = true, .scratchpad = true}, 0
+  );
+  CHECK(scratchpad.opacity && *scratchpad.opacity == 0.9);
 }
 
 UMBRIEL_TEST(windowRulesMatchXdgTagsAndComposeSelectors) {
@@ -633,47 +663,39 @@ UMBRIEL_TEST(windowRulesMatchXdgTagsAndComposeSelectors) {
   running.opacity = 0.5;
   config.windowRules.push_back(std::move(running));
 
-  const auto matchingLauncher = umbriel::resolveWindowRules(
-      config, "runner", "now playing", "game-launcher", ContentType::Game, false, false, false, false, 0
-  );
+  const auto matchingLauncher =
+      umbriel::resolveWindowRules(config, "runner", "now playing", "game-launcher", ContentType::Game, {}, 0);
   CHECK(matchingLauncher.opacity && *matchingLauncher.opacity == 0.9);
   CHECK(matchingLauncher.defaultFloating && *matchingLauncher.defaultFloating);
 
-  const auto matchingRunning = umbriel::resolveWindowRules(
-      config, "runner", "now playing", "game-running", ContentType::Game, false, false, false, false, 0
-  );
+  const auto matchingRunning =
+      umbriel::resolveWindowRules(config, "runner", "now playing", "game-running", ContentType::Game, {}, 0);
   CHECK(matchingRunning.opacity && *matchingRunning.opacity == 0.5);
 
-  const auto matchingSecondTag = umbriel::resolveWindowRules(
-      config, "runner", "now playing", "game-settings", ContentType::Game, false, false, false, false, 0
-  );
+  const auto matchingSecondTag =
+      umbriel::resolveWindowRules(config, "runner", "now playing", "game-settings", ContentType::Game, {}, 0);
   CHECK(matchingSecondTag.opacity && *matchingSecondTag.opacity == 0.5);
 
-  const auto wrongApp = umbriel::resolveWindowRules(
-      config, "launcher", "now playing", "game-running", ContentType::Game, false, false, false, false, 0
-  );
+  const auto wrongApp =
+      umbriel::resolveWindowRules(config, "launcher", "now playing", "game-running", ContentType::Game, {}, 0);
   CHECK(wrongApp.opacity && *wrongApp.opacity == 0.25);
-  const auto wrongTitle = umbriel::resolveWindowRules(
-      config, "runner", "paused", "game-running", ContentType::Game, false, false, false, false, 0
-  );
+  const auto wrongTitle =
+      umbriel::resolveWindowRules(config, "runner", "paused", "game-running", ContentType::Game, {}, 0);
   CHECK(wrongTitle.opacity && *wrongTitle.opacity == 0.25);
-  const auto wrongContent = umbriel::resolveWindowRules(
-      config, "runner", "now playing", "game-running", ContentType::Video, false, false, false, false, 0
-  );
+  const auto wrongContent =
+      umbriel::resolveWindowRules(config, "runner", "now playing", "game-running", ContentType::Video, {}, 0);
   CHECK(wrongContent.opacity && *wrongContent.opacity == 0.25);
   const auto wrongFocus = umbriel::resolveWindowRules(
-      config, "runner", "now playing", "game-running", ContentType::Game, true, false, false, false, 0
+      config, "runner", "now playing", "game-running", ContentType::Game, {.focused = true}, 0
   );
   CHECK(wrongFocus.opacity && *wrongFocus.opacity == 0.25);
 
-  const auto missingTag = umbriel::resolveWindowRules(
-      config, "runner", "now playing", std::nullopt, ContentType::Game, false, false, false, false, 0
-  );
+  const auto missingTag =
+      umbriel::resolveWindowRules(config, "runner", "now playing", std::nullopt, ContentType::Game, {}, 0);
   CHECK(!missingTag.opacity);
   CHECK(!missingTag.defaultFloating);
-  const auto unknownTag = umbriel::resolveWindowRules(
-      config, "runner", "now playing", "browser", ContentType::Game, false, false, false, false, 0
-  );
+  const auto unknownTag =
+      umbriel::resolveWindowRules(config, "runner", "now playing", "browser", ContentType::Game, {}, 0);
   CHECK(!unknownTag.opacity);
   CHECK(!unknownTag.defaultFloating);
 }
@@ -700,24 +722,21 @@ UMBRIEL_TEST(windowRulesMatchEmptyIdentityOnlyWhenTheClientSetIt) {
   config.windowRules.push_back(std::move(blankTag));
 
   // A window whose title, app ID, and tag are all set to the empty string.
-  const auto allEmpty =
-      umbriel::resolveWindowRules(config, "", "", "", ContentType::None, false, false, false, false, 0);
+  const auto allEmpty = umbriel::resolveWindowRules(config, "", "", "", ContentType::None, {}, 0);
   CHECK(allEmpty.defaultFloating && *allEmpty.defaultFloating);
   CHECK(allEmpty.opacity && *allEmpty.opacity == 0.5);
   CHECK(allEmpty.defaultMaximize && *allEmpty.defaultMaximize);
 
   // A window that never sent any of them matches nothing: an unset value is not an empty one.
-  const auto allUnset = umbriel::resolveWindowRules(
-      config, std::nullopt, std::nullopt, std::nullopt, ContentType::None, false, false, false, false, 0
-  );
+  const auto allUnset =
+      umbriel::resolveWindowRules(config, std::nullopt, std::nullopt, std::nullopt, ContentType::None, {}, 0);
   CHECK(!allUnset.defaultFloating);
   CHECK(!allUnset.opacity);
   CHECK(!allUnset.defaultMaximize);
 
   // Selectors are independent: an empty title matches while a non-empty app ID and an unset tag do not.
-  const auto emptyTitleOnly = umbriel::resolveWindowRules(
-      config, "firefox", "", std::nullopt, ContentType::None, false, false, false, false, 0
-  );
+  const auto emptyTitleOnly =
+      umbriel::resolveWindowRules(config, "firefox", "", std::nullopt, ContentType::None, {}, 0);
   CHECK(emptyTitleOnly.defaultFloating && *emptyTitleOnly.defaultFloating);
   CHECK(!emptyTitleOnly.opacity);
   CHECK(!emptyTitleOnly.defaultMaximize);

--- a/tests/unit/config_resolve.cpp
+++ b/tests/unit/config_resolve.cpp
@@ -443,8 +443,9 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   unfocused.defaultFloating = true;
   config.windowRules.push_back(std::move(unfocused));
 
-  const auto resolved =
-      umbriel::resolveWindowRules(config, "foot", "project shell", std::nullopt, ContentType::None, false, 0);
+  const auto resolved = umbriel::resolveWindowRules(
+      config, "foot", "project shell", std::nullopt, ContentType::None, false, false, false, false, 0
+  );
   CHECK(resolved.opacity && *resolved.opacity == 0.8);
   CHECK(resolved.blur && *resolved.blur);
   CHECK(resolved.defaultFloating && *resolved.defaultFloating);
@@ -461,7 +462,9 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   CHECK(resolved.allowTearing && *resolved.allowTearing);
   CHECK(resolved.hdr == umbriel::HdrMode::On);
 
-  const auto appOnly = umbriel::resolveWindowRules(config, "foot", "editor", std::nullopt, ContentType::None, false, 0);
+  const auto appOnly = umbriel::resolveWindowRules(
+      config, "foot", "editor", std::nullopt, ContentType::None, false, false, false, false, 0
+  );
   CHECK(appOnly.defaultPinned && *appOnly.defaultPinned);
   CHECK(appOnly.defaultScrollingColumn && *appOnly.defaultScrollingColumn == "browser-stack");
   CHECK(appOnly.defaultScrollingColumnOrder && *appOnly.defaultScrollingColumnOrder == 20);
@@ -469,8 +472,9 @@ UMBRIEL_TEST(windowRulesMergeMatchingFieldsInOrder) {
   CHECK(appOnly.allowTearing && !*appOnly.allowTearing);
   CHECK(appOnly.hdr == umbriel::HdrMode::Off);
 
-  const auto focused =
-      umbriel::resolveWindowRules(config, "foot", "project shell", std::nullopt, ContentType::None, true, 0);
+  const auto focused = umbriel::resolveWindowRules(
+      config, "foot", "project shell", std::nullopt, ContentType::None, true, false, false, false, 0
+  );
   CHECK(focused.opacity && *focused.opacity == 0.8);
   CHECK(!focused.defaultFloating);
   CHECK(umbriel::anyWindowRuleHasTitlePattern(config));
@@ -520,8 +524,9 @@ UMBRIEL_TEST(windowRulesMergeFractionSizingLastWriterWins) {
   second.defaultWidth = 0.75;
   config.windowRules.push_back(std::move(second));
 
-  const auto resolved =
-      umbriel::resolveWindowRules(config, "utility", std::nullopt, std::nullopt, ContentType::None, false, 0);
+  const auto resolved = umbriel::resolveWindowRules(
+      config, "utility", std::nullopt, std::nullopt, ContentType::None, false, false, false, false, 0
+  );
   CHECK(resolved.defaultFloating && *resolved.defaultFloating);
   // Later rules overwrite only the fields they set.
   CHECK(resolved.defaultWidth && *resolved.defaultWidth == 0.75);
@@ -558,35 +563,44 @@ UMBRIEL_TEST(windowRulesMatchContentTypesAndComposeSelectors) {
   none.defaultFloating = true;
   config.windowRules.push_back(std::move(none));
 
-  const auto matchingGame =
-      umbriel::resolveWindowRules(config, "runner", "now playing", std::nullopt, ContentType::Game, false, 0);
+  const auto matchingGame = umbriel::resolveWindowRules(
+      config, "runner", "now playing", std::nullopt, ContentType::Game, false, false, false, false, 0
+  );
   CHECK(matchingGame.opacity && *matchingGame.opacity == 0.75);
   CHECK(!matchingGame.defaultFloating);
 
-  const auto wrongApp =
-      umbriel::resolveWindowRules(config, "launcher", "now playing", std::nullopt, ContentType::Game, false, 0);
+  const auto wrongApp = umbriel::resolveWindowRules(
+      config, "launcher", "now playing", std::nullopt, ContentType::Game, false, false, false, false, 0
+  );
   CHECK(!wrongApp.opacity);
-  const auto wrongTitle =
-      umbriel::resolveWindowRules(config, "runner", "paused", std::nullopt, ContentType::Game, false, 0);
+  const auto wrongTitle = umbriel::resolveWindowRules(
+      config, "runner", "paused", std::nullopt, ContentType::Game, false, false, false, false, 0
+  );
   CHECK(!wrongTitle.opacity);
-  const auto wrongFocus =
-      umbriel::resolveWindowRules(config, "runner", "now playing", std::nullopt, ContentType::Game, true, 0);
+  const auto wrongFocus = umbriel::resolveWindowRules(
+      config, "runner", "now playing", std::nullopt, ContentType::Game, true, false, false, false, 0
+  );
   CHECK(!wrongFocus.opacity);
   const auto afterStartupRule = umbriel::resolveWindowRules(
-      config, "runner", "now playing", std::nullopt, ContentType::Game, false, umbriel::kStartupWindowRuleDurationMs
+      config, "runner", "now playing", std::nullopt, ContentType::Game, false, false, false, false,
+      umbriel::kStartupWindowRuleDurationMs
   );
   CHECK(!afterStartupRule.opacity);
   CHECK(afterStartupRule.defaultFloating && *afterStartupRule.defaultFloating);
 
-  const auto matchingPhoto =
-      umbriel::resolveWindowRules(config, "viewer", "photo", std::nullopt, ContentType::Photo, false, 0);
+  const auto matchingPhoto = umbriel::resolveWindowRules(
+      config, "viewer", "photo", std::nullopt, ContentType::Photo, false, false, false, false, 0
+  );
   CHECK(matchingPhoto.opacity && *matchingPhoto.opacity == 0.25);
 
-  const auto matchingNone =
-      umbriel::resolveWindowRules(config, "terminal", "shell", std::nullopt, ContentType::None, false, 0);
+  const auto matchingNone = umbriel::resolveWindowRules(
+      config, "terminal", "shell", std::nullopt, ContentType::None, false, false, false, false, 0
+  );
   CHECK(matchingNone.defaultFloating && *matchingNone.defaultFloating);
 
-  const auto video = umbriel::resolveWindowRules(config, "viewer", "video", std::nullopt, ContentType::Video, false, 0);
+  const auto video = umbriel::resolveWindowRules(
+      config, "viewer", "video", std::nullopt, ContentType::Video, false, false, false, false, 0
+  );
   CHECK(!video.opacity);
   CHECK(!video.defaultFloating);
 }
@@ -619,38 +633,47 @@ UMBRIEL_TEST(windowRulesMatchXdgTagsAndComposeSelectors) {
   running.opacity = 0.5;
   config.windowRules.push_back(std::move(running));
 
-  const auto matchingLauncher =
-      umbriel::resolveWindowRules(config, "runner", "now playing", "game-launcher", ContentType::Game, false, 0);
+  const auto matchingLauncher = umbriel::resolveWindowRules(
+      config, "runner", "now playing", "game-launcher", ContentType::Game, false, false, false, false, 0
+  );
   CHECK(matchingLauncher.opacity && *matchingLauncher.opacity == 0.9);
   CHECK(matchingLauncher.defaultFloating && *matchingLauncher.defaultFloating);
 
-  const auto matchingRunning =
-      umbriel::resolveWindowRules(config, "runner", "now playing", "game-running", ContentType::Game, false, 0);
+  const auto matchingRunning = umbriel::resolveWindowRules(
+      config, "runner", "now playing", "game-running", ContentType::Game, false, false, false, false, 0
+  );
   CHECK(matchingRunning.opacity && *matchingRunning.opacity == 0.5);
 
-  const auto matchingSecondTag =
-      umbriel::resolveWindowRules(config, "runner", "now playing", "game-settings", ContentType::Game, false, 0);
+  const auto matchingSecondTag = umbriel::resolveWindowRules(
+      config, "runner", "now playing", "game-settings", ContentType::Game, false, false, false, false, 0
+  );
   CHECK(matchingSecondTag.opacity && *matchingSecondTag.opacity == 0.5);
 
-  const auto wrongApp =
-      umbriel::resolveWindowRules(config, "launcher", "now playing", "game-running", ContentType::Game, false, 0);
+  const auto wrongApp = umbriel::resolveWindowRules(
+      config, "launcher", "now playing", "game-running", ContentType::Game, false, false, false, false, 0
+  );
   CHECK(wrongApp.opacity && *wrongApp.opacity == 0.25);
-  const auto wrongTitle =
-      umbriel::resolveWindowRules(config, "runner", "paused", "game-running", ContentType::Game, false, 0);
+  const auto wrongTitle = umbriel::resolveWindowRules(
+      config, "runner", "paused", "game-running", ContentType::Game, false, false, false, false, 0
+  );
   CHECK(wrongTitle.opacity && *wrongTitle.opacity == 0.25);
-  const auto wrongContent =
-      umbriel::resolveWindowRules(config, "runner", "now playing", "game-running", ContentType::Video, false, 0);
+  const auto wrongContent = umbriel::resolveWindowRules(
+      config, "runner", "now playing", "game-running", ContentType::Video, false, false, false, false, 0
+  );
   CHECK(wrongContent.opacity && *wrongContent.opacity == 0.25);
-  const auto wrongFocus =
-      umbriel::resolveWindowRules(config, "runner", "now playing", "game-running", ContentType::Game, true, 0);
+  const auto wrongFocus = umbriel::resolveWindowRules(
+      config, "runner", "now playing", "game-running", ContentType::Game, true, false, false, false, 0
+  );
   CHECK(wrongFocus.opacity && *wrongFocus.opacity == 0.25);
 
-  const auto missingTag =
-      umbriel::resolveWindowRules(config, "runner", "now playing", std::nullopt, ContentType::Game, false, 0);
+  const auto missingTag = umbriel::resolveWindowRules(
+      config, "runner", "now playing", std::nullopt, ContentType::Game, false, false, false, false, 0
+  );
   CHECK(!missingTag.opacity);
   CHECK(!missingTag.defaultFloating);
-  const auto unknownTag =
-      umbriel::resolveWindowRules(config, "runner", "now playing", "browser", ContentType::Game, false, 0);
+  const auto unknownTag = umbriel::resolveWindowRules(
+      config, "runner", "now playing", "browser", ContentType::Game, false, false, false, false, 0
+  );
   CHECK(!unknownTag.opacity);
   CHECK(!unknownTag.defaultFloating);
 }
@@ -677,21 +700,24 @@ UMBRIEL_TEST(windowRulesMatchEmptyIdentityOnlyWhenTheClientSetIt) {
   config.windowRules.push_back(std::move(blankTag));
 
   // A window whose title, app ID, and tag are all set to the empty string.
-  const auto allEmpty = umbriel::resolveWindowRules(config, "", "", "", ContentType::None, false, 0);
+  const auto allEmpty =
+      umbriel::resolveWindowRules(config, "", "", "", ContentType::None, false, false, false, false, 0);
   CHECK(allEmpty.defaultFloating && *allEmpty.defaultFloating);
   CHECK(allEmpty.opacity && *allEmpty.opacity == 0.5);
   CHECK(allEmpty.defaultMaximize && *allEmpty.defaultMaximize);
 
   // A window that never sent any of them matches nothing: an unset value is not an empty one.
-  const auto allUnset =
-      umbriel::resolveWindowRules(config, std::nullopt, std::nullopt, std::nullopt, ContentType::None, false, 0);
+  const auto allUnset = umbriel::resolveWindowRules(
+      config, std::nullopt, std::nullopt, std::nullopt, ContentType::None, false, false, false, false, 0
+  );
   CHECK(!allUnset.defaultFloating);
   CHECK(!allUnset.opacity);
   CHECK(!allUnset.defaultMaximize);
 
   // Selectors are independent: an empty title matches while a non-empty app ID and an unset tag do not.
-  const auto emptyTitleOnly =
-      umbriel::resolveWindowRules(config, "firefox", "", std::nullopt, ContentType::None, false, 0);
+  const auto emptyTitleOnly = umbriel::resolveWindowRules(
+      config, "firefox", "", std::nullopt, ContentType::None, false, false, false, false, 0
+  );
   CHECK(emptyTitleOnly.defaultFloating && *emptyTitleOnly.defaultFloating);
   CHECK(!emptyTitleOnly.opacity);
   CHECK(!emptyTitleOnly.defaultMaximize);


### PR DESCRIPTION
## Summary

Added: 
- `match.is_floating`
- `match.is_pinned`
- `match.is_scratchpad`

## Motivation

At the moment, dynamic window rules are quite limited. This makes it easier to specify different types of windows. 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [x] Documentation

## Related Issue

See the feature request [here](https://github.com/noctalia-dev/umbriel/issues/162). Before closing the issue, I would like to discuss a rewrite of `default_size` to take advantage of the new `is_floating` rule (see Additional Notes). 

## Testing

I ran `just format / just lint / just test` and confirmed that all tests still passed. I also ran a nested session to confirm that everything behaved as expected. 

## Manual Coverage

- [x] Tested in a nested Umbriel session
- [ ] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

At the moment, it seems to me that much of the `default_size` / `default_width` / `default_height` behavior is redundant, given that `default_width` applies only to scrolling layout and `default_height` is discarded unless `default_floating = true`. If there are not currently any plans to expand on these settings, I would like to rewrite them as `default_floating_size` and `default_scrolling_width`, which I think would make it much simpler to understand when and how they apply. In my implementation, `default_floating_size` would apply only the first time a window becomes floating, whether that's as a result of `default_floating = true` or user input. Since this would involve breaking changes, I thought I should run it past the team before I get started (I'm also available on discord if preferred). 