### PR TITLE
fix(session): use env var instead of argv for login re-entry marker

### DIFF
--- a/data/start-umbriel.in
+++ b/data/start-umbriel.in
@@ -11,9 +11,9 @@ if [ -n "${MANAGERPID:-}" ] && [ "${SYSTEMD_EXEC_PID:-}" = "$$" ]; then
 fi
 
 login_reentry=false
-if [ "${1:-}" = "__umbriel_login_shell" ]; then
+if [ "${UMBRIEL_LOGIN_REENTRY:-}" = 1 ]; then
   login_reentry=true
-  shift
+  unset UMBRIEL_LOGIN_REENTRY
   unset WAYLAND_DISPLAY WAYLAND_SOCKET DISPLAY UMBRIEL_SOCKET \
     XDG_CURRENT_DESKTOP XDG_SESSION_DESKTOP XDG_SESSION_TYPE
 fi
@@ -50,10 +50,10 @@ if [ "$login_reentry" = false ]; then
   # shell once so its noninteractive login profile can extend the environment.
   case "$login_shell_kind" in
     fish)
-      exec "$SHELL" -l -c 'exec $argv' "$0" __umbriel_login_shell "$@"
+      UMBRIEL_LOGIN_REENTRY=1 exec "$SHELL" -l -c 'exec $argv' "$0" "$@"
       ;;
     bourne)
-      exec "$SHELL" -l -c 'exec "$@"' "$SHELL" "$0" __umbriel_login_shell "$@"
+      UMBRIEL_LOGIN_REENTRY=1 exec "$SHELL" -l -c 'exec "$@"' "$SHELL" "$0" "$@"
       ;;
   esac
 fi


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary

<!-- What changed and why? -->
Use an exported `UMBRIEL_LOGIN_REENTRY` environment variable instead of a positional argument to detect login re-entry, since it survives an exec performed by the user's own login profile.

## Motivation

<!-- What problem does this solve? -->
Launching `start-umbriel` from `~/.bash_profile` causes it to infinitely try to re-launch itself.

## Type of Change

<!-- Mark all that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [ ] Tested with a scaled output
- [ ] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [ ] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

<!-- Add follow-up notes, reviewer context, or known limitations. -->
