### PR TITLE
feat(view): center dialogs over their parent and support xdg-foreign

### DIFF
--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -313,8 +313,9 @@ Parented XDG dialogs are stacked with their ancestor chain. Raising any member
 raises the family while keeping each dialog above its parent, including when an
 ancestor is floating, pinned, or fullscreen. A dialog without a
 `default_position` rule opens centered over the visible part of its parent,
-kept inside the usable area; a parent scrolled out of view leaves it centered
-on the area.
+kept inside the usable area: over the output for a fullscreen parent and over
+the usable area for one maximized to edges. A parent scrolled out of view leaves
+it centered on the area.
 
 ### Maximize and fullscreen
 

--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -311,7 +311,9 @@ fullscreen.
 
 Parented XDG dialogs are stacked with their ancestor chain. Raising any member
 raises the family while keeping each dialog above its parent, including when an
-ancestor is floating, pinned, or fullscreen.
+ancestor is floating, pinned, or fullscreen. A dialog without a
+`default_position` rule opens centered over its parent, kept inside the usable
+area.
 
 ### Maximize and fullscreen
 

--- a/docs/user/layout.md
+++ b/docs/user/layout.md
@@ -312,8 +312,9 @@ fullscreen.
 Parented XDG dialogs are stacked with their ancestor chain. Raising any member
 raises the family while keeping each dialog above its parent, including when an
 ancestor is floating, pinned, or fullscreen. A dialog without a
-`default_position` rule opens centered over its parent, kept inside the usable
-area.
+`default_position` rule opens centered over the visible part of its parent,
+kept inside the usable area; a parent scrolled out of view leaves it centered
+on the area.
 
 ### Maximize and fullscreen
 

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -32,6 +32,11 @@ hidden from restricted clients until it has received a security review.
 Trusted host services such as xdg-desktop-portal can mediate capture and other
 privileged operations for a sandboxed application.
 
+Restricted clients receive the xdg-foreign exporter but not the importer. A
+sandboxed application can export one of its windows and hand the handle to a
+portal, which imports it to parent its dialog. Parenting a window to another
+client's window stays with unrestricted processes.
+
 ## Per-application grants
 
 Some protocols have no portal equivalent. A status bar needs layer-shell, a

--- a/meson.build
+++ b/meson.build
@@ -253,6 +253,19 @@ xdg_toplevel_tag_client_c = custom_target(
   command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
 )
 
+xdg_foreign_client_h = custom_target(
+  'xdg-foreign-unstable-v2-client-protocol.h',
+  input: wayland_protocols_dep.get_variable(pkgconfig: 'pkgdatadir') / 'unstable/xdg-foreign/xdg-foreign-unstable-v2.xml',
+  output: 'xdg-foreign-unstable-v2-client-protocol.h',
+  command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+)
+xdg_foreign_client_c = custom_target(
+  'xdg-foreign-unstable-v2-client-protocol.c',
+  input: wayland_protocols_dep.get_variable(pkgconfig: 'pkgdatadir') / 'unstable/xdg-foreign/xdg-foreign-unstable-v2.xml',
+  output: 'xdg-foreign-unstable-v2-client-protocol.c',
+  command: [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+)
+
 content_type_client_h = custom_target(
   'content-type-v1-client-protocol.h',
   input: wayland_protocols_dep.get_variable(pkgconfig: 'pkgdatadir') / 'staging/content-type/content-type-v1.xml',

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -454,7 +454,13 @@ namespace umbriel {
     m_newXdgPopup.notify = onNewXdgPopup;
     wl_signal_add(&m_xdgShell->events.new_popup, &m_newXdgPopup);
 
-    wlr_xdg_foreign_v2_create(m_display, wlr_xdg_foreign_registry_create(m_display));
+    wlr_xdg_foreign_registry* foreignRegistry = wlr_xdg_foreign_registry_create(m_display);
+    if (foreignRegistry == nullptr) {
+      throw std::runtime_error("failed to create xdg-foreign registry");
+    }
+    if (wlr_xdg_foreign_v2_create(m_display, foreignRegistry) == nullptr) {
+      throw std::runtime_error("failed to create xdg-foreign global");
+    }
 
     m_xdgToplevelTagManager = wlr_xdg_toplevel_tag_manager_v1_create(m_display, 1);
     if (m_xdgToplevelTagManager == nullptr) {

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -51,7 +51,7 @@ namespace umbriel {
     // Security-context clients only receive reviewed, ordinary application
     // protocols. New globals stay unavailable until they are classified here.
     // [[security_context_rule]] widens the set for matching clients.
-    constexpr std::array<std::string_view, 28> kAllowedSecurityContextGlobals{
+    constexpr std::array<std::string_view, 29> kAllowedSecurityContextGlobals{
         "wl_shm",
         "wl_drm",
         "zwp_linux_dmabuf_v1",
@@ -69,6 +69,7 @@ namespace umbriel {
         "wp_color_manager_v1",
         "xdg_wm_base",
         "xdg_toplevel_tag_manager_v1",
+        "zxdg_exporter_v2",
         "zxdg_decoration_manager_v1",
         "org_kde_kwin_server_decoration_manager",
         "zwp_relative_pointer_manager_v1",
@@ -452,6 +453,8 @@ namespace umbriel {
     wl_signal_add(&m_xdgShell->events.new_toplevel, &m_newXdgToplevel);
     m_newXdgPopup.notify = onNewXdgPopup;
     wl_signal_add(&m_xdgShell->events.new_popup, &m_newXdgPopup);
+
+    wlr_xdg_foreign_v2_create(m_display, wlr_xdg_foreign_registry_create(m_display));
 
     m_xdgToplevelTagManager = wlr_xdg_toplevel_tag_manager_v1_create(m_display, 1);
     if (m_xdgToplevelTagManager == nullptr) {

--- a/src/view/floating.h
+++ b/src/view/floating.h
@@ -73,6 +73,22 @@ namespace umbriel {
     };
   }
 
+  // Center a window of the given size over what shows of `box` inside `usable`, kept fully inside `usable` when it
+  // fits. A box entirely out of view centers the window on `usable` instead.
+  [[nodiscard]] constexpr FloatingPoint
+  centeredOverShown(const wlr_box& box, const wlr_box& usable, int width, int height) {
+    const auto clamp = [](int value, int low, int high) { return value < low ? low : (value > high ? high : value); };
+    const int left = box.x > usable.x ? box.x : usable.x;
+    const int top = box.y > usable.y ? box.y : usable.y;
+    const int right = box.x + box.width < usable.x + usable.width ? box.x + box.width : usable.x + usable.width;
+    const int bottom = box.y + box.height < usable.y + usable.height ? box.y + box.height : usable.y + usable.height;
+    const wlr_box shown{.x = left, .y = top, .width = right - left, .height = bottom - top};
+    FloatingPoint origin = centeredOrigin(shown.width > 0 && shown.height > 0 ? shown : usable, width, height);
+    origin.x = clamp(origin.x, usable.x, usable.x + (usable.width > width ? usable.width - width : 0));
+    origin.y = clamp(origin.y, usable.y, usable.y + (usable.height > height ? usable.height - height : 0));
+    return origin;
+  }
+
   // Pixel length of `fraction` of the usable area on one axis. Rounds like
   // Layout::fractionalWidth so a float and a tiled lane at the same fraction do
   // not disagree by a pixel on an odd axis. A degenerate axis yields 0, which

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1428,6 +1428,14 @@ namespace umbriel {
     return true;
   }
 
+  wlr_box View::targetBox() const {
+    if (m_workspace != nullptr && m_workspace->layout().columnOf(this) >= 0) {
+      return m_workspace->layout().targetBox(this);
+    }
+    const wlr_box& geometry = m_toplevel->base->geometry;
+    return {layoutTargetX(), layoutTargetY(), geometry.width, geometry.height};
+  }
+
   void View::placeInUsableArea(const std::optional<WindowPosition>& position) {
     const wlr_box usable = floatingUsableArea();
     if (usable.width <= 0 || usable.height <= 0) {
@@ -1476,12 +1484,8 @@ namespace umbriel {
       origin = clampFloatingOrigin(origin, {.x = 0, .y = 0, .width = width, .height = height}, usable);
       m_floating.rememberPositionFraction(origin, usable);
     } else if (const View* parent = transientParent()) {
-      // Dialogs open over their parent, kept fully inside the usable area when they fit.
-      const wlr_scene_node& node = parent->m_sceneTree->node;
-      const wlr_box& presented = parent->m_presentedBox;
-      origin = centeredOrigin({node.x, node.y, presented.width, presented.height}, width, height);
-      origin.x = std::clamp(origin.x, usable.x, std::max(usable.x, usable.x + usable.width - width));
-      origin.y = std::clamp(origin.y, usable.y, std::max(usable.y, usable.y + usable.height - height));
+      // Where the parent is headed, not where its node is mid-animation right after it mapped.
+      origin = centeredOverShown(parent->targetBox(), usable, width, height);
     }
     setPosition(origin.x, origin.y);
   }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1475,6 +1475,13 @@ namespace umbriel {
       }
       origin = clampFloatingOrigin(origin, {.x = 0, .y = 0, .width = width, .height = height}, usable);
       m_floating.rememberPositionFraction(origin, usable);
+    } else if (const View* parent = transientParent()) {
+      // Dialogs open over their parent, kept fully inside the usable area when they fit.
+      const wlr_scene_node& node = parent->m_sceneTree->node;
+      const wlr_box& presented = parent->m_presentedBox;
+      origin = centeredOrigin({node.x, node.y, presented.width, presented.height}, width, height);
+      origin.x = std::clamp(origin.x, usable.x, std::max(usable.x, usable.x + usable.width - width));
+      origin.y = std::clamp(origin.y, usable.y, std::max(usable.y, usable.y + usable.height - height));
     }
     setPosition(origin.x, origin.y);
   }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1456,8 +1456,11 @@ namespace umbriel {
     if (inLayout) {
       return m_workspace->presentedTiledBox(this);
     }
+    // A float's scheduled size is the one a maximize or resize is taking it to, and the client's own once it settled.
     const wlr_box& geometry = m_toplevel->base->geometry;
-    return {layoutTargetX(), layoutTargetY(), geometry.width, geometry.height};
+    const int width = m_toplevel->scheduled.width > 0 ? m_toplevel->scheduled.width : geometry.width;
+    const int height = m_toplevel->scheduled.height > 0 ? m_toplevel->scheduled.height : geometry.height;
+    return {layoutTargetX(), layoutTargetY(), width, height};
   }
 
   void View::placeInUsableArea(const std::optional<WindowPosition>& position) {

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1428,9 +1428,33 @@ namespace umbriel {
     return true;
   }
 
+  wlr_box View::fullscreenArea() const {
+    Output* output = nullptr;
+    if (m_workspace != nullptr && m_workspace->group() != nullptr) {
+      output = m_workspace->group()->output();
+    }
+    if (output == nullptr) {
+      output = currentOutput();
+    }
+    wlr_output* wlrOutput = output != nullptr ? output->wlr() : m_server->preferredOutput();
+    wlr_box fullArea{};
+    wlr_output_layout_get_box(m_server->outputLayout(), wlrOutput, &fullArea);
+    return fullArea;
+  }
+
   wlr_box View::targetBox() const {
-    if (m_workspace != nullptr && m_workspace->layout().columnOf(this) >= 0) {
-      return m_workspace->layout().targetBox(this);
+    // A window that mapped in this same dispatch has its arrange still pending, so its slot is missing or stale.
+    const bool inLayout = m_workspace != nullptr && m_workspace->layout().columnOf(this) >= 0;
+    if (inLayout) {
+      m_workspace->flushArrange();
+    }
+    if (m_toplevel->scheduled.fullscreen) {
+      // Fullscreen takes the output's size; the strip still places a tiled one at its column.
+      const wlr_box area = fullscreenArea();
+      return {layoutTargetX(), layoutTargetY(), area.width, area.height};
+    }
+    if (inLayout) {
+      return m_workspace->presentedTiledBox(this);
     }
     const wlr_box& geometry = m_toplevel->base->geometry;
     return {layoutTargetX(), layoutTargetY(), geometry.width, geometry.height};
@@ -1484,8 +1508,10 @@ namespace umbriel {
       origin = clampFloatingOrigin(origin, {.x = 0, .y = 0, .width = width, .height = height}, usable);
       m_floating.rememberPositionFraction(origin, usable);
     } else if (const View* parent = transientParent()) {
-      // Where the parent is headed, not where its node is mid-animation right after it mapped.
-      origin = centeredOverShown(parent->targetBox(), usable, width, height);
+      // Where the parent is headed, not where its node is mid-animation right after it mapped. A fullscreen parent
+      // shows over any panel, so the whole output counts as visible for it.
+      const wlr_box shownIn = parent->m_toplevel->scheduled.fullscreen ? parent->fullscreenArea() : usable;
+      origin = centeredOverShown(parent->targetBox(), shownIn, width, height);
     }
     setPosition(origin.x, origin.y);
   }
@@ -2047,16 +2073,7 @@ namespace umbriel {
   }
 
   void View::applyFullscreenLayout(bool animate) {
-    Output* output = nullptr;
-    if (m_workspace != nullptr && m_workspace->group() != nullptr) {
-      output = m_workspace->group()->output();
-    }
-    if (output == nullptr) {
-      output = currentOutput();
-    }
-    wlr_output* wlrOutput = output != nullptr ? output->wlr() : m_server->preferredOutput();
-    wlr_box fullArea{};
-    wlr_output_layout_get_box(m_server->outputLayout(), wlrOutput, &fullArea);
+    const wlr_box fullArea = fullscreenArea();
     if (fullArea.width <= 0 || fullArea.height <= 0) {
       return;
     }

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -157,6 +157,9 @@ namespace umbriel {
     // listings that order by position must read these instead.
     [[nodiscard]] int layoutTargetX() const { return static_cast<int>(std::lround(m_posX.target())); }
     [[nodiscard]] int layoutTargetY() const { return static_cast<int>(std::lround(m_posY.target())); }
+    // The box this window is headed for: its layout slot when tiled, else its own position at its committed size.
+    // Valid ahead of the animation that carries the node there.
+    [[nodiscard]] wlr_box targetBox() const;
     // Move the scene nodes without touching the position animation: an
     // interactive drag tracks the pointer 1:1 and owns the position itself.
     void setDragPosition(int x, int y);

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -158,8 +158,8 @@ namespace umbriel {
     [[nodiscard]] int layoutTargetX() const { return static_cast<int>(std::lround(m_posX.target())); }
     [[nodiscard]] int layoutTargetY() const { return static_cast<int>(std::lround(m_posY.target())); }
     // The box this window is headed for: the output when fullscreen, its presented slot when tiled, which is the usable
-    // area when maximized to edges, else its own position at its committed size. Valid ahead of the animation that
-    // carries the node there, and settles a pending arrange to get there.
+    // area when maximized to edges, else its own position at the size it is resizing to. Valid ahead of the animation
+    // that carries the node there and of the client's resize, and settles a pending arrange to get there.
     [[nodiscard]] wlr_box targetBox() const;
     // Move the scene nodes without touching the position animation: an
     // interactive drag tracks the pointer 1:1 and owns the position itself.

--- a/src/view/view.h
+++ b/src/view/view.h
@@ -157,8 +157,9 @@ namespace umbriel {
     // listings that order by position must read these instead.
     [[nodiscard]] int layoutTargetX() const { return static_cast<int>(std::lround(m_posX.target())); }
     [[nodiscard]] int layoutTargetY() const { return static_cast<int>(std::lround(m_posY.target())); }
-    // The box this window is headed for: its layout slot when tiled, else its own position at its committed size.
-    // Valid ahead of the animation that carries the node there.
+    // The box this window is headed for: the output when fullscreen, its presented slot when tiled, which is the usable
+    // area when maximized to edges, else its own position at its committed size. Valid ahead of the animation that
+    // carries the node there, and settles a pending arrange to get there.
     [[nodiscard]] wlr_box targetBox() const;
     // Move the scene nodes without touching the position animation: an
     // interactive drag tracks the pointer 1:1 and owns the position itself.
@@ -408,6 +409,8 @@ namespace umbriel {
     // clamp does not apply or the origin already satisfies it.
     [[nodiscard]] std::optional<FloatingPoint> floatingClampTarget(FloatingPoint origin, int width, int height);
     void placeInUsableArea(const std::optional<WindowPosition>& position = std::nullopt);
+    // The output box a fullscreen window covers: its workspace's output, else the one under it.
+    [[nodiscard]] wlr_box fullscreenArea() const;
     void setPinned(bool pinned, bool focus);
     [[nodiscard]] View* transientParent() const;
     void syncTransientSceneParent();

--- a/src/wlr.h
+++ b/src/wlr.h
@@ -71,6 +71,8 @@ extern "C" {
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_xdg_activation_v1.h>
 #include <wlr/types/wlr_xdg_decoration_v1.h>
+#include <wlr/types/wlr_xdg_foreign_registry.h>
+#include <wlr/types/wlr_xdg_foreign_v2.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_xdg_toplevel_tag_v1.h>

--- a/tests/harness/checks/230_transient_close_focus.sh
+++ b/tests/harness/checks/230_transient_close_focus.sh
@@ -98,12 +98,10 @@ if grep -q '^configured-maximized$' "$CLIENT_LOG"; then
   exit 1
 fi
 
-child_x=$(jq -r --arg id "$child_id" '.[] | select(.id == $id) | .x' <<< "$windows")
-child_y=$(jq -r --arg id "$child_id" '.[] | select(.id == $id) | .y' <<< "$windows")
 child_w=$(jq -r --arg id "$child_id" '.[] | select(.id == $id) | .w' <<< "$windows")
 child_h=$(jq -r --arg id "$child_id" '.[] | select(.id == $id) | .h' <<< "$windows")
-if ((child_x != 340 || child_y != 110 || child_w != 600 || child_h != 500)); then
-  echo "transient is ${child_w}x${child_h} at ${child_x},${child_y}, expected 600x500 centered at 340,110: $windows"
+if ((child_w != 600 || child_h != 500)); then
+  echo "transient is ${child_w}x${child_h}, expected its natural 600x500: $windows"
   exit 1
 fi
 

--- a/tests/harness/checks/237_transient_placement.sh
+++ b/tests/harness/checks/237_transient_placement.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# A parented XDG toplevel without a position rule opens centered over its parent, not over the output.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/tests/unmap-client}"
+readonly CLIENT_LOG="$UMBRIEL_RUNTIME_DIR/transient-placement.log"
+
+windows() {
+  "$UMBRIEL" windows --json
+}
+
+wait_for_window_count() {
+  local want=$1
+  for _ in $(seq 60); do
+    [[ $(windows | jq 'length') -eq $want ]] && return 0
+    sleep 0.1
+  done
+  echo "expected $want windows, got: $(windows)"
+  return 1
+}
+
+wait_for_position() {
+  local title=$1 x=$2 y=$3
+  for _ in $(seq 60); do
+    if [[ $(windows | jq -r --arg title "$title" '.[] | select(.title == $title) | "\(.x) \(.y)"') == "$x $y" ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "expected $title at $x,$y, got: $(windows)"
+  return 1
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[animation]
+enabled = false
+
+[[window_rule]]
+match.title = "^transient-parent$"
+default_floating = true
+default_position = { x = 100, y = 110, anchor = "top_left" }
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+# Over the 900x600 parent the 400x300 child lands at 350,260. Centered on the 1280x720 output it would be 440,210.
+TRANSIENT_SUITE=1 TRANSIENT_PARENT_SIZE=900x600 "$CLIENT" transient-child 400 300 > "$CLIENT_LOG" 2>&1 &
+wait_for_window_count 3
+wait_for_position transient-parent 100 110
+wait_for_position transient-child 350 260
+
+echo "transient dialogs open centered over their parent"

--- a/tests/harness/checks/244_transient_parent_mapped_together.sh
+++ b/tests/harness/checks/244_transient_parent_mapped_together.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# A dialog whose parent maps in the same dispatch opens centered on the parent's tile, which the layout has not
+# arranged yet when the dialog is placed.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/tests/unmap-client}"
+readonly CLIENT_LOG="$UMBRIEL_RUNTIME_DIR/transient-mapped-together.log"
+
+windows() {
+  "$UMBRIEL" windows --json
+}
+
+wait_for_window_count() {
+  local want=$1
+  for _ in $(seq 60); do
+    [[ $(windows | jq 'length') -eq $want ]] && return 0
+    sleep 0.1
+  done
+  echo "expected $want windows, got: $(windows)"
+  return 1
+}
+
+wait_for_position() {
+  local title=$1 x=$2 y=$3
+  for _ in $(seq 60); do
+    if [[ $(windows | jq -r --arg title "$title" '.[] | select(.title == $title) | "\(.x) \(.y)"') == "$x $y" ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "expected $title at $x,$y, got: $(windows)"
+  return 1
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF2'
+
+[animation]
+enabled = false
+
+[layout.scrolling]
+default_width_fraction = 0.5
+center_underfull_strip = false
+EOF2
+"$UMBRIEL" msg config-reload > /dev/null
+
+# The output is 1280x720 with an edge pad of 10, so the parent's column is 624 wide and 700 high at 10,10, and its
+# 400x300 dialog lands at 122,210. Placed before the arrange, it would center on the output, at 440,210.
+TRANSIENT_SUITE=mapped-together "$CLIENT" transient-child 400 300 > "$CLIENT_LOG" 2>&1 &
+wait_for_window_count 2
+wait_for_position transient-parent 10 10
+wait_for_position transient-child 122 210
+
+echo "a dialog mapped with its parent opens centered on the parent's tile"

--- a/tests/harness/checks/245_transient_parent_fullscreen.sh
+++ b/tests/harness/checks/245_transient_parent_fullscreen.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# A dialog opens centered on what its parent shows: the whole output for a fullscreen parent and the usable area for
+# one maximized to edges, not the tile underneath either.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/tests/unmap-client}"
+readonly LAYER_CLIENT="${UMBRIEL_LAYER_CLIENT:-./build-debug/tests/layer-client}"
+readonly BASE_CONFIG="$UMBRIEL_RUNTIME_DIR/transient-fullscreen-base.toml"
+readonly PANEL_LOG="$UMBRIEL_RUNTIME_DIR/transient-fullscreen-panel.log"
+readonly CLIENT_LOG="$UMBRIEL_RUNTIME_DIR/transient-fullscreen.log"
+
+windows() {
+  "$UMBRIEL" windows --json
+}
+
+wait_for_window_count() {
+  local want=$1
+  for _ in $(seq 60); do
+    [[ $(windows | jq 'length') -eq $want ]] && return 0
+    sleep 0.1
+  done
+  echo "expected $want windows, got: $(windows)"
+  return 1
+}
+
+wait_for_position() {
+  local title=$1 x=$2 y=$3
+  for _ in $(seq 60); do
+    if [[ $(windows | jq -r --arg title "$title" '.[] | select(.title == $title) | "\(.x) \(.y)"') == "$x $y" ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "expected $title at $x,$y, got: $(windows)"
+  return 1
+}
+
+# $1 is the rule that opens the parent in the state under test. A left strut keeps the tiles away from the output's
+# corner, so a dialog centered on the parent's tile lands elsewhere than one centered on the output or the usable area.
+write_config() {
+  cat "$BASE_CONFIG" > "$UMBRIEL_CONFIG"
+  cat >> "$UMBRIEL_CONFIG" <<EOF2
+
+[animation]
+enabled = false
+
+[layout]
+mode = "dwindle"
+
+[layout.struts]
+left = 100
+
+[[window_rule]]
+match.title = "^transient-parent$"
+$1 = true
+EOF2
+  "$UMBRIEL" msg config-reload > /dev/null
+}
+
+cp "$UMBRIEL_CONFIG" "$BASE_CONFIG"
+
+# A 40 pixel panel takes the top of the usable area.
+"$LAYER_CLIENT" HEADLESS-1 40 > "$PANEL_LOG" 2>&1 &
+for _ in $(seq 80); do
+  if grep -q '^ready$' "$PANEL_LOG"; then
+    break
+  fi
+  sleep 0.05
+done
+if ! grep -q '^ready$' "$PANEL_LOG"; then
+  echo "exclusive-zone panel did not map: $(< "$PANEL_LOG")"
+  exit 1
+fi
+
+# Fullscreen covers the whole 1280x720 output, so the 400x300 dialog opens at 440,210.
+write_config default_fullscreen
+TRANSIENT_SUITE=1 "$CLIENT" transient-child 400 300 > "$CLIENT_LOG" 2>&1 &
+client_pid=$!
+wait_for_window_count 3
+wait_for_position transient-child 440 210
+
+kill "$client_pid"
+wait "$client_pid" 2> /dev/null || true
+wait_for_window_count 0
+
+# Maximized to edges fills the usable area below the panel, 1280x680 at 0,40, so the dialog opens at 440,230.
+write_config default_maximize_to_edges
+TRANSIENT_SUITE=1 "$CLIENT" transient-child 400 300 > "$CLIENT_LOG" 2>&1 &
+wait_for_window_count 3
+wait_for_position transient-child 440 230
+
+echo "a dialog opens centered on what a fullscreen or edge-maximized parent shows"

--- a/tests/harness/checks/246_foreign_parent_placement.sh
+++ b/tests/harness/checks/246_foreign_parent_placement.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# A dialog parented through xdg-foreign, the way a portal attaches its file chooser to an application's window, opens
+# centered over the window another process exported.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/tests/unmap-client}"
+readonly OBSERVER="${UMBRIEL_SEAT_LOG_CLIENT:-./build-debug/tests/seat-log-client}"
+readonly PARENT_LOG="$UMBRIEL_RUNTIME_DIR/foreign-parent.log"
+readonly CHILD_LOG="$UMBRIEL_RUNTIME_DIR/foreign-child.log"
+
+windows() {
+  "$UMBRIEL" windows --json
+}
+
+wait_for_window_count() {
+  local want=$1
+  for _ in $(seq 60); do
+    [[ $(windows | jq 'length') -eq $want ]] && return 0
+    sleep 0.1
+  done
+  echo "expected $want windows, got: $(windows)"
+  return 1
+}
+
+wait_for_position() {
+  local title=$1 x=$2 y=$3
+  for _ in $(seq 60); do
+    if [[ $(windows | jq -r --arg title "$title" '.[] | select(.title == $title) | "\(.x) \(.y)"') == "$x $y" ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "expected $title at $x,$y, got: $(windows)"
+  return 1
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF2'
+
+[animation]
+enabled = false
+
+[[window_rule]]
+match.title = "^foreign-parent$"
+default_floating = true
+default_position = { x = 0, y = 0, anchor = "top_left" }
+EOF2
+"$UMBRIEL" msg config-reload > /dev/null
+
+# The observer keeps its own 640x480, so the parent covers 0,0 to 640,480, and prints the handle it exported.
+EXPORT_TOPLEVEL=1 "$OBSERVER" foreign-parent > "$PARENT_LOG" 2>&1 &
+wait_for_window_count 1
+handle=
+for _ in $(seq 60); do
+  handle=$(sed -n 's/^exported handle=//p' "$PARENT_LOG")
+  [[ -n $handle ]] && break
+  sleep 0.1
+done
+if [[ -z $handle ]]; then
+  echo "the parent never received its xdg-foreign handle: $(cat "$PARENT_LOG")"
+  exit 1
+fi
+
+# Another process imports the handle for its 400x300 dialog, which lands centered over the parent, at 120,90.
+TRANSIENT_FOREIGN_HANDLE=$handle "$CLIENT" foreign-child 400 300 > "$CHILD_LOG" 2>&1 &
+wait_for_window_count 2
+wait_for_position foreign-child 120 90
+
+echo "a dialog parented through xdg-foreign opens centered over the exported window"

--- a/tests/harness/checks/247_transient_parent_maximizing.sh
+++ b/tests/harness/checks/247_transient_parent_maximizing.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# A dialog that opens while its floating parent is still resizing to maximized centers over the size the parent is
+# taking, not the one it has yet to leave, and stays there once the parent gets there.
+set -euo pipefail
+
+readonly CLIENT="${UMBRIEL_UNMAP_CLIENT:-./build-debug/tests/unmap-client}"
+readonly OBSERVER="${UMBRIEL_SEAT_LOG_CLIENT:-./build-debug/tests/seat-log-client}"
+readonly PARENT_LOG="$UMBRIEL_RUNTIME_DIR/maximizing-parent.log"
+readonly CHILD_LOG="$UMBRIEL_RUNTIME_DIR/maximizing-child.log"
+readonly PARENT_FIFO="$UMBRIEL_RUNTIME_DIR/maximizing-parent-control"
+
+windows() {
+  "$UMBRIEL" windows --json
+}
+
+field_of() {
+  local title=$1 field=$2
+  windows | jq -r --arg title "$title" --arg field "$field" '.[] | select(.title == $title) | .[$field]'
+}
+
+wait_for_window_count() {
+  local want=$1
+  for _ in $(seq 60); do
+    [[ $(windows | jq 'length') -eq $want ]] && return 0
+    sleep 0.1
+  done
+  echo "expected $want windows, got: $(windows)"
+  return 1
+}
+
+wait_for_size() {
+  local title=$1 size=$2
+  for _ in $(seq 60); do
+    [[ "$(field_of "$title" w)x$(field_of "$title" h)" == "$size" ]] && return 0
+    sleep 0.1
+  done
+  echo "expected $title at $size, got: $(windows)"
+  return 1
+}
+
+wait_for_position() {
+  local title=$1 x=$2 y=$3
+  for _ in $(seq 60); do
+    if [[ $(windows | jq -r --arg title "$title" '.[] | select(.title == $title) | "\(.x) \(.y)"') == "$x $y" ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "expected $title at $x,$y, got: $(windows)"
+  return 1
+}
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF2'
+
+[animation]
+enabled = false
+
+[[window_rule]]
+match.title = "^maximizing-parent$"
+default_floating = true
+default_position = { x = 0, y = 0, anchor = "top_left" }
+EOF2
+"$UMBRIEL" msg config-reload > /dev/null
+
+# The parent keeps its own 640x480 at 0,0 and leaves the configure that maximizes it unanswered until told to, so it
+# stays at that size with the maximize pending.
+mkfifo "$PARENT_FIFO"
+exec {parent_fd}<>"$PARENT_FIFO"
+HOLD_RESIZE=1 EXPORT_TOPLEVEL=1 "$OBSERVER" maximizing-parent <&"$parent_fd" > "$PARENT_LOG" 2>&1 &
+wait_for_window_count 1
+handle=
+for _ in $(seq 60); do
+  handle=$(sed -n 's/^exported handle=//p' "$PARENT_LOG")
+  [[ -n $handle ]] && break
+  sleep 0.1
+done
+if [[ -z $handle ]]; then
+  echo "the parent never received its xdg-foreign handle: $(cat "$PARENT_LOG")"
+  exit 1
+fi
+"$UMBRIEL" msg window-toggle-maximize-to-edges > /dev/null
+
+# The 400x300 dialog centers over the whole 1280x720 output the parent is taking, at 440,210, not over its old box.
+TRANSIENT_FOREIGN_HANDLE=$handle "$CLIENT" maximizing-child 400 300 > "$CHILD_LOG" 2>&1 &
+wait_for_window_count 2
+wait_for_position maximizing-child 440 210
+if [[ "$(field_of maximizing-parent w)x$(field_of maximizing-parent h)" != 640x480 ]]; then
+  echo "the parent was expected to still hold its 640x480: $(windows)"
+  exit 1
+fi
+
+# Once the parent takes the output, the dialog is already centered over it.
+printf r >&"$parent_fd"
+wait_for_size maximizing-parent 1280x720
+wait_for_position maximizing-child 440 210
+
+echo "a dialog opened during its parent's maximize centers over the size the parent is taking"

--- a/tests/harness/checks/535_security_context.sh
+++ b/tests/harness/checks/535_security_context.sh
@@ -26,6 +26,7 @@ readonly -a NORMAL_GLOBALS=(
   wl_output
   xdg_wm_base
   xdg_toplevel_tag_manager_v1
+  zxdg_exporter_v2
   zxdg_decoration_manager_v1
   org_kde_kwin_server_decoration_manager
   zwp_relative_pointer_manager_v1
@@ -42,6 +43,7 @@ readonly -a NORMAL_GLOBALS=(
 readonly -a RESTRICTED_GLOBALS=(
   wp_security_context_manager_v1
   zxdg_output_manager_v1
+  zxdg_importer_v2
   ext_idle_notifier_v1
   ext_data_control_manager_v1
   zwlr_data_control_manager_v1

--- a/tests/harness/clients/seat_log_client.cpp
+++ b/tests/harness/clients/seat_log_client.cpp
@@ -1,17 +1,23 @@
 // Maps a plain xdg toplevel and logs every seat input event it receives, so
 // checks can assert which keys and buttons reach a focused surface. With
 // EXPORT_TOPLEVEL set it also exports the toplevel through xdg-foreign and
-// prints the handle, so another client can parent a dialog to it.
+// prints the handle, so another client can parent a dialog to it. With
+// HOLD_RESIZE set it leaves any configure that resizes the mapped window
+// unanswered until a byte arrives on stdin, so the window keeps its size while
+// the resize stays pending.
 
 #include "xdg-foreign-unstable-v2-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <format>
+#include <optional>
+#include <poll.h>
 #include <print>
 #include <string>
 #include <string_view>
@@ -49,6 +55,9 @@ namespace {
     int height = 480;
     // A configure asked for a size the current buffer does not have.
     bool resizePending = true;
+    bool holdResize = false;
+    bool mapped = false;
+    std::optional<uint32_t> heldSerial;
     PressAction pressAction = PressAction::None;
     bool actionRequested = false;
   };
@@ -215,16 +224,25 @@ namespace {
   void exportedHandle(void*, zxdg_exported_v2*, const char* handle) { std::println("exported handle={}", handle); }
   constexpr zxdg_exported_v2_listener kExportedListener = {.handle = exportedHandle};
 
-  void xdgConfigure(void* data, xdg_surface* surface, uint32_t serial) {
-    auto& state = *static_cast<State*>(data);
-    xdg_surface_ack_configure(surface, serial);
+  void answerConfigure(State& state, uint32_t serial) {
+    xdg_surface_ack_configure(state.xdgSurface, serial);
     if (state.resizePending && !createBuffer(state)) {
       return;
     }
     state.resizePending = false;
+    state.mapped = true;
     wl_surface_attach(state.surface, state.buffer, 0, 0);
     wl_surface_damage_buffer(state.surface, 0, 0, state.width, state.height);
     wl_surface_commit(state.surface);
+  }
+
+  void xdgConfigure(void* data, xdg_surface*, uint32_t serial) {
+    auto& state = *static_cast<State*>(data);
+    if (state.holdResize && state.mapped && state.resizePending) {
+      state.heldSerial = serial;
+      return;
+    }
+    answerConfigure(state, serial);
   }
   constexpr xdg_surface_listener kXdgListener = {.configure = xdgConfigure};
 
@@ -287,6 +305,7 @@ int main(int argc, char** argv) {
   }
 
   State state;
+  state.holdResize = std::getenv("HOLD_RESIZE") != nullptr;
   if (mode == "move-on-press") {
     state.pressAction = PressAction::Move;
   } else if (mode == "resize-on-press") {
@@ -322,7 +341,33 @@ int main(int argc, char** argv) {
     );
   }
 
-  while (wl_display_dispatch(state.display) >= 0) {
+  const int displayFd = wl_display_get_fd(state.display);
+  while (true) {
+    wl_display_flush(state.display);
+    pollfd sources[2] = {
+        {.fd = displayFd, .events = POLLIN, .revents = 0},
+        {.fd = state.holdResize ? STDIN_FILENO : -1, .events = POLLIN, .revents = 0},
+    };
+    if (poll(sources, 2, -1) < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    if ((sources[0].revents & POLLIN) != 0 && wl_display_dispatch(state.display) < 0) {
+      break;
+    }
+    if ((sources[0].revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+      break;
+    }
+    if ((sources[1].revents & (POLLIN | POLLHUP)) != 0) {
+      char command = 0;
+      [[maybe_unused]] const ssize_t bytes = read(STDIN_FILENO, &command, 1);
+      state.holdResize = false;
+      if (state.heldSerial) {
+        answerConfigure(state, *state.heldSerial);
+      }
+    }
   }
   return EXIT_SUCCESS;
 }

--- a/tests/harness/clients/seat_log_client.cpp
+++ b/tests/harness/clients/seat_log_client.cpp
@@ -1,6 +1,9 @@
 // Maps a plain xdg toplevel and logs every seat input event it receives, so
-// checks can assert which keys and buttons reach a focused surface.
+// checks can assert which keys and buttons reach a focused surface. With
+// EXPORT_TOPLEVEL set it also exports the toplevel through xdg-foreign and
+// prints the handle, so another client can parent a dialog to it.
 
+#include "xdg-foreign-unstable-v2-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 
 #include <algorithm>
@@ -31,6 +34,7 @@ namespace {
     wl_shm* shm = nullptr;
     wl_seat* seat = nullptr;
     xdg_wm_base* wmBase = nullptr;
+    zxdg_exporter_v2* exporter = nullptr;
     wl_pointer* pointer = nullptr;
     wl_keyboard* keyboard = nullptr;
     wl_surface* surface = nullptr;
@@ -208,6 +212,9 @@ namespace {
   void wmBasePing(void*, xdg_wm_base* base, uint32_t serial) { xdg_wm_base_pong(base, serial); }
   constexpr xdg_wm_base_listener kWmBaseListener = {.ping = wmBasePing};
 
+  void exportedHandle(void*, zxdg_exported_v2*, const char* handle) { std::println("exported handle={}", handle); }
+  constexpr zxdg_exported_v2_listener kExportedListener = {.handle = exportedHandle};
+
   void xdgConfigure(void* data, xdg_surface* surface, uint32_t serial) {
     auto& state = *static_cast<State*>(data);
     xdg_surface_ack_configure(surface, serial);
@@ -255,6 +262,8 @@ namespace {
     } else if (std::strcmp(interface, xdg_wm_base_interface.name) == 0) {
       state.wmBase = static_cast<xdg_wm_base*>(wl_registry_bind(registry, name, &xdg_wm_base_interface, 1));
       xdg_wm_base_add_listener(state.wmBase, &kWmBaseListener, &state);
+    } else if (std::strcmp(interface, zxdg_exporter_v2_interface.name) == 0) {
+      state.exporter = static_cast<zxdg_exporter_v2*>(wl_registry_bind(registry, name, &zxdg_exporter_v2_interface, 1));
     }
   }
   void registryRemove(void*, wl_registry*, uint32_t) {}
@@ -303,6 +312,15 @@ int main(int argc, char** argv) {
   xdg_toplevel_add_listener(state.toplevel, &kToplevelListener, &state);
   xdg_toplevel_set_title(state.toplevel, title);
   wl_surface_commit(state.surface);
+  if (std::getenv("EXPORT_TOPLEVEL") != nullptr) {
+    if (state.exporter == nullptr) {
+      std::println(stderr, "seat-log-client: compositor is missing zxdg_exporter_v2");
+      return EXIT_FAILURE;
+    }
+    zxdg_exported_v2_add_listener(
+        zxdg_exporter_v2_export_toplevel(state.exporter, state.surface), &kExportedListener, nullptr
+    );
+  }
 
   while (wl_display_dispatch(state.display) >= 0) {
   }

--- a/tests/harness/clients/unmap_client.cpp
+++ b/tests/harness/clients/unmap_client.cpp
@@ -11,7 +11,7 @@
 // CONTENT_TYPE sets a surface hint before its initial commit. CONTENT_TYPE_ON_SUBSURFACE places it on a rendering
 // child, matching current Proton behavior. XDG_TAG sets a toplevel tag before the initial commit.
 // CONTENT_TYPE_AFTER_MAP, XDG_TAG_AFTER_MAP, and TITLE_AFTER_MAP update their metadata on stdin. NO_TITLE never sets a
-// title at all.
+// title at all. With TRANSIENT_SUITE, TRANSIENT_PARENT_SIZE=<width>x<height> gives the parent its own size.
 
 #include "color-management-v1-client-protocol.h"
 #include "content-type-v1-client-protocol.h"
@@ -125,11 +125,12 @@ namespace {
   };
 
   struct AuxiliaryToplevel {
-    State* state = nullptr;
     wl_surface* surface = nullptr;
     xdg_surface* xdgSurface = nullptr;
     xdg_toplevel* toplevel = nullptr;
     Buffer buffer;
+    int width = 0;
+    int height = 0;
     bool mapped = false;
   };
 
@@ -239,10 +240,10 @@ namespace {
       .name = seatName,
   };
 
-  Buffer createBuffer(State& state) {
+  Buffer createBuffer(State& state, int width, int height) {
     Buffer buffer;
-    const int stride = state.width * 4;
-    buffer.size = static_cast<size_t>(stride * state.height);
+    const int stride = width * 4;
+    buffer.size = static_cast<size_t>(stride * height);
     const int fd = memfd_create("umbriel-unmap-client", MFD_CLOEXEC);
     if (fd < 0 || ftruncate(fd, static_cast<off_t>(buffer.size)) < 0) {
       if (fd >= 0) {
@@ -259,7 +260,7 @@ namespace {
     std::fill_n(static_cast<uint32_t*>(buffer.pixels), buffer.size / sizeof(uint32_t), 0xFF5577AA);
 
     wl_shm_pool* pool = wl_shm_create_pool(state.shm, fd, static_cast<int>(buffer.size));
-    buffer.resource = wl_shm_pool_create_buffer(pool, 0, state.width, state.height, stride, WL_SHM_FORMAT_ARGB8888);
+    buffer.resource = wl_shm_pool_create_buffer(pool, 0, width, height, stride, WL_SHM_FORMAT_ARGB8888);
     wl_shm_pool_destroy(pool);
     close(fd);
     return buffer;
@@ -274,7 +275,7 @@ namespace {
     }
     window.mapped = true;
     wl_surface_attach(window.surface, window.buffer.resource, 0, 0);
-    wl_surface_damage_buffer(window.surface, 0, 0, window.state->width, window.state->height);
+    wl_surface_damage_buffer(window.surface, 0, 0, window.width, window.height);
     wl_surface_commit(window.surface);
   }
 
@@ -301,9 +302,10 @@ namespace {
       .wm_capabilities = nullptr,
   };
 
-  bool createAuxiliaryToplevel(State& state, AuxiliaryToplevel& window, const char* title) {
-    window.state = &state;
-    window.buffer = createBuffer(state);
+  bool createAuxiliaryToplevel(State& state, AuxiliaryToplevel& window, const char* title, int width, int height) {
+    window.width = width;
+    window.height = height;
+    window.buffer = createBuffer(state, width, height);
     if (window.buffer.resource == nullptr) {
       return false;
     }
@@ -325,8 +327,8 @@ namespace {
     return true;
   }
 
-  bool mapAuxiliaryToplevel(State& state, AuxiliaryToplevel& window, const char* title) {
-    if (!createAuxiliaryToplevel(state, window, title)) {
+  bool mapAuxiliaryToplevel(State& state, AuxiliaryToplevel& window, const char* title, int width, int height) {
+    if (!createAuxiliaryToplevel(state, window, title, width, height)) {
       return false;
     }
     wl_surface_commit(window.surface);
@@ -723,7 +725,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  state.buffer = createBuffer(state);
+  state.buffer = createBuffer(state, state.width, state.height);
   if (state.buffer.resource == nullptr) {
     std::println(stderr, "unmap-client: failed to allocate shared-memory buffer");
     return EXIT_FAILURE;
@@ -735,13 +737,20 @@ int main(int argc, char** argv) {
       transientSuite && std::strcmp(transientSuiteMode, "unmapped-parent-cleared") == 0;
   const bool unmappedTransientParent =
       clearUnmappedTransientParent || (transientSuite && std::strcmp(transientSuiteMode, "unmapped-parent") == 0);
+  int parentWidth = state.width;
+  int parentHeight = state.height;
+  if (const char* size = std::getenv("TRANSIENT_PARENT_SIZE"); size != nullptr
+      && (std::sscanf(size, "%dx%d", &parentWidth, &parentHeight) != 2 || parentWidth < 1 || parentHeight < 1)) {
+    std::println(stderr, "unmap-client: TRANSIENT_PARENT_SIZE must be <width>x<height>");
+    return EXIT_FAILURE;
+  }
   AuxiliaryToplevel transientParent;
   AuxiliaryToplevel transientUnrelated;
   if (transientSuite) {
     const bool supportReady = unmappedTransientParent
-        ? createAuxiliaryToplevel(state, transientParent, "transient-parent")
-        : mapAuxiliaryToplevel(state, transientParent, "transient-parent")
-            && mapAuxiliaryToplevel(state, transientUnrelated, "transient-unrelated");
+        ? createAuxiliaryToplevel(state, transientParent, "transient-parent", parentWidth, parentHeight)
+        : mapAuxiliaryToplevel(state, transientParent, "transient-parent", parentWidth, parentHeight)
+            && mapAuxiliaryToplevel(state, transientUnrelated, "transient-unrelated", state.width, state.height);
     if (!supportReady) {
       std::println(stderr, "unmap-client: failed to create transient-suite support windows");
       return EXIT_FAILURE;
@@ -768,7 +777,7 @@ int main(int argc, char** argv) {
       std::println(stderr, "unmap-client: compositor is missing wl_subcompositor");
       return EXIT_FAILURE;
     }
-    state.colorChildBuffer = createBuffer(state);
+    state.colorChildBuffer = createBuffer(state, state.width, state.height);
     if (state.colorChildBuffer.resource == nullptr) {
       std::println(stderr, "unmap-client: failed to allocate color child buffer");
       return EXIT_FAILURE;

--- a/tests/harness/clients/unmap_client.cpp
+++ b/tests/harness/clients/unmap_client.cpp
@@ -12,6 +12,8 @@
 // child, matching current Proton behavior. XDG_TAG sets a toplevel tag before the initial commit.
 // CONTENT_TYPE_AFTER_MAP, XDG_TAG_AFTER_MAP, and TITLE_AFTER_MAP update their metadata on stdin. NO_TITLE never sets a
 // title at all. With TRANSIENT_SUITE, TRANSIENT_PARENT_SIZE=<width>x<height> gives the parent its own size.
+// TRANSIENT_SUITE=mapped-together maps the parent and this toplevel in one flush, parenting from the first configure
+// so the compositor maps both in the same dispatch.
 
 #include "color-management-v1-client-protocol.h"
 #include "content-type-v1-client-protocol.h"
@@ -99,6 +101,7 @@ namespace {
     bool requestMaximizedAfterConfigure = false;
     bool maximizeRequested = false;
     bool logConfigures = false;
+    xdg_toplevel* parentOnFirstConfigure = nullptr;
     bool requestFullscreen = false;
     bool fullscreenRequested = false;
     bool requestHdr = false;
@@ -352,6 +355,11 @@ namespace {
       wl_surface_commit(state.surface);
       state.maximizeRequested = true;
       return;
+    }
+    if (state.parentOnFirstConfigure != nullptr) {
+      // The parent's map commit is queued ahead of this one in the same flush, so the compositor has it mapped by the
+      // time it reads this request.
+      xdg_toplevel_set_parent(state.toplevel, state.parentOnFirstConfigure);
     }
     state.mapped = true;
     wl_surface_attach(state.surface, state.buffer.resource, 0, 0);
@@ -737,6 +745,8 @@ int main(int argc, char** argv) {
       transientSuite && std::strcmp(transientSuiteMode, "unmapped-parent-cleared") == 0;
   const bool unmappedTransientParent =
       clearUnmappedTransientParent || (transientSuite && std::strcmp(transientSuiteMode, "unmapped-parent") == 0);
+  const bool mappedTogether = transientSuite && std::strcmp(transientSuiteMode, "mapped-together") == 0;
+  const bool parentInitialCommitOnly = unmappedTransientParent || mappedTogether;
   int parentWidth = state.width;
   int parentHeight = state.height;
   if (const char* size = std::getenv("TRANSIENT_PARENT_SIZE"); size != nullptr
@@ -747,7 +757,7 @@ int main(int argc, char** argv) {
   AuxiliaryToplevel transientParent;
   AuxiliaryToplevel transientUnrelated;
   if (transientSuite) {
-    const bool supportReady = unmappedTransientParent
+    const bool supportReady = parentInitialCommitOnly
         ? createAuxiliaryToplevel(state, transientParent, "transient-parent", parentWidth, parentHeight)
         : mapAuxiliaryToplevel(state, transientParent, "transient-parent", parentWidth, parentHeight)
             && mapAuxiliaryToplevel(state, transientUnrelated, "transient-unrelated", state.width, state.height);
@@ -755,9 +765,10 @@ int main(int argc, char** argv) {
       std::println(stderr, "unmap-client: failed to create transient-suite support windows");
       return EXIT_FAILURE;
     }
-    if (unmappedTransientParent) {
-      // Queue the parent's initial commit without dispatching its configure. The
-      // child therefore sends set_parent while this toplevel is still unmapped.
+    if (parentInitialCommitOnly) {
+      // Queue the parent's initial commit without dispatching its configure. The child therefore sends set_parent
+      // while this toplevel is still unmapped, or, mapped together, its configure arrives in the same read as the
+      // child's and its map commit goes out in the same flush.
       wl_surface_commit(transientParent.surface);
     }
   }
@@ -871,7 +882,9 @@ int main(int argc, char** argv) {
     // as a post-map maximize request.
     xdg_toplevel_set_maximized(state.toplevel);
   }
-  if (transientSuite) {
+  if (mappedTogether) {
+    state.parentOnFirstConfigure = transientParent.toplevel;
+  } else if (transientSuite) {
     xdg_toplevel_set_parent(state.toplevel, transientParent.toplevel);
     if (clearUnmappedTransientParent) {
       xdg_toplevel_set_parent(state.toplevel, nullptr);

--- a/tests/harness/clients/unmap_client.cpp
+++ b/tests/harness/clients/unmap_client.cpp
@@ -13,12 +13,14 @@
 // CONTENT_TYPE_AFTER_MAP, XDG_TAG_AFTER_MAP, and TITLE_AFTER_MAP update their metadata on stdin. NO_TITLE never sets a
 // title at all. With TRANSIENT_SUITE, TRANSIENT_PARENT_SIZE=<width>x<height> gives the parent its own size.
 // TRANSIENT_SUITE=mapped-together maps the parent and this toplevel in one flush, parenting from the first configure
-// so the compositor maps both in the same dispatch.
+// so the compositor maps both in the same dispatch. TRANSIENT_FOREIGN_HANDLE=<handle> parents this toplevel to
+// another client's exported toplevel, the way a portal dialog is parented.
 
 #include "color-management-v1-client-protocol.h"
 #include "content-type-v1-client-protocol.h"
 #include "tearing-control-v1-client-protocol.h"
 #include "xdg-activation-v1-client-protocol.h"
+#include "xdg-foreign-unstable-v2-client-protocol.h"
 #include "xdg-shell-client-protocol.h"
 #include "xdg-toplevel-tag-v1-client-protocol.h"
 
@@ -72,6 +74,7 @@ namespace {
     xdg_wm_base* wmBase = nullptr;
     xdg_activation_v1* activation = nullptr;
     xdg_toplevel_tag_manager_v1* xdgTagManager = nullptr;
+    zxdg_importer_v2* importer = nullptr;
     wp_content_type_manager_v1* contentTypeManager = nullptr;
     wp_content_type_v1* contentType = nullptr;
     wl_surface* contentTypeSurface = nullptr;
@@ -485,6 +488,8 @@ namespace {
       state.xdgTagManager = static_cast<xdg_toplevel_tag_manager_v1*>(
           wl_registry_bind(registry, name, &xdg_toplevel_tag_manager_v1_interface, std::min(version, 1U))
       );
+    } else if (std::strcmp(interface, zxdg_importer_v2_interface.name) == 0) {
+      state.importer = static_cast<zxdg_importer_v2*>(wl_registry_bind(registry, name, &zxdg_importer_v2_interface, 1));
     } else if (std::strcmp(interface, wp_content_type_manager_v1_interface.name) == 0) {
       state.contentTypeManager = static_cast<wp_content_type_manager_v1*>(
           wl_registry_bind(registry, name, &wp_content_type_manager_v1_interface, std::min(version, 1U))
@@ -747,6 +752,11 @@ int main(int argc, char** argv) {
       clearUnmappedTransientParent || (transientSuite && std::strcmp(transientSuiteMode, "unmapped-parent") == 0);
   const bool mappedTogether = transientSuite && std::strcmp(transientSuiteMode, "mapped-together") == 0;
   const bool parentInitialCommitOnly = unmappedTransientParent || mappedTogether;
+  const char* foreignHandle = std::getenv("TRANSIENT_FOREIGN_HANDLE");
+  if (foreignHandle != nullptr && state.importer == nullptr) {
+    std::println(stderr, "unmap-client: compositor is missing zxdg_importer_v2");
+    return EXIT_FAILURE;
+  }
   int parentWidth = state.width;
   int parentHeight = state.height;
   if (const char* size = std::getenv("TRANSIENT_PARENT_SIZE"); size != nullptr
@@ -890,6 +900,11 @@ int main(int argc, char** argv) {
       xdg_toplevel_set_parent(state.toplevel, nullptr);
     }
   }
+  zxdg_imported_v2* imported = nullptr;
+  if (foreignHandle != nullptr) {
+    imported = zxdg_importer_v2_import_toplevel(state.importer, foreignHandle);
+    zxdg_imported_v2_set_parent_of(imported, state.surface);
+  }
   wl_surface_commit(state.surface);
 
   if (!remapOnStdin && !updateOnStdin) {
@@ -995,6 +1010,12 @@ int main(int argc, char** argv) {
   }
   if (state.xdgTagManager != nullptr) {
     xdg_toplevel_tag_manager_v1_destroy(state.xdgTagManager);
+  }
+  if (imported != nullptr) {
+    zxdg_imported_v2_destroy(imported);
+  }
+  if (state.importer != nullptr) {
+    zxdg_importer_v2_destroy(state.importer);
   }
   if (state.activation != nullptr) {
     xdg_activation_v1_destroy(state.activation);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -198,6 +198,8 @@ unmap_client = executable(
     xdg_activation_client_c,
     xdg_toplevel_tag_client_h,
     xdg_toplevel_tag_client_c,
+    xdg_foreign_client_h,
+    xdg_foreign_client_c,
     content_type_client_h,
     content_type_client_c,
     color_management_client_h,
@@ -284,7 +286,13 @@ security_context_client = executable(
 # Harness helper that logs the seat input events a window receives, for input state checks.
 seat_log_client = executable(
   'seat-log-client',
-  ['harness/clients/seat_log_client.cpp', xdg_shell_client_h, xdg_shell_client_c],
+  [
+    'harness/clients/seat_log_client.cpp',
+    xdg_shell_client_h,
+    xdg_shell_client_c,
+    xdg_foreign_client_h,
+    xdg_foreign_client_c,
+  ],
   dependencies: [wayland_client_dep],
 )
 

--- a/tests/unit/floating.cpp
+++ b/tests/unit/floating.cpp
@@ -4,6 +4,7 @@
 
 using umbriel::anchoredContentOrigin;
 using umbriel::centeredOrigin;
+using umbriel::centeredOverShown;
 using umbriel::clampFloatingOrigin;
 using umbriel::floatingFractionSize;
 using umbriel::FloatingGeometry;
@@ -186,6 +187,44 @@ UMBRIEL_TEST(clampDoesNotInvertWhenTheBoundsCross) {
   // Low bound wins rather than the range being read backwards.
   CHECK_EQ(clamped.x, usable.x + floatingKeepVisible(0));
   CHECK_EQ(clamped.y, usable.y + floatingKeepVisible(0));
+}
+
+// Dialog placement
+UMBRIEL_TEST(aDialogCentersOnAParentThatIsFullyInView) {
+  const wlr_box parent{100, 110, 900, 600};
+  const FloatingPoint origin = centeredOverShown(parent, kUsable, 400, 300);
+  CHECK_EQ(origin.x, 350);
+  CHECK_EQ(origin.y, 260);
+}
+
+UMBRIEL_TEST(aDialogCentersOnTheVisiblePartOfAScrolledParent) {
+  // The parent hangs 500 wide off the left edge, so only its right 400 show.
+  const wlr_box parent{-500, 0, 900, 600};
+  const FloatingPoint origin = centeredOverShown(parent, kUsable, 200, 100);
+  CHECK_EQ(origin.x, 100);
+  CHECK_EQ(origin.y, 250);
+}
+
+UMBRIEL_TEST(aDialogOverAParentOutOfViewCentersOnTheArea) {
+  const wlr_box parent{-2000, 0, 900, 600};
+  const FloatingPoint origin = centeredOverShown(parent, kUsable, 400, 300);
+  CHECK_EQ(origin.x, 760);
+  CHECK_EQ(origin.y, 390);
+}
+
+UMBRIEL_TEST(aDialogStaysInsideTheAreaWhenItFits) {
+  // Centered on the sliver of parent in the corner, the dialog would overhang; it is pulled back to the edge.
+  const wlr_box parent{1800, 1000, 900, 600};
+  const FloatingPoint origin = centeredOverShown(parent, kUsable, 400, 300);
+  CHECK_EQ(origin.x, kUsable.width - 400);
+  CHECK_EQ(origin.y, kUsable.height - 300);
+}
+
+UMBRIEL_TEST(aDialogLargerThanTheAreaKeepsItsTopLeftOnIt) {
+  const wlr_box usable{0, 40, 1280, 680};
+  const FloatingPoint origin = centeredOverShown({0, 40, 1280, 680}, usable, 1500, 900);
+  CHECK_EQ(origin.x, 0);
+  CHECK_EQ(origin.y, 40);
 }
 
 // Resize anchoring


### PR DESCRIPTION
## Summary

Adds xdg-foreign-unstable-v2 so another process can parent a dialog to a
window, the way xdg-desktop-portal attaches its file chooser, and opens a
parented dialog centered over the visible part of its parent instead of over
the output.

- `zxdg_exporter_v2` is offered to security-context clients, `zxdg_importer_v2`
  stays restricted: a sandboxed app exports its window, the portal imports it.
- A dialog without a `default_position` rule opens centered on what shows of
  its parent, kept inside the usable area when it fits; a parent scrolled out of
  view leaves it centered on the area. The parent's presented box is used, not
  its node position: a pending arrange is settled first, so a dialog mapping in
  the same dispatch as its parent lands where the parent is headed, and a
  fullscreen parent counts at the output, one maximized to edges at the usable
  area. A floating parent counts at the size it is resizing to, so a dialog
  opened during its maximize centers over the maximized parent.
- The centering arithmetic lives in `floating.h` with unit tests; the harness
  check pins the live placement.

## Motivation

Portals had nothing to attach to, so their dialogs opened as unrelated windows.
Parented dialogs opened centered on the output, away from the window they
belong to, and the corner of the usable area when the parent's map animation
was still pending.

## Type of Change

- [x] New feature
- [x] Bug fix

## Testing

- `just format`, `just lint`, `just test` (unit tests incl. new dialog
  placement cases in `tests/unit/floating.cpp`)
- `just check` full suite on the host: all checks pass, including the new
  `237_transient_placement`; `535_security_context` covers the new globals.
- Added in review and passing on the host: `244_transient_parent_mapped_together`,
  `245_transient_parent_fullscreen`, `246_foreign_parent_placement`, an
  export/import round trip between two clients, and
  `247_transient_parent_maximizing`, a parent that holds the configure
  maximizing it while its dialog opens.
- Native session with GTK 4, Qt 6, Firefox, and the file chooser
  portal.

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with native Wayland applications
- [x] Tested with the scrolling layout

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

No configuration keys are added. `docs/user/layout.md` describes the placement.

