### PR TITLE
fix(input): release pointer after client-initiated window move (fix mouse controls getting stuck after drag)

### DIFF
--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -960,6 +960,10 @@ namespace umbriel {
 
     if (state == WL_POINTER_BUTTON_STATE_RELEASED) {
       if (auto* grab = std::get_if<MoveGrab>(&m_grab)) {
+        wlr_seat* seat = m_server->seat()->wlr();
+        if (seat->pointer_state.button_count > 0) {
+          wlr_seat_pointer_notify_button(seat, timeMsec, button, state);
+        }
         if (grab->pending) {
           resetMode();
         } else {

--- a/tests/harness/checks/528_client_move_key_release.sh
+++ b/tests/harness/checks/528_client_move_key_release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# A client-side titlebar receives the initiating press before asking the
+# compositor for an xdg-toplevel move. Finishing that move must return the
+# matching release to the client and clear the seat's implicit pointer grab.
+set -euo pipefail
+
+readonly OUTPUT_W=1280
+readonly OUTPUT_H=720
+readonly LEFT_BUTTON=272
+readonly KEY_A=30
+readonly POINTER="${UMBRIEL_POINTER_CLIENT:-./build-debug/tests/pointer-client}"
+readonly OBSERVER="${UMBRIEL_SEAT_LOG_CLIENT:-./build-debug/tests/seat-log-client}"
+readonly LOG="$UMBRIEL_RUNTIME_DIR/client-move-key-release.log"
+
+if [[ ! -x $POINTER || ! -x $OBSERVER ]]; then
+  echo "input helpers are not available"
+  exit 1
+fi
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[animation]
+duration_ms = 1
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+"$OBSERVER" client-move-key-release --request-move > "$LOG" 2>&1 &
+window=''
+for _ in $(seq 60); do
+  window=$("$UMBRIEL" windows --json | jq -c '.[] | select(.title == "client-move-key-release")')
+  [[ -n $window ]] && break
+  sleep 0.1
+done
+if [[ -z $window ]]; then
+  echo "client-move window never appeared"
+  exit 1
+fi
+sleep 0.4
+window=$("$UMBRIEL" windows --json | jq -c '.[] | select(.title == "client-move-key-release")')
+x=$(jq -r '(.x + .w / 2 | round)' <<< "$window")
+y=$(jq -r '(.y + .h / 2 | round)' <<< "$window")
+
+# Press on the client decoration surrogate, move far enough to commit the
+# compositor drag, type during it, then release. A second click proves that the
+# first release cleared the seat instead of leaving its button count stuck.
+"$POINTER" "$OUTPUT_W" "$OUTPUT_H" \
+  move "$x" "$y" pause 300 press "$LEFT_BUTTON" \
+  move "$((x + 80))" "$((y + 40))" tap "$KEY_A" \
+  move "$((x + 120))" "$((y + 60))" release "$LEFT_BUTTON" \
+  pause 100 click "$LEFT_BUTTON"
+
+for _ in $(seq 30); do
+  (( $(grep -c "pointer-button code=$LEFT_BUTTON state=released" "$LOG" || true) >= 2 )) && break
+  sleep 0.1
+done
+
+presses=$(grep -c "pointer-button code=$LEFT_BUTTON state=pressed" "$LOG" || true)
+releases=$(grep -c "pointer-button code=$LEFT_BUTTON state=released" "$LOG" || true)
+if ((presses != 2 || releases != 2)); then
+  echo "client move stranded pointer state: presses=$presses releases=$releases"
+  echo "log: $(tr '\n' '|' < "$LOG")"
+  exit 1
+fi
+
+echo "a client-initiated window move forwards its release after typing"

--- a/tests/harness/clients/seat_log_client.cpp
+++ b/tests/harness/clients/seat_log_client.cpp
@@ -36,6 +36,7 @@ namespace {
     int height = 480;
     // A configure asked for a size the current buffer does not have.
     bool resizePending = true;
+    bool requestMove = false;
   };
 
   const char* keyStateName(uint32_t value) { return value == WL_KEYBOARD_KEY_STATE_PRESSED ? "pressed" : "released"; }
@@ -84,8 +85,12 @@ namespace {
   // checks parse.
   void pointerMotion(void*, wl_pointer*, uint32_t, wl_fixed_t, wl_fixed_t) {}
 
-  void pointerButton(void*, wl_pointer*, uint32_t, uint32_t, uint32_t button, uint32_t buttonState) {
+  void pointerButton(void* data, wl_pointer*, uint32_t serial, uint32_t, uint32_t button, uint32_t buttonState) {
+    auto& state = *static_cast<State*>(data);
     std::println("pointer-button code={} state={}", button, buttonStateName(buttonState));
+    if (state.requestMove && button == 272 && buttonState == WL_POINTER_BUTTON_STATE_PRESSED) {
+      xdg_toplevel_move(state.toplevel, state.seat, serial);
+    }
   }
 
   void pointerAxis(void*, wl_pointer*, uint32_t, uint32_t, wl_fixed_t) {}
@@ -244,6 +249,7 @@ int main(int argc, char** argv) {
   const char* title = argc > 1 ? argv[1] : "seat-log-client";
 
   State state;
+  state.requestMove = argc > 2 && std::strcmp(argv[2], "--request-move") == 0;
   state.display = wl_display_connect(nullptr);
   if (state.display == nullptr) {
     std::println(stderr, "seat-log-client: cannot connect to a Wayland display");


### PR DESCRIPTION
## Summary

Forward the pointer button release after a client-initiated window move, preventing the seat’s pointer state from remaining stuck. Added a regression test that performs a client-side titlebar move, types during the drag, releases the button, and verifies subsequent clicks still work.

## Motivation

Client-side titlebar drags use xdg_toplevel.move after the client receives the initial button press. Umbriel previously consumed the matching release when finishing the move, leaving the button registered as held and locking subsequent mouse input.

## Type of Change

<!-- Mark all that apply. -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

Properly closes #191 

## Testing

 - just check 526 528 -v
 - just test
 - git diff --check

## Manual Coverage

<!-- Mark what applies to this PR. -->

- [X] Tested in a native Umbriel session
- [X] Tested with a scaled output
- [X] Tested with native Wayland applications
- [X] Tested with X11 applications through xwayland-satellite
- [X] Tested with the scrolling layout

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [X] This PR is ready for review, or it is marked as Draft.
- [X] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [X] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [X] I ran `just format`, or this PR has no C++ changes.
- [X] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [X] I functionally verified compositor behavior where automated checks are insufficient.
- [X] I self-reviewed the changes.
- [X] I checked for new warnings or errors.
- [X] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [X] I used canonical names for config keys, IPC actions, paths, and identifiers.
