### PR TITLE
fix(overview): clamp overshooting progress used as opacity

### DIFF
--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -64,7 +64,8 @@ namespace umbriel {
     // over-bright wash (scene/color.h).
     std::array<float, 4> tint(const std::array<float, 4>& base, double opacity) {
       std::array<float, 4> out{};
-      premultiplied(out.data(), base, static_cast<float>(opacity));
+      // Overshooting curves push the overview progress past [0, 1].
+      premultiplied(out.data(), base, static_cast<float>(std::clamp(opacity, 0.0, 1.0)));
       return out;
     }
     void layoutWorkspaceBackground(
@@ -248,7 +249,8 @@ namespace umbriel {
     }
 
     if (card.badge != nullptr) {
-      const auto badgeAlpha = static_cast<float>(m_progress);
+      // Overshooting curves can push m_progress past [0, 1] and wlr_scene_buffer_set_opacity asserts.
+      const auto badgeAlpha = static_cast<float>(std::clamp(m_progress, 0.0, 1.0));
       const bool matched = card.shortcutMatched != SIZE_MAX;
       const bool fits =
           contentW >= card.badgeWidth + 2 * kBadgeMargin && contentH >= card.badgeHeight + 2 * kBadgeMargin;
@@ -371,7 +373,8 @@ namespace umbriel {
       if (blur->width != metrics.outputBox.width || blur->height != metrics.outputBox.height) {
         wlr_scene_blur_set_size(blur, metrics.outputBox.width, metrics.outputBox.height);
       }
-      const auto level = static_cast<float>(m_progress);
+      // Blur alpha and strength are normalized to [0, 1]; clamp an overshooting progress.
+      const auto level = static_cast<float>(std::clamp(m_progress, 0.0, 1.0));
       if (blur->alpha != level) {
         wlr_scene_blur_set_alpha(blur, level);
       }


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Clamp the overview animation progress to [0, 1] wherever it is used as an
opacity or alpha value. `Overview::applyProgress()` feeds the raw
`m_progress` into `wlr_scene_buffer_set_opacity` (card badge alpha),
`wlr_scene_blur_set_alpha`/`set_strength` (background blur), and `tint()`'s
premultiply, while wlroots asserts opacity is in [0, 1].

<!-- What changed and why? -->

## Motivation


With an overshooting overview animation curve — an underdamped spring such as
`"spring: 0.7,100"`, or `back`/`elastic` — the eased progress overshoots past
1.0, so opening the overview aborts the compositor immediately:
```
umbriel: types/scene/wlr_scene.c:2010: wlr_scene_buffer_set_opacity: Assertion `opacity >= 0 && opacity <= 1' failed.
 +++ killed by SIGABRT (core dumped) +++
```

Every other animated opacity path (`View::effectiveOpacity`, `server.cpp`,
`layer_surface.cpp`) already clamps overshooting animation values; the
overview was the only site missing it. The three call sites clamped here
preserve the overshoot for geometric values (zoom, position) while keeping
the alpha-derived ones inside their valid range.
<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing


`just check` and manual test.
<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

>I am not a native English speaker and use LLM to assist with translation
<!-- Add follow-up notes, reviewer context, or known limitations. -->
