### PR TITLE
test(session): isolate the login shell registry

### DIFF
--- a/tests/session_launcher.sh
+++ b/tests/session_launcher.sh
@@ -30,21 +30,12 @@ readonly DRS_INJECTION_MARKER="$TEST_DIR/drs-injected"
 readonly DANGEROUS_ARGUMENT="\$(touch '$INJECTION_MARKER')"
 
 mkdir -p "$TEST_HOME" "$TEST_BIN"
-cp "$SOURCE_LAUNCHER" "$LAUNCHER"
-cp "$SOURCE_DIRECT_LAUNCHER" "$DIRECT_LAUNCHER"
+sed 's|/etc/shells|"$HOME/shells"|g' "$SOURCE_LAUNCHER" > "$LAUNCHER"
+sed 's|/etc/shells|"$HOME/shells"|g' "$SOURCE_DIRECT_LAUNCHER" > "$DIRECT_LAUNCHER"
 chmod 700 "$LAUNCHER" "$DIRECT_LAUNCHER"
 
-login_shell=
-while IFS= read -r candidate; do
-  if [[ $candidate == */bash && -x $candidate ]]; then
-    login_shell=$candidate
-    break
-  fi
-done < /etc/shells
-if [[ -z $login_shell ]]; then
-  echo "session launcher check needs bash listed in /etc/shells"
-  exit 77
-fi
+login_shell=$BASH
+printf '%s\n' "$login_shell" > "$TEST_HOME/shells"
 
 cat > "$TEST_HOME/.bash_profile" <<'EOF'
 printf 'profile\n' >> "$UMBRIEL_TEST_PROFILE_TRACE"


### PR DESCRIPTION
## Summary

Use the running Bash and a private shell registry in the session launcher's test copies.

## Motivation

With tests enabled, a Nix sandbox build fails because `tests/session_launcher.sh` reads `/etc/shells`, which is absent there. A fixture lets the existing assertions execute independently of the host's registered login shells.

## Type of Change

- [x] Bug fix

## Testing

- Reproduced the original failure with an empty `/etc` in Bubblewrap.
- The patched session test passes in that environment and on the host, covering native, direct, nested and externally managed launches.
- The Nix package check passes with tests enabled, including `session-launcher`.
- `git diff --check` passes. No compositor code changes.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
