### PR TITLE
fix(input): keep modifier-only binds alive while an input method is active

### DIFF
--- a/docs/user/keybinds.md
+++ b/docs/user/keybinds.md
@@ -41,6 +41,9 @@ left and right key for the logical modifier are accepted, and modifier-only
 binds never repeat. Combinations containing only multiple modifiers, such as
 `Ctrl+Alt`, are invalid.
 
+Physical and virtual keyboards support modifier-only binds. Input-method key
+echoes do not arm or cancel a pending tap.
+
 ## Special keys
 
 **Scroll wheel:** `WheelUp`, `WheelDown`, `WheelLeft`, `WheelRight` (require

--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -261,11 +261,8 @@ namespace umbriel {
       if (!modifierOnly && nsyms > 0) {
         m_server->cursor()->noteTyping();
       }
-      // IME input-method virtual keyboards echo back keys the compositor already
-      // forwarded to them; letting one arm a modifier tap would cancel the pending
-      // physical tap, so modifier-only binds stop firing while an input method is
-      // active. Only physical keys take part in modifier-only binds.
-      if (!m_virtual) {
+      // IME echoes must not cancel the original key's pending tap.
+      if (!m_server->inputMethodRelay()->ownsKeyboard(m_keyboard)) {
         m_server->armModifierTap(
             this, event->keycode, std::span<const uint32_t>(syms, nsyms > 0 ? static_cast<size_t>(nsyms) : 0), modifiers
         );

--- a/src/input/keyboard.cpp
+++ b/src/input/keyboard.cpp
@@ -261,9 +261,15 @@ namespace umbriel {
       if (!modifierOnly && nsyms > 0) {
         m_server->cursor()->noteTyping();
       }
-      m_server->armModifierTap(
-          this, event->keycode, std::span<const uint32_t>(syms, nsyms > 0 ? static_cast<size_t>(nsyms) : 0), modifiers
-      );
+      // IME input-method virtual keyboards echo back keys the compositor already
+      // forwarded to them; letting one arm a modifier tap would cancel the pending
+      // physical tap, so modifier-only binds stop firing while an input method is
+      // active. Only physical keys take part in modifier-only binds.
+      if (!m_virtual) {
+        m_server->armModifierTap(
+            this, event->keycode, std::span<const uint32_t>(syms, nsyms > 0 ? static_cast<size_t>(nsyms) : 0), modifiers
+        );
+      }
       cancelRepeat();
       bool vtSwitched = false;
       for (int i = 0; i < nsyms; ++i) {

--- a/src/input/text_input.cpp
+++ b/src/input/text_input.cpp
@@ -60,15 +60,22 @@ namespace umbriel {
   }
 
   wlr_input_method_keyboard_grab_v2* InputMethodRelay::grabForKeyboard(wlr_keyboard* keyboard) const {
-    if (m_inputMethod == nullptr || m_inputMethod->keyboard_grab == nullptr || keyboard == nullptr) {
-      return nullptr;
-    }
-    wlr_virtual_keyboard_v1* virtualKeyboard = wlr_input_device_get_virtual_keyboard(&keyboard->base);
-    if (virtualKeyboard != nullptr
-        && wl_resource_get_client(virtualKeyboard->resource) == wl_resource_get_client(m_inputMethod->resource)) {
+    if (m_inputMethod == nullptr
+        || m_inputMethod->keyboard_grab == nullptr
+        || keyboard == nullptr
+        || ownsKeyboard(keyboard)) {
       return nullptr;
     }
     return m_inputMethod->keyboard_grab;
+  }
+
+  bool InputMethodRelay::ownsKeyboard(wlr_keyboard* keyboard) const {
+    if (m_inputMethod == nullptr || keyboard == nullptr) {
+      return false;
+    }
+    wlr_virtual_keyboard_v1* virtualKeyboard = wlr_input_device_get_virtual_keyboard(&keyboard->base);
+    return virtualKeyboard != nullptr
+        && wl_resource_get_client(virtualKeyboard->resource) == wl_resource_get_client(m_inputMethod->resource);
   }
 
   void InputMethodRelay::onNewTextInput(wl_listener* listener, void* data) {

--- a/src/input/text_input.h
+++ b/src/input/text_input.h
@@ -31,6 +31,7 @@ namespace umbriel {
     // Returns the grab that should receive this keyboard, or null when there is
     // no grab or this is the input method's own virtual keyboard.
     [[nodiscard]] wlr_input_method_keyboard_grab_v2* grabForKeyboard(wlr_keyboard* keyboard) const;
+    [[nodiscard]] bool ownsKeyboard(wlr_keyboard* keyboard) const;
 
   private:
     struct TextInput {

--- a/tests/harness/checks/520_input_method_wheel.sh
+++ b/tests/harness/checks/520_input_method_wheel.sh
@@ -38,6 +38,8 @@ duration_ms = 1
 
 [keybinds]
 "Mod+WheelDown" = "workspace-next"
+"Alt" = "workspace-next"
+"Super" = "workspace-next"
 EOF
 "$UMBRIEL" msg config-reload > /dev/null
 
@@ -56,6 +58,7 @@ sleep 0.1
 POINTER_PID=$!
 sleep 0.1
 "$INPUT_METHOD" > "$INPUT_METHOD_LOG" 2>&1 &
+INPUT_METHOD_PID=$!
 
 for _ in $(seq 40); do
   grep -qx 'grabbed' "$INPUT_METHOD_LOG" 2>/dev/null && break
@@ -88,4 +91,52 @@ if grep -q '^key 30 1$' "$FIRST_LOG" 2>/dev/null; then
   exit 1
 fi
 
-echo "input-method grabs preserve modifier wheel bindings and keyboard focus"
+# Observe the IME echo while Super is held, then verify the release action.
+"$UMBRIEL" msg workspace-switch:1 > /dev/null
+"$POINTER" "$OUTPUT_W" "$OUTPUT_H" key-press 125 pause 1000 key-release 125 > "$POINTER_LOG" 2>&1 &
+POINTER_PID=$!
+for _ in $(seq 40); do
+  grep -q '^key 125 1$' "$FIRST_LOG" 2>/dev/null && break
+  sleep 0.01
+done
+if ! grep -q '^key 125 1$' "$FIRST_LOG" || [[ $(active_title) != input-first ]]; then
+  echo "expected the IME's Super press echo on workspace 1 before releasing the modifier"
+  exit 1
+fi
+wait "$POINTER_PID"
+if [[ $(active_title) != input-second ]]; then
+  echo "IME echo cancelled the modifier tap instead of switching to workspace 2 on release"
+  exit 1
+fi
+
+# An unrelated virtual keyboard's key press still cancels a held modifier tap.
+"$UMBRIEL" msg workspace-switch:1 > /dev/null
+presses_before=$(grep -c '^key 56 1$' "$FIRST_LOG" || true)
+"$POINTER" "$OUTPUT_W" "$OUTPUT_H" key-press 56 pause 1000 key-release 56 > "$POINTER_LOG" 2>&1 &
+POINTER_PID=$!
+for _ in $(seq 40); do
+  [[ $(grep -c '^key 56 1$' "$FIRST_LOG" || true) -gt $presses_before ]] && break
+  sleep 0.01
+done
+if [[ $(grep -c '^key 56 1$' "$FIRST_LOG" || true) -le $presses_before ]]; then
+  echo "input method did not echo the held Alt key"
+  exit 1
+fi
+# Keep this keyboard alive past the release so its destruction cannot cancel the tap.
+"$POINTER" "$OUTPUT_W" "$OUTPUT_H" tap 30 pause 1200
+wait "$POINTER_PID"
+if [[ $(active_title) != input-first ]]; then
+  echo "an unrelated virtual keyboard's key press failed to cancel the modifier tap"
+  exit 1
+fi
+
+kill "$INPUT_METHOD_PID"
+wait "$INPUT_METHOD_PID" || true
+"$POINTER" "$OUTPUT_W" "$OUTPUT_H" tap 56
+if [[ $(active_title) != input-second ]]; then
+  echo "virtual keyboard modifier tap did not switch to workspace 2 without an input method"
+  exit 1
+fi
+"$UMBRIEL" msg workspace-switch:1 > /dev/null
+
+echo "input-method grabs preserve modifier wheel bindings, taps, cancellation, and keyboard focus"

--- a/tests/harness/clients/pointer_client.cpp
+++ b/tests/harness/clients/pointer_client.cpp
@@ -186,8 +186,9 @@ int main(int argc, char** argv) {
   }
 
   const std::vector<std::string> args(argv + 3, argv + argc);
-  const bool needsKeyboard =
-      std::ranges::find(args, "mod") != args.end() || std::ranges::find(args, "tap") != args.end();
+  const bool needsKeyboard = std::ranges::any_of(args, [](const std::string& command) {
+    return command == "mod" || command == "tap" || command == "key-press" || command == "key-release";
+  });
   VirtualKeyboard keyboard;
   if (needsKeyboard && !initializeKeyboard(keyboard, state, display)) {
     return EXIT_FAILURE;
@@ -234,14 +235,20 @@ int main(int argc, char** argv) {
       const uint32_t depressed = modifierMask(keyboard, args[i + 1]);
       i += 1;
       zwp_virtual_keyboard_v1_modifiers(keyboard.protocol, depressed, 0, 0, 0);
-    } else if (command == "tap") {
+    } else if (command == "tap" || command == "key-press" || command == "key-release") {
       needs(1);
       const auto key = static_cast<uint32_t>(std::atoi(args[i + 1].c_str()));
       i += 1;
-      zwp_virtual_keyboard_v1_key(keyboard.protocol, nextTime(), key, WL_KEYBOARD_KEY_STATE_PRESSED);
-      zwlr_virtual_pointer_v1_frame(pointer);
-      wl_display_roundtrip(display);
-      zwp_virtual_keyboard_v1_key(keyboard.protocol, nextTime(), key, WL_KEYBOARD_KEY_STATE_RELEASED);
+      if (command != "key-release") {
+        zwp_virtual_keyboard_v1_key(keyboard.protocol, nextTime(), key, WL_KEYBOARD_KEY_STATE_PRESSED);
+      }
+      if (command == "tap") {
+        zwlr_virtual_pointer_v1_frame(pointer);
+        wl_display_roundtrip(display);
+      }
+      if (command != "key-press") {
+        zwp_virtual_keyboard_v1_key(keyboard.protocol, nextTime(), key, WL_KEYBOARD_KEY_STATE_RELEASED);
+      }
     } else if (command == "pause") {
       needs(1);
       const auto duration = std::chrono::milliseconds(std::atoi(args[i + 1].c_str()));


### PR DESCRIPTION

<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

Only let physical keyboards arm modifier taps; virtual-keyboard echoes no longer cancel them.
<!-- What changed and why? -->

## Motivation

An input method grabs the physical keyboard and echoes each forwarded key back through its own virtual keyboard. Every key press cancels the pending modifier tap (armModifierTap starts with cancelForKeyPress), so the virtual echo of a held modifier cancels the physical tap and the modifier-only bind never fires on release. Combination binds are unaffected because they match on press.
<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

Closes #139
<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just check` and manual test

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

> I am a non-native English speaker and used an LLM for translation
<!-- Add follow-up notes, reviewer context, or known limitations. -->
