### PR TITLE
feat(overview): add axis-aware wheel navigation

### DIFF
--- a/docs/user/workspaces-overview.md
+++ b/docs/user/workspaces-overview.md
@@ -42,10 +42,15 @@ closes.
 
 Click a window to focus it, middle-click to close it, or drag it to another
 workspace. When a click selects a window in another scrolling column, the
-column reveal runs together with the closing zoom. Each wheel notch moves one
-workspace at a time. The vertical wheel works on either arrangement; a
-horizontal wheel navigates only horizontal workspaces. A 4-finger swipe opens
-or closes the overview.
+column reveal runs together with the closing zoom. Wheel scrolls vertically;
+Shift+wheel and native horizontal wheel scroll horizontally. Wheel navigation
+commits discrete targets: along the output's workspace axis it switches workspace;
+across that axis it selects and reveals the next scrolling column in the preview
+under the pointer. Configured wheel bindings take precedence over Shift+wheel.
+At factor `1.0`, each notch advances one target; `0.5` needs two notches and `2.0`
+advances two targets. Factors change notch sensitivity, not continuous gesture travel
+for the wheel. Normal transition animations still apply.
+A 4-finger swipe opens or closes the overview.
 
 Two-finger scrolling and three-finger swipes both navigate continuously:
 
@@ -63,11 +68,11 @@ moves away. Wheel and keyboard navigation are unchanged.
 
 Touchpad `natural_scroll` sets the direction of both gestures.
 `overview.scroll_factor_horizontal` and `overview.scroll_factor_vertical`
-scale how far a gesture travels; both default to `1.0`, and a factor of `0.8`
-needs 25% more finger movement for the same distance. They apply to the
-physical direction of the movement, not to the output's workspace axis, and
-they are independent of the input device's `scroll_factor`, which still only
-scales application scrolling.
+scale how far a gesture travels and multiply wheel notch accumulation; both
+default to `1.0`. A factor of `0.8` needs 25% more finger movement for the same
+distance. They apply to the physical direction of the movement (horizontal for
+Shift+wheel), not to the output's workspace axis. They are independent of the
+input device's `scroll_factor`, which still only scales application scrolling.
 
 Three-finger swipes cover one workspace in the same travel a swipe outside the
 overview takes to switch workspaces. Two-finger scrolling has its own distance:

--- a/docs/user/workspaces.md
+++ b/docs/user/workspaces.md
@@ -153,8 +153,9 @@ master workspaces follow their output's axis for switching and the overview,
 like every other layout.
 
 A three-finger swipe along the axis switches workspaces, and a swipe across it
-scrolls the strip. In the overview, the ordinary vertical wheel navigates either
-arrangement, while a horizontal wheel navigates only horizontal workspaces.
+scrolls the strip. In the overview, wheel moves vertically and Shift+wheel moves
+horizontally in discrete steps. Along the workspace axis it switches workspaces;
+across that axis it selects and reveals scrolling columns in the hovered preview.
 
 An axis change on reload applies to every workspace on the output. Any live
 swipe, strip drag or tiled resize is settled first, and an open overview closes.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -789,8 +789,8 @@ curve = "easeout"
 
 [overview]
 zoom = 0.5                                      # Workspace scale in overview, 0.1-0.75
-scroll_factor_horizontal = 1.0                  # Overview gesture travel, left and right, 0.1-10.0
-scroll_factor_vertical = 1.0                    # Overview gesture travel, up and down, 0.1-10.0
+scroll_factor_horizontal = 1.0                  # Overview gesture/wheel multiplier, left and right, 0.1-10.0
+scroll_factor_vertical = 1.0                    # Overview gesture/wheel multiplier, up and down, 0.1-10.0
 # Pinned windows stay hidden until overview closes; visible scratchpads are dismissed.
 # background_blur = true                        # Blur the wallpaper behind overview rows
 # workspace_wallpaper = true                    # Mirror wallpapers inside workspace previews

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -610,7 +610,7 @@ namespace umbriel {
     struct Overview {
       // Workspace scale when fully zoomed out.
       double zoom = 0.5;
-      // Touchpad travel per workspace or viewport in the overview, by the physical direction of the movement rather
+      // Touchpad travel and wheel accumulation in the overview, by the physical direction of the movement rather
       // than the output's workspace axis. Independent of an input device's own scroll_factor.
       double scrollFactorHorizontal = 1.0;
       double scrollFactorVertical = 1.0;

--- a/src/input/cursor.cpp
+++ b/src/input/cursor.cpp
@@ -1142,9 +1142,15 @@ namespace umbriel {
       eventDir = rawDelta < 0 ? WheelDirection::Left : WheelDirection::Right;
     }
 
-    // Unmodified scrolling drives the overview filmstrip instead of the inert desktop under the cursor. Panels
-    // (top/overlay) keep their own scrolling, and modifier chords still fall through to the wheel binds below.
-    if (Overview* overview = m_server->overview(); overview != nullptr && overview->active() && effective == 0) {
+    const bool shiftWheel = effective == WLR_MODIFIER_SHIFT && event->source != WL_POINTER_AXIS_SOURCE_FINGER;
+    const bool boundShiftWheel = shiftWheel && std::ranges::any_of(config().keybinds, [&](const Keybind& bind) {
+                                   return bind.submap == m_server->activeSubmap()
+                                       && bind.wheel == eventDir
+                                       && effective == (bind.modifiers | (bind.useMod ? m_server->modKey() : 0));
+                                 });
+    // Shift maps vertical wheel travel onto the horizontal axis. Explicit bindings and panels keep their input.
+    if (Overview* overview = m_server->overview();
+        overview != nullptr && overview->active() && (effective == 0 || (shiftWheel && !boundShiftWheel))) {
       double sx = 0;
       double sy = 0;
       wlr_surface* surface = nullptr;
@@ -1162,12 +1168,16 @@ namespace umbriel {
           );
           return;
         }
-        const int axis = isVertical ? 0 : 1;
+        const bool overviewVertical = isVertical && !shiftWheel;
+        const int axis = overviewVertical ? 0 : 1;
+        const double factor =
+            overviewVertical ? config().overview.scrollFactorVertical : config().overview.scrollFactorHorizontal;
         m_wheelAccum[axis] +=
-            event->delta_discrete != 0 ? static_cast<double>(event->delta_discrete) / 120.0 : event->delta / 15.0;
+            (event->delta_discrete != 0 ? static_cast<double>(event->delta_discrete) / 120.0 : event->delta / 15.0)
+            * factor;
         double& accumulated = m_wheelAccum[axis];
         while (std::abs(accumulated) >= 1.0) {
-          overview->handleAxisNotch(isVertical, accumulated, m_cursor->x, m_cursor->y);
+          overview->handleAxisNotch(overviewVertical, accumulated, m_cursor->x, m_cursor->y);
           accumulated -= std::copysign(1.0, accumulated);
         }
         return;

--- a/src/overview/overview.cpp
+++ b/src/overview/overview.cpp
@@ -2377,12 +2377,29 @@ namespace umbriel {
     Output* output = m_server->outputFromWlr(wlr_output_layout_output_at(m_server->outputLayout(), lx, ly));
     const WorkspaceGroup* group = output != nullptr ? output->workspaceGroup() : nullptr;
     const bool horizontalWorkspaces = group != nullptr && group->workspaceAxis() == WorkspaceAxis::Horizontal;
-    // The vertical wheel navigates either arrangement; a horizontal wheel only
-    // matches horizontally arranged workspaces.
-    if (!vertical && !horizontalWorkspaces) {
+    const int sign = direction < 0 ? -1 : 1;
+    // Wheel input commits discrete targets on its physical axis, unlike continuous touchpad navigation.
+    if (vertical != horizontalWorkspaces) {
+      selectRelativeWorkspace(sign, output);
       return true;
     }
-    selectRelativeWorkspace(direction < 0 ? -1 : 1, output);
+    Workspace* workspace = workspaceAtPoint(lx, ly, nullptr, nullptr, true);
+    ScrollingLayout* scrolling = workspace != nullptr ? workspace->scrollingLayout() : nullptr;
+    if (scrolling == nullptr) {
+      return true;
+    }
+    View* target = vertical ? workspace->focusVertical(sign) : workspace->focusAdjacent(sign);
+    if (target == nullptr) {
+      return true;
+    }
+    clearShortcutInput();
+    if (workspace->active()) {
+      m_server->focusView(target, FocusReason::Gesture);
+    } else {
+      workspace->setFocusedView(target);
+    }
+    scrolling->snapVisible(scrolling->columnOf(target), workspace->scrollViewportExtent());
+    workspace->markArrange(true);
     return true;
   }
 

--- a/tests/harness/checks/310_overview_wheel.sh
+++ b/tests/harness/checks/310_overview_wheel.sh
@@ -65,7 +65,7 @@ open_overview() {
 }
 
 # One window, so the group holds workspace 1 (occupied) and a dynamic 2.
-foot sh -c 'sleep 120' > /dev/null 2>&1 &
+"$UMBRIEL_UNMAP_CLIENT" overview-wheel 1200 700 > /dev/null 2>&1 &
 for _ in $(seq 60); do
   [[ $("$UMBRIEL" windows --json | jq 'length') -eq 1 ]] && break
   sleep 0.25
@@ -104,7 +104,7 @@ printf '[layout\n' > "$UMBRIEL_CONFIG"
 expect_notch 1 2
 expect_notch -1 1
 
-# Horizontally arranged workspaces keep the vertical wheel and add the horizontal one. The malformed write above left
+# Horizontally arranged workspaces use the horizontal wheel. The malformed write above left
 # the file unusable, so this phase rewrites it whole; three static workspaces put both ends of the arrangement within
 # reach of a wheel.
 cat > "$UMBRIEL_CONFIG" << 'EOF'
@@ -132,9 +132,9 @@ if [[ $("$WORKSPACE") != 1 ]]; then
 fi
 open_overview
 
-# The vertical wheel navigates either arrangement.
-expect_notch 1 2
-expect_notch -1 1
+# Vertical wheel keeps its physical axis and cannot switch horizontal workspaces.
+expect_inert_notch 1 notch "a vertical notch switched horizontal workspaces"
+expect_inert_notch -1 notch "a vertical notch switched horizontal workspaces"
 
 # The horizontal wheel matches this arrangement, so it steps the filmstrip too.
 expect_notch 1 2 notch-horizontal

--- a/tests/harness/checks/312_overview_shift_wheel.sh
+++ b/tests/harness/checks/312_overview_shift_wheel.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Wheel navigation uses physical axes and discrete column/workspace targets, with independent factors.
+set -euo pipefail
+
+cat >> "$UMBRIEL_CONFIG" <<'EOF'
+
+[overview]
+scroll_factor_horizontal = 0.5
+scroll_factor_vertical = 2.0
+
+[layout.scrolling]
+default_width_fraction = 0.5
+
+[output."HEADLESS-1"]
+workspaces = 3
+EOF
+"$UMBRIEL" msg config-reload > /dev/null
+
+for index in 1 2 3; do
+  "$UMBRIEL_UNMAP_CLIENT" "shift-wheel-$index" 1200 700 > /dev/null 2>&1 &
+  for _ in $(seq 60); do
+    [[ $("$UMBRIEL" windows --json | jq length) == "$index" ]] && break
+    sleep 0.05
+  done
+done
+[[ $("$UMBRIEL" windows --json | jq length) == 3 ]]
+"$UMBRIEL" msg column-focus-first > /dev/null
+"$UMBRIEL" msg overview-open > /dev/null
+
+first_x() {
+  "$UMBRIEL" windows --json | jq -r '.[] | select(.title == "shift-wheel-1") | .x'
+}
+selected_title() {
+  "$UMBRIEL" windows --json | jq -r '.[] | select(.focused) | .title'
+}
+active_workspace() {
+  "$UMBRIEL" workspaces --json | jq -r '.[] | select(.active) | .index'
+}
+before=$(first_x)
+# Keep one virtual keyboard/pointer alive for the two half-factor notches.
+"$UMBRIEL_POINTER_CLIENT" 1280 720 move 640 360 mod shift notch 1 pause 400 notch 1 pause 400 mod none &
+pointer_pid=$!
+sleep 0.2
+[[ $(first_x) == "$before" ]] || { echo 'half-factor wheel moved on its first notch'; exit 1; }
+[[ $(selected_title) == shift-wheel-1 ]] || { echo "half-factor first notch: $(selected_title)"; exit 1; }
+wait "$pointer_pid"
+for _ in $(seq 60); do
+  [[ $(selected_title) == shift-wheel-2 ]] && break
+  sleep 0.05
+done
+[[ $(selected_title) == shift-wheel-2 ]] || { echo 'Shift-wheel did not select the next column'; exit 1; }
+[[ $(active_workspace) == 1 ]] || { echo 'horizontal wheel moved vertically between workspaces'; exit 1; }
+(( $(first_x) < before )) || { echo 'Shift-wheel did not reveal the selected column'; exit 1; }
+"$UMBRIEL_POINTER_CLIENT" 1280 720 mod shift notch -1 notch -1 mod none
+[[ $(selected_title) == shift-wheel-1 ]] || { echo 'reverse Shift-wheel did not select the previous column'; exit 1; }
+
+"$UMBRIEL" msg workspace-switch:1 > /dev/null
+"$UMBRIEL_POINTER_CLIENT" 1280 720 notch 1
+for _ in $(seq 60); do
+  [[ $(active_workspace) == 3 ]] && break
+  sleep 0.05
+done
+[[ $(active_workspace) == 3 ]] || { echo 'double vertical factor did not advance two workspaces'; exit 1; }
+
+# The same horizontal input follows the filmstrip when the workspace axis changes.
+printf '\nworkspace_axis = "horizontal"\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+"$UMBRIEL" msg workspace-switch:1 > /dev/null
+"$UMBRIEL" msg overview-open > /dev/null
+# In this arrangement the vertical wheel steps columns, not workspaces. Factor 2 skips to column 3.
+"$UMBRIEL" msg column-focus-first > /dev/null
+"$UMBRIEL_POINTER_CLIENT" 1280 720 notch 1
+[[ $(selected_title) == shift-wheel-3 ]] || { echo 'vertical wheel did not step vertical columns'; exit 1; }
+[[ $(active_workspace) == 1 ]] || { echo 'vertical wheel switched horizontal workspaces'; exit 1; }
+"$UMBRIEL_POINTER_CLIENT" 1280 720 mod shift notch 1 notch 1 mod none
+[[ $(active_workspace) == 2 ]] || { echo 'Shift-wheel did not follow horizontal workspaces'; exit 1; }
+
+# A user binding wins, even though the default horizontal factor would require two notches.
+printf '\n[keybinds]\n"Shift+WheelDown" = "workspace-next"\n' >> "$UMBRIEL_CONFIG"
+"$UMBRIEL" msg config-reload > /dev/null
+"$UMBRIEL" msg overview-open > /dev/null
+"$UMBRIEL_POINTER_CLIENT" 1280 720 mod shift notch 1 mod none
+[[ $(active_workspace) == 3 ]] || { echo 'Shift-wheel ignored the configured binding'; exit 1; }
+echo 'wheel steps vertically, Shift-wheel steps horizontally, factors count notches, and bindings win'


### PR DESCRIPTION
## Summary

Make overview wheel navigation follow screen axes: wheel moves vertically, while Shift+wheel and native horizontal wheel move horizontally. Movement along the configured workspace axis switches workspaces; movement across it selects and reveals the next scrolling column under the pointer.

Apply `overview.scroll_factor_horizontal` and `overview.scroll_factor_vertical` to discrete wheel-notch accumulation. Wheel navigation remains step-based, while touchpad navigation keeps its existing continuous behavior. Explicit Shift+wheel bindings continue to take precedence.

## Motivation

The overview previously ignored its scroll factors for mouse wheels, and modifier chords bypassed its built-in wheel handling. This left no default Shift+wheel path for horizontal navigation and made wheel sensitivity inconsistent with the overview settings.

## Type of Change

- [x] New feature
- [x] Documentation

## Testing

- Clean release rebuild with no compiler warnings.
- `run-clang-tidy` across `src/` and `tests/` with warnings treated as errors.
- `meson test -C build-release --print-errorlogs` — 59 passed.
- `bash tests/harness/check.sh ./build-release/umbriel overview -j 8` — 16 passed.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

The implementation reuses existing workspace focus and scrolling-layout reveal paths. It does not add layout state or new configuration keys.
