### PR TITLE
feat(overview): step window focus with the cross-axis three-finger swipe

### DIFF
--- a/src/input/gestures.cpp
+++ b/src/input/gestures.cpp
@@ -165,6 +165,7 @@ namespace umbriel {
       m_state = State::Idle;
       break;
     case State::OverviewSelect:
+    case State::OverviewSelectWindow:
     case State::Pending:
     case State::Idle:
       m_state = State::Idle;
@@ -257,6 +258,7 @@ namespace umbriel {
       break;
     case State::Forward:
     case State::OverviewSelect:
+    case State::OverviewSelectWindow:
     case State::Pending:
     case State::Idle:
       m_state = State::Idle;
@@ -346,16 +348,11 @@ namespace umbriel {
       const bool alongWorkspaceAxis = horizontalTravel == (m_workspaceAxis == WorkspaceAxis::Horizontal);
 
       if (Overview* overview = m_server->overview(); overview != nullptr && overview->interactive()) {
-        // Perpendicular travel has no meaning over the filmstrip, and letting it
-        // through would step workspaces on any swipe that drifted off true.
-        if (!alongWorkspaceAxis) {
-          m_state = State::Idle;
-          return;
-        }
-        // Start measuring workspace travel from the lock point, not the touch down.
         m_accumX = 0;
         m_accumY = 0;
-        m_state = State::OverviewSelect;
+        // Along the axis steps workspaces; across it steps window focus, mirroring
+        // the arrow-key navigation and the non-overview cross-axis strip gesture.
+        m_state = alongWorkspaceAxis ? State::OverviewSelect : State::OverviewSelectWindow;
         return;
       }
 
@@ -452,6 +449,28 @@ namespace umbriel {
       return;
     }
 
+    case State::OverviewSelectWindow: {
+      Overview* overview = m_server->overview();
+      if (overview == nullptr || !overview->interactive()) {
+        m_state = State::Idle;
+        return;
+      }
+      const bool horizontal = m_workspaceAxis == WorkspaceAxis::Horizontal;
+      double& accum = horizontal ? m_accumY : m_accumX;
+      accum += horizontal ? event->dy : event->dx;
+      // Same sense as the strip gesture outside the overview: swiping toward the
+      // negative axis direction steps focus forward (right/down).
+      while (accum <= -kOverviewStepPx) {
+        accum += kOverviewStepPx;
+        overview->stepWindow(m_naturalScrollDirection);
+      }
+      while (accum >= kOverviewStepPx) {
+        accum -= kOverviewStepPx;
+        overview->stepWindow(-m_naturalScrollDirection);
+      }
+      return;
+    }
+
     case State::Overview: {
       Overview* overview = m_server->overview();
       if (overview == nullptr) {
@@ -498,6 +517,7 @@ namespace umbriel {
     case State::Pending:
     // Each row step was committed as it happened; there is nothing to settle.
     case State::OverviewSelect:
+    case State::OverviewSelectWindow:
       m_state = State::Idle;
       return;
 

--- a/src/input/gestures.h
+++ b/src/input/gestures.h
@@ -33,7 +33,7 @@ namespace umbriel {
     void endPointerScroll(bool cancelled, uint32_t timeMsec);
 
   private:
-    enum class State { Idle, Forward, Pending, Scroll, Switch, Overview, OverviewSelect };
+    enum class State { Idle, Forward, Pending, Scroll, Switch, Overview, OverviewSelect, OverviewSelectWindow };
     enum class ScrollSource { None, Swipe, Pointer };
 
     static void onSwipeBegin(wl_listener* listener, void* data);
@@ -95,6 +95,8 @@ namespace umbriel {
 
     // OverviewSelect state (three-finger along the workspace axis, overview up)
     // reuses the axis accumulator as the travel left over since the last step.
+    // OverviewSelectWindow state (three-finger across the workspace axis, overview
+    // up) steps window focus through Overview::stepWindow instead of discarding it.
 
     wl_listener m_swipeBegin{};
     wl_listener m_swipeUpdate{};

--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -2348,6 +2348,28 @@ namespace umbriel {
     return true;
   }
 
+  void Overview::stepWindow(int sign) {
+    Workspace* workspace = preferredWorkspace();
+    if (workspace == nullptr || workspace->group() == nullptr) {
+      return;
+    }
+    // Mirror the non-overview cross-axis gesture, which only scrolls the strip in
+    // the scrolling layout: dwindle and master have no strip, so the overview
+    // cross-axis swipe is inert there too.
+    if (workspace->scrollingLayout() == nullptr) {
+      return;
+    }
+    // Cross-axis navigation runs perpendicular to the filmstrip: on a vertical
+    // workspace axis that is left/right, on a horizontal axis it is up/down.
+    const bool horizontalAxis = workspace->group()->workspaceAxis() == WorkspaceAxis::Horizontal;
+    const KeybindAction action = horizontalAxis
+        ? (sign < 0 ? KeybindAction::WindowFocusUp : KeybindAction::WindowFocusDown)
+        : (sign < 0 ? KeybindAction::WindowFocusLeft : KeybindAction::WindowFocusRight);
+    Keybind bind;
+    bind.action = action;
+    m_server->executeKeybindAction(bind);
+  }
+
   void Overview::refreshShortcutMatches() {
     for (const auto& state : m_outputs) {
       for (const auto& card : state->cards) {

--- a/src/overview/overview.h
+++ b/src/overview/overview.h
@@ -104,6 +104,9 @@ namespace umbriel {
     // overview is up the real trees are hidden, so there is nothing to slide and switching is a discrete step rather
     // than the animated transition it is outside.
     bool selectRelativeWorkspace(int delta, Output* output);
+    // Step window focus across the workspace axis (perpendicular to the filmstrip), matching the arrow-key
+    // navigation: sign < 0 steps left/up, sign > 0 steps right/down. Used by the three-finger cross-axis swipe.
+    void stepWindow(int sign);
     [[nodiscard]] bool dragging() const { return m_dragCard != nullptr || m_middlePressed; }
 
   private:


### PR DESCRIPTION
<!-- A bot checks this description and converts the pull request back to a draft if
     required structure is missing. It never closes the pull request.

     Required: the Summary, Motivation, Type of Change, Testing, and Checklist
     headings, and the Checklist wording below. Before marking a pull request ready for
     review, select at least one change type and check every Checklist item.

     Everything else may be deleted, including these guidance comments and any of the
     Related Issue, Manual Coverage, Screenshots / Videos, and Additional Notes sections.
     In Type of Change, keep only the lines that apply.

     An explanation does not replace a required check. If a required statement is not
     true yet, keep the pull request as Draft. -->

## Summary


The overview's three-finger swipe previously only stepped workspaces alongthe workspace axis and dropped perpendicular travel.
This routes the cross-axis swipe to window focus instead (`Overview::stepWindow`),
mirroring the arrow-key navigation: along the axis steps workspaces, across it steps windows.

As with the non-overview cross-axis strip gesture, this only applies in the scrolling layout — dwindle and master have no strip, so the swipe stays inert there.
<!-- What changed and why? -->

## Motivation

Arrow keys, the cross-axis strip gesture, and the overview three-finger swipe were inconsistent. Outside the overview a vertical-axis cross swipe scrolls the strip and focuses the neighboring column, and inside the overview the left/right arrow keys navigate windows — but the cross-axis swipe did nothing. This closes that gap and gives the overview the same up/down = workspace, left/right = window muscle memory the rest of the compositor already has.
<!-- What problem does this solve? -->

## Type of Change

<!-- Mark all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

.
<!-- Example: Closes #123 -->

## Testing

<!-- List commands run and any manual testing. If not run, say why. -->
`just test`, `just check`, and manual test:
-  scrolling layout: overview cross-axis swipe steps window focus;
- dwindle and master: overview cross-axis swipe stays inert (matching the
    non-overview gesture);
- along-axis swipe still steps workspaces;
- arrow-key navigation and the non-overview three-finger gestures unchanged.

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [x] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [ ] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [ ] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [x] Tested with the dwindle layout

## Screenshots / Videos

.
<!-- Include screenshots or videos for visual, animation, or layout changes. -->

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

> I am not a native English speaker, and I used an LLM to assist with the translation.
<!-- Add follow-up notes, reviewer context, or known limitations. -->
