### PR TITLE
perf(umbrielfx): disable implicit flush

### DIFF
--- a/umbrielfx/internal/render/egl.h
+++ b/umbrielfx/internal/render/egl.h
@@ -21,6 +21,7 @@ struct wlr_egl {
 		bool EXT_image_dma_buf_import_modifiers;
 		bool IMG_context_priority;
 		bool EXT_create_context_robustness;
+		bool KHR_context_flush_control;
 
 		// Device extensions
 		bool EXT_device_drm;

--- a/umbrielfx/render/egl.c
+++ b/umbrielfx/render/egl.c
@@ -367,6 +367,9 @@ static bool egl_init_display(struct wlr_egl *egl, EGLDisplay display,
 	egl->exts.IMG_context_priority =
 		check_egl_ext(display_exts_str, "EGL_IMG_context_priority");
 
+	egl->exts.KHR_context_flush_control =
+		check_egl_ext(display_exts_str, "EGL_KHR_context_flush_control");
+
 	wlr_log(WLR_INFO, "Using EGL %d.%d", (int)major, (int)minor);
 	wlr_log(WLR_INFO, "Supported EGL display extensions: %s", display_exts_str);
 	if (device_exts_str != NULL) {
@@ -413,7 +416,7 @@ static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 	}
 
 	size_t atti = 0;
-	EGLint attribs[7];
+	EGLint attribs[9];
 
 	attribs[atti++] = EGL_CONTEXT_CLIENT_VERSION;
 	attribs[atti++] = 2;
@@ -432,6 +435,12 @@ static bool egl_init(struct wlr_egl *egl, EGLenum platform,
 	if (egl->exts.EXT_create_context_robustness) {
 		attribs[atti++] = EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT;
 		attribs[atti++] = EGL_LOSE_CONTEXT_ON_RESET_EXT;
+	}
+
+	// Disable implicit flushes when releasing the context to reduce overhead.
+	if (egl->exts.KHR_context_flush_control) {
+		attribs[atti++] = EGL_CONTEXT_RELEASE_BEHAVIOR_KHR;
+		attribs[atti++] = EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR;
 	}
 
 	attribs[atti++] = EGL_NONE;


### PR DESCRIPTION
## Summary

Disable implicit flushes on context release

## Motivation

I was experiencing a drop in compositor framerate vs Hyprland, especially on my second monitor, during high GPU use. After this addition, framerate has improved

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Build / packaging
- [ ] Documentation

## Related Issue

## Testing

A/B tested this vs main while running a Steam game with several applications open

## Manual Coverage

- [ ] Tested in a nested Umbriel session
- [x] Tested in a native Umbriel session
- [x] Tested with multiple monitors
- [x] Tested with a scaled output
- [x] Tested with native Wayland applications
- [x] Tested with X11 applications through xwayland-satellite
- [x] Tested with the scrolling layout
- [ ] Tested with the dwindle layout

## Screenshots / Videos

## Checklist

<!-- Before marking the pull request ready for review, check every item below. -->

- [x] This PR is ready for review, or it is marked as Draft.
- [x] This change fits `SCOPE.md`, or its scope was agreed in an issue or on Discord first.
- [x] I read and followed the relevant guidance in `CONTRIBUTING.md`.
- [x] I ran `just format`, or this PR has no C++ changes.
- [x] I ran the relevant build, test, lint, or verification commands, or explained why they were not run.
- [x] I functionally verified compositor behavior where automated checks are insufficient.
- [x] I self-reviewed the changes.
- [x] I checked for new warnings or errors.
- [x] I updated `docs/` and `examples/config.toml`, or this PR does not change user-facing configuration or behavior.
- [x] I used canonical names for config keys, IPC actions, paths, and identifiers.

## Additional Notes

