### PR TITLE
fix(umbrielfx): guard clip intersect against negative surface size

### DIFF
--- a/umbrielfx/types/scene/surface.c
+++ b/umbrielfx/types/scene/surface.c
@@ -240,6 +240,19 @@ static void surface_reconfigure(struct wlr_scene_surface *scene_surface) {
 	struct wlr_surface *surface = scene_surface->surface;
 	struct wlr_surface_state *state = &surface->current;
 
+	int width = state->width;
+	int height = state->height;
+
+	if (!wlr_box_empty(&scene_surface->clip)) {
+		width = min(scene_surface->clip.width, width - scene_surface->clip.x);
+		height = min(scene_surface->clip.height, height - scene_surface->clip.y);
+	}
+
+	if (width <= 0 || height <= 0) {
+		wlr_scene_buffer_set_buffer(scene_buffer, NULL);
+		return;
+	}
+
 	struct wlr_fbox src_box;
 	wlr_surface_get_buffer_source_box(surface, &src_box);
 
@@ -247,16 +260,11 @@ static void surface_reconfigure(struct wlr_scene_surface *scene_surface) {
 	pixman_region32_init(&opaque);
 	pixman_region32_copy(&opaque, &surface->opaque_region);
 
-	int width = state->width;
-	int height = state->height;
-
 	if (!wlr_box_empty(&scene_surface->clip)) {
 		struct wlr_box *clip = &scene_surface->clip;
 
 		int buffer_width = state->buffer_width;
 		int buffer_height = state->buffer_height;
-		width = min(clip->width, width - clip->x);
-		height = min(clip->height, height - clip->y);
 
 		wlr_fbox_transform(&src_box, &src_box, state->transform,
 			buffer_width, buffer_height);
@@ -272,12 +280,6 @@ static void surface_reconfigure(struct wlr_scene_surface *scene_surface) {
 
 		pixman_region32_translate(&opaque, -clip->x, -clip->y);
 		pixman_region32_intersect_rect(&opaque, &opaque, 0, 0, width, height);
-	}
-
-	if (width <= 0 || height <= 0) {
-		wlr_scene_buffer_set_buffer(scene_buffer, NULL);
-		pixman_region32_fini(&opaque);
-		return;
 	}
 
 	float opacity = 1.0;


### PR DESCRIPTION
## Summary

Skip the Pixman opaque-region intersection when a retained surface clip has empty dimensions; the existing empty-buffer path then rejects it.

## Motivation

A subsurface can shrink below an existing clip origin. This makes the clipped width or height negative, and passing that size to Pixman emits an invalid-rectangle diagnostic.

## Type of Change

- [x] Bug fix

## Testing

The following checks were run on the original author revision:

- Package test suite: 45 passed, 14 GPU tests skipped because the builder had no suitable DRM render node, 0 failed.
- Contained headless workload: six subsurface shrinks and 54 IPC commands; 10 invalid-rectangle diagnostics before the change and 0 after, with both runs exiting successfully.
- After switching and rebooting, the deployed Umbriel used that revision and emitted no Pixman diagnostics in the observed session.

The merged revision was source-reviewed at [4c0e622](https://github.com/noctalia-dev/umbriel/commit/4c0e622d0afb4d3c37b357cccad7920338530546); the package and headless tests above were not rerun on that revision.

## Checklist

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.
